### PR TITLE
Temp fix for form field name attribute.

### DIFF
--- a/apps/www/src/lib/components/ui/form/FormField.svelte
+++ b/apps/www/src/lib/components/ui/form/FormField.svelte
@@ -17,9 +17,12 @@
 
 	const { value, errors, constraints } = superFormFieldProxy(form, name);
 
+	const fieldName = name.match(/^[a-zA-Z]\w*/);
+	if (!fieldName) throw new Error("Invalid form field name.");
+
 	$: field = superFormField({
 		id,
-		name,
+		name: fieldName[0],
 		errors: $errors,
 		constraints: $constraints,
 		value


### PR DESCRIPTION
The problem ("feature") is that the name attribute must be set to the schema field name. So in the case of arrays, the index isn't needed, though it's required for making it a formFieldProxy, so the id is used for that.

It's a problem with normal form posting only, with `dataType: 'json'` this isn't an issue, since the name attribute is irrelevant.