### PR TITLE
fix: remove unused props from dialog portal

### DIFF
--- a/apps/www/src/lib/components/ui/dialog/DialogPortal.svelte
+++ b/apps/www/src/lib/components/ui/dialog/DialogPortal.svelte
@@ -1,12 +1,8 @@
 <script lang="ts">
 	import { Dialog as DialogPrimitive } from "radix-svelte";
-	import { cn } from "$lib/utils";
-
-	let className: string | undefined | null = undefined;
-	export { className as class };
 </script>
 
-<DialogPrimitive.Portal class={cn(className)} {...$$restProps}>
+<DialogPrimitive.Portal>
 	<div
 		class="fixed inset-0 z-50 flex items-start justify-center sm:items-center"
 	>


### PR DESCRIPTION
Closes: #77 

Remove unused props from dialog portal component.