### PR TITLE
Fixes `pnpm`'s lockfile version for backwards compatibility 

### DIFF
--- a/apps/www/pnpm-lock.yaml
+++ b/apps/www/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true

--- a/packages/cli/pnpm-lock.yaml
+++ b/packages/cli/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true


### PR DESCRIPTION
Closes #122 

pnpm implemented a breaking change to their lockfiles in `pnpm@8.6.0`. The change has since been reverted for `pnpm@8.6.2` and onwards.

Here's the related comment and solution: https://github.com/pnpm/pnpm/issues/6648#issuecomment-1588863457.