### PR TITLE
Add tabs

### DIFF
--- a/apps/www/src/lib/components/ui/tabs/Tabs.svelte
+++ b/apps/www/src/lib/components/ui/tabs/Tabs.svelte
@@ -1,0 +1,81 @@
+<script lang="ts" context="module">
+	export type RootProps = Omit<
+		CreateTabsProps,
+		"value" | "defaultValue" | "onValueChange"
+	> & {
+		value?: CreateTabsProps["defaultValue"];
+		class?: string;
+	};
+</script>
+
+<script lang="ts">
+	import {
+		type CreateTabsProps,
+		melt,
+		type StoreValue
+	} from "@melt-ui/svelte";
+	import { ctx } from "./index";
+
+	type $$Props = RootProps;
+
+	export let orientation: $$Props["orientation"] = undefined;
+	export let activateOnFocus: $$Props["activateOnFocus"] = undefined;
+	export let loop: $$Props["loop"] = undefined;
+	export let autoSet: $$Props["autoSet"] = undefined;
+
+	// I chose to only export value, as defaultValue, to allow for more
+	// traditional component behaviour (e.g. two-way binding)
+	export let value: $$Props["value"] = undefined;
+
+	function removeUndefined<T extends object>(obj: T): T {
+		const result = {} as T;
+		for (const key in obj) {
+			const value = obj[key];
+			if (value !== undefined) result[key] = value;
+		}
+
+		console.log(result);
+		return result;
+	}
+
+	const {
+		elements: { root },
+		states: { value: localValue },
+		options
+	} = ctx.set(
+		removeUndefined({
+			orientation,
+			activateOnFocus,
+			loop,
+			autoSet,
+			defaultValue: value,
+			onValueChange({ next }) {
+				value = next;
+				return next;
+			}
+		})
+	);
+
+	$: value !== undefined && localValue.set(value);
+
+	function updateOption<
+		K extends keyof typeof options,
+		V extends StoreValue<(typeof options)[keyof typeof options]>
+	>(key: K, value: V | undefined) {
+		if (value === undefined) return;
+		const store = options[key];
+		store.set(value as never);
+	}
+
+	$: updateOption("activateOnFocus", activateOnFocus);
+	$: updateOption("loop", loop);
+	$: updateOption("autoSet", autoSet);
+	$: updateOption("orientation", orientation);
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+</script>
+
+<div use:melt={$root} class={className} {...$$restProps}>
+	<slot />
+</div>

--- a/apps/www/src/lib/components/ui/tabs/Tabs.svelte
+++ b/apps/www/src/lib/components/ui/tabs/Tabs.svelte
@@ -34,7 +34,6 @@
 			if (value !== undefined) result[key] = value;
 		}
 
-		console.log(result);
 		return result;
 	}
 

--- a/apps/www/src/lib/components/ui/tabs/TabsContent.svelte
+++ b/apps/www/src/lib/components/ui/tabs/TabsContent.svelte
@@ -1,20 +1,33 @@
+<script lang="ts" context="module">
+	export type ContentProps = {
+		class?: string;
+		value: Parameters<StoreValue<TabsElements["content"]>>[0];
+	};
+</script>
+
 <script lang="ts">
-	import type { TabsContentProps } from "radix-svelte";
-	import { Tabs as TabsPrimitive } from "radix-svelte";
 	import { cn } from "$lib/utils";
+	import { melt, type StoreValue, type TabsElements } from "@melt-ui/svelte";
+	import { ctx } from ".";
+
+	type $$Props = ContentProps;
 
 	let className: string | undefined | null = undefined;
 	export { className as class };
-	export let value: TabsContentProps["value"];
+	export let value: $$Props["value"];
+
+	const {
+		elements: { content }
+	} = ctx.get();
 </script>
 
-<TabsPrimitive.Content
+<div
 	class={cn(
 		"mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
 		className
 	)}
-	{value}
+	use:melt={$content(value)}
 	{...$$restProps}
 >
 	<slot />
-</TabsPrimitive.Content>
+</div>

--- a/apps/www/src/lib/components/ui/tabs/TabsList.svelte
+++ b/apps/www/src/lib/components/ui/tabs/TabsList.svelte
@@ -1,12 +1,26 @@
+<script lang="ts" context="module">
+	export type ListProps = {
+		class?: string;
+	};
+</script>
+
 <script lang="ts">
-	import { Tabs as TabsPrimitive } from "radix-svelte";
 	import { cn } from "$lib/utils";
+	import { melt } from "@melt-ui/svelte";
+	import { ctx } from ".";
+
+	type $$Props = ListProps;
 
 	let className: string | undefined | null = undefined;
 	export { className as class };
+
+	const {
+		elements: { list }
+	} = ctx.get();
 </script>
 
-<TabsPrimitive.List
+<div
+	use:melt={$list}
 	class={cn(
 		"inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
 		className
@@ -14,4 +28,4 @@
 	{...$$restProps}
 >
 	<slot />
-</TabsPrimitive.List>
+</div>

--- a/apps/www/src/lib/components/ui/tabs/TabsTrigger.svelte
+++ b/apps/www/src/lib/components/ui/tabs/TabsTrigger.svelte
@@ -1,20 +1,35 @@
-<script lang="ts">
-	import type { TabsTriggerProps } from "radix-svelte";
-	import { Tabs as TabsPrimitive } from "radix-svelte";
-	import { cn } from "$lib/utils";
+<script lang="ts" context="module">
+	type EnforceObject<T> = T extends object ? T : never;
 
-	let className: string | undefined | null = undefined;
-	export { className as class };
-	export let value: TabsTriggerProps["value"];
+	export type TriggerProps = EnforceObject<TabsTriggerProps> & {
+		class?: string;
+	};
 </script>
 
-<TabsPrimitive.Trigger
+<script lang="ts">
+	import { cn } from "$lib/utils";
+	import { melt, type TabsTriggerProps } from "@melt-ui/svelte";
+	import { ctx } from ".";
+
+	type $$Props = TriggerProps;
+
+	let className: $$Props["class"] = undefined;
+	export { className as class };
+	export let value: $$Props["value"];
+	export let disabled: $$Props["disabled"] = undefined;
+
+	const {
+		elements: { trigger }
+	} = ctx.get();
+</script>
+
+<button
 	class={cn(
 		"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
 		className
 	)}
-	{value}
+	use:melt={$trigger({ value, disabled })}
 	{...$$restProps}
 >
 	<slot />
-</TabsPrimitive.Trigger>
+</button>

--- a/apps/www/src/lib/components/ui/tabs/index.ts
+++ b/apps/www/src/lib/components/ui/tabs/index.ts
@@ -1,7 +1,50 @@
-import { Tabs as TabsPrimitive } from "radix-svelte";
+import {
+	createTabs,
+	melt,
+	type CreateTabsProps,
+	type Tabs as TabsReturn
+} from "@melt-ui/svelte";
+import { getContext, setContext } from "svelte";
 
-export { default as TabsContent } from "./TabsContent.svelte";
-export { default as TabsList } from "./TabsList.svelte";
-export { default as TabsTrigger } from "./TabsTrigger.svelte";
+import { default as Root, type RootProps } from "./Tabs.svelte";
+import { default as Content, type ContentProps } from "./TabsContent.svelte";
+import { default as List, type ListProps } from "./TabsList.svelte";
+import { default as Trigger, type TriggerProps } from "./TabsTrigger.svelte";
 
-export const Tabs = TabsPrimitive.Root;
+const NAME = "Tabs";
+
+export const ctx = {
+	set: setTabs,
+	get: getTabs
+};
+
+function getTabs() {
+	return getContext<TabsReturn>(NAME);
+}
+
+function setTabs(props: CreateTabsProps) {
+	setContext(NAME, createTabs({ ...props }));
+
+	return getTabs();
+}
+
+export const Tabs = Object.assign(Root, {
+	Content,
+	List,
+	Trigger
+});
+
+export {
+	Root as TabsRoot,
+	Content as TabsContent,
+	List as TabsList,
+	Trigger as TabsTrigger,
+	melt
+};
+
+export type TabsElements = {
+	root: RootProps;
+	content: ContentProps;
+	trigger: TriggerProps;
+	list: ListProps;
+};


### PR DESCRIPTION
I'm following some different conventions:

- I didn't create a context getter for each and every element, as some people may want to get more things from the createBuilder method. Instead of having to define it in two places, i'd argue we just give them the whole context always
- I'm not passing down the value store or the onChange method, instead, I'm only allowing the defaultValue prop, but aliasing it to value. I then track changes so it can be used with bind:value. I think this is more fitting of a component-like structure
- Probably something else that i can't remember