### PR TITLE
docs: fixed broken radix links

### DIFF
--- a/apps/www/src/content/components/alert-dialog.md
+++ b/apps/www/src/content/components/alert-dialog.md
@@ -4,7 +4,7 @@ description: A modal dialog that interrupts the user with important content and 
 featured: true
 component: true
 source: https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/lib/components/ui/alert-dialog
-radix: https://www.radix-svelte.com/docs/alert-dialog
+radix: https://www.radix-svelte.com/docs/alertdialog
 ---
 
 <script>

--- a/apps/www/src/content/components/hover-card.md
+++ b/apps/www/src/content/components/hover-card.md
@@ -3,7 +3,7 @@ title: Hover Card
 description: For sighted users to preview content available behind a link.
 component: true
 source: https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/lib/components/ui/hover-card
-radix: https://www.radix-svelte.com/docs/hover-card
+radix: https://www.radix-svelte.com/docs/hovercard
 ---
 
 <script>

--- a/apps/www/src/content/components/radio-group.md
+++ b/apps/www/src/content/components/radio-group.md
@@ -3,7 +3,7 @@ title: Radio Group
 description: A set of checkable buttons—known as radio buttons—where no more than one of the buttons can be checked at a time.
 component: true
 source: https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/lib/components/ui/radio-group
-radix: https://www.radix-svelte.com/docs/radio-group
+radix: https://www.radix-svelte.com/docs/radiogroup
 ---
 
 <script>


### PR DESCRIPTION
Fixes Radix links for `alert-dialog`, `hover-card`, and `radio-group`.

The lack of `-`'s may be an error on Radix's end since their route for `aspect-ratio` (https://www.radix-svelte.com/docs/aspect-ratio) seems to follow this convention. We can update this again once that's sorted on their end.