### PR TITLE
make preview code imports more sveltish

### DIFF
--- a/apps/www/mdsvex.config.js
+++ b/apps/www/mdsvex.config.js
@@ -45,7 +45,10 @@ export const mdsvexOptions = {
 						const match = codeEl.data?.meta.match(regex);
 						if (match) {
 							node.__event__ = match ? match[1] : null;
-							codeEl.data.meta = codeEl.data.meta.replace(regex, "");
+							codeEl.data.meta = codeEl.data.meta.replace(
+								regex,
+								""
+							);
 						}
 					}
 
@@ -187,7 +190,10 @@ function rehypeComponentPreToPre() {
 		// Replace `Component.pre` tags with `pre` tags.
 		// This is a workaround to use rehype-pretty-code along with custom mdsvex components.
 		visit(tree, (node) => {
-			if (node?.type === "element" && node?.tagName === "Components.pre") {
+			if (
+				node?.type === "element" &&
+				node?.tagName === "Components.pre"
+			) {
 				node.tagName = "pre";
 			}
 

--- a/apps/www/mdsvex.config.js
+++ b/apps/www/mdsvex.config.js
@@ -45,10 +45,7 @@ export const mdsvexOptions = {
 						const match = codeEl.data?.meta.match(regex);
 						if (match) {
 							node.__event__ = match ? match[1] : null;
-							codeEl.data.meta = codeEl.data.meta.replace(
-								regex,
-								""
-							);
+							codeEl.data.meta = codeEl.data.meta.replace(regex, "");
 						}
 					}
 
@@ -120,7 +117,7 @@ export function rehypeComponentExample() {
 						let sourceCode = getComponentSourceFileContent(src);
 						sourceCode = sourceCode.replaceAll(
 							`@/registry/${style.name}/`,
-							"@/components/"
+							"$lib/components/"
 						);
 
 						const sourceCodeNode = u("element", {
@@ -190,10 +187,7 @@ function rehypeComponentPreToPre() {
 		// Replace `Component.pre` tags with `pre` tags.
 		// This is a workaround to use rehype-pretty-code along with custom mdsvex components.
 		visit(tree, (node) => {
-			if (
-				node?.type === "element" &&
-				node?.tagName === "Components.pre"
-			) {
+			if (node?.type === "element" && node?.tagName === "Components.pre") {
 				node.tagName = "pre";
 			}
 


### PR DESCRIPTION
Change the imports on the preview code snippets from `@/components` to `$lib/components` to align with standard Svelte practices.