### PR TITLE
add max length to hex input

### DIFF
--- a/apps/www/src/content/theming.md
+++ b/apps/www/src/content/theming.md
@@ -13,9 +13,7 @@ We use CSS variables for styling. This allows you to easily change the colors of
 
 ## Hex -> Color Channel
 
-To make it easier, we've created the following tool which you can use to convert your HEX color to HSL without the color space function.
-
-Simply add your color in hex format, copy one of the generated values, then add them to the CSS variable.
+You can use this tool to convert your HEX color to HSL without the color space function. Simply add your color in hex format, copy one of the generated values, then add them to the CSS variable.
 
 <HexToChannels />
 

--- a/apps/www/src/lib/components/docs/HexToChannels.svelte
+++ b/apps/www/src/lib/components/docs/HexToChannels.svelte
@@ -26,7 +26,7 @@
 	<div class="w-full max-w-sm mx-auto space-y-6 py-4">
 		<div class="grid gap-2">
 			<Label for="hex">HEX</Label>
-			<Input name="hex" bind:value={hex} />
+			<Input name="hex" bind:value={hex} maxlength="7" />
 		</div>
 		<div class="grid gap-2 relative">
 			<CopyButton class="absolute right-2 top-[30px]" value={hslString} />


### PR DESCRIPTION
There's no reason to have over 7 characters (including the `#` in the hex input). Will only cause confusion.