### PR TITLE
Fix the shortcut in the menubar example

### DIFF
--- a/apps/www/src/content/components/menubar.md
+++ b/apps/www/src/content/components/menubar.md
@@ -45,7 +45,7 @@ npm install bits-ui
     <Menubar.Content>
       <Menubar.Item>
         New Tab
-        <MenubarShortcut>⌘T</MenubarShortcut>
+        <Menubar.Shortcut>⌘T</Menubar.Shortcut>
       </Menubar.Item>
       <Menubar.Item>New Window</Menubar.Item>
       <Menubar.Separator />


### PR DESCRIPTION
It's a super tiny fix, but I noticed the usage example doesn't work out of the box when copied from the docs to my project.