### PR TITLE
chore: removes config to tailwindcss-animate inside the templates

### DIFF
--- a/.changeset/shaggy-eagles-impress.md
+++ b/.changeset/shaggy-eagles-impress.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": patch
+---
+
+- Remove `tailwindcss-animate` from dependencies

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -26,7 +26,6 @@ import {
 import * as templates from "../utils/templates";
 
 const PROJECT_DEPENDENCIES = [
-	"tailwindcss-animate",
 	"tailwind-variants",
 	"clsx",
 	"tailwind-merge"

--- a/packages/cli/src/utils/templates.ts
+++ b/packages/cli/src/utils/templates.ts
@@ -144,7 +144,6 @@ export const flyAndScale = (
 };`;
 
 export const TAILWIND_CONFIG_WITH_VARIABLES = `import { fontFamily } from "tailwindcss/defaultTheme";
-import tailwindcssAnimate from "tailwindcss-animate";
 
 /** @type {import('tailwindcss').Config} */
 const config = {
@@ -204,14 +203,12 @@ const config = {
 			}
 		}
 	},
-	plugins: [tailwindcssAnimate]
 };
 
 export default config;
 `;
 
 export const TAILWIND_CONFIG = `import { fontFamily } from "tailwindcss/defaultTheme";
-import tailwindcssAnimate from "tailwindcss-animate";
 
 /** @type {import('tailwindcss').Config} */
 const config = {
@@ -236,7 +233,6 @@ const config = {
 			}
 		}
 	},
-	plugins: [tailwindcssAnimate]
 };
 
 export default config;


### PR DESCRIPTION
tailwindcss-animate isn't used no more and should be removed from init

- cleans up the templates resulting tailwind.config.ts
- removes the dependency to tailwindcss-animate in init