### PR TITLE
fix: remove duplicate button elements in dialog example

### DIFF
--- a/apps/www/src/lib/components/docs/examples/dialog/DialogDemo.svelte
+++ b/apps/www/src/lib/components/docs/examples/dialog/DialogDemo.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Button } from "$components/ui/button";
+	import { Button, buttonVariants } from "$components/ui/button";
 	import {
 		Dialog,
 		DialogContent,
@@ -14,8 +14,8 @@
 </script>
 
 <Dialog modal={true}>
-	<DialogTrigger>
-		<Button variant="outline">Edit Profile</Button>
+	<DialogTrigger class={buttonVariants({ variant: "outline" })}>
+		Edit Profile
 	</DialogTrigger>
 	<DialogContent class="sm:max-w-[425px]">
 		<DialogHeader>


### PR DESCRIPTION
Closes: #79 

`DialogTrigger` already renders a button, so there is no need to render another button inside its slot.