### PR TITLE
Docs: change className to class prop

### DIFF
--- a/apps/www/src/content/components/select.md
+++ b/apps/www/src/content/components/select.md
@@ -42,7 +42,7 @@ npm install bits-ui
 </script>
 
 <Select.Root>
-  <Select.Trigger className="w-[180px]">
+  <Select.Trigger class="w-[180px]">
     <Select.Value placeholder="Theme" />
   </Select.Trigger>
   <Select.Content>


### PR DESCRIPTION
The docs contain an example of a Select component. This example uses a non-existent className prop, which is changed to the class prop in this pull request.