### PR TITLE
chore: removes config to tailwindcss-animate in docs

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -56,7 +56,6 @@
 		"svelte": "^4.0.5",
 		"svelte-check": "^3.4.3",
 		"tailwindcss": "^3.3.3",
-		"tailwindcss-animate": "^1.0.6",
 		"tslib": "^2.4.1",
 		"tsx": "^3.12.7",
 		"typescript": "^5.1.6",

--- a/apps/www/pnpm-lock.yaml
+++ b/apps/www/pnpm-lock.yaml
@@ -150,9 +150,6 @@ devDependencies:
   tailwindcss:
     specifier: ^3.3.3
     version: 3.3.3
-  tailwindcss-animate:
-    specifier: ^1.0.6
-    version: 1.0.6(tailwindcss@3.3.3)
   tslib:
     specifier: ^2.4.1
     version: 2.6.1
@@ -5058,14 +5055,6 @@ packages:
       tailwind-merge: 1.14.0
       tailwindcss: 3.3.3
     dev: false
-
-  /tailwindcss-animate@1.0.6(tailwindcss@3.3.3):
-    resolution: {integrity: sha512-4WigSGMvbl3gCCact62ZvOngA+PRqhAn7si3TQ3/ZuPuQZcIEtVap+ENSXbzWhpojKB8CpvnIsrwBu8/RnHtuw==}
-    peerDependencies:
-      tailwindcss: '>=3.0.0 || insiders'
-    dependencies:
-      tailwindcss: 3.3.3
-    dev: true
 
   /tailwindcss@3.3.3:
     resolution: {integrity: sha512-A0KgSkef7eE4Mf+nKJ83i75TMyq8HqY3qmFIJSWy8bNt0v1lG7jUcpGpoTFxAwYcWOphcTBLPPJg+bDfhDf52w==}

--- a/apps/www/src/content/installation.md
+++ b/apps/www/src/content/installation.md
@@ -123,7 +123,7 @@ npx svelte-add@latest tailwindcss
 Add the following dependencies to your project:
 
 ```bash
-npm install tailwindcss-animate tailwind-variants clsx tailwind-merge
+npm install tailwind-variants clsx tailwind-merge
 ```
 
 ### Configure tailwind.config.js
@@ -132,7 +132,6 @@ This is what this project's `tailwind.config.js` file looks like:
 
 ```javascript title="tailwind.config.js"
 import { fontFamily } from "tailwindcss/defaultTheme";
-import tailwindcssAnimate from "tailwindcss-animate";
 
 /** @type {import('tailwindcss').Config} */
 const config = {

--- a/apps/www/src/lib/components/docs/theme-customizer/customizer.svelte
+++ b/apps/www/src/lib/components/docs/theme-customizer/customizer.svelte
@@ -61,8 +61,7 @@
 						</p>
 						<p>
 							The <span class="font-medium">Default</span> style has
-							larger inputs, uses lucide-react for icons and tailwindcss-animate
-							for animations.
+							larger inputs, uses lucide-react for icons.
 						</p>
 						<p>
 							The <span class="font-medium">New York</span> style ships

--- a/apps/www/tailwind.config.js
+++ b/apps/www/tailwind.config.js
@@ -1,5 +1,4 @@
 import { fontFamily } from "tailwindcss/defaultTheme";
-import tailwindcssAnimate from "tailwindcss-animate";
 
 /** @type {import('tailwindcss').Config} */
 const config = {
@@ -58,8 +57,7 @@ const config = {
 				sans: ["Inter", ...fontFamily.sans]
 			}
 		}
-	},
-	plugins: [tailwindcssAnimate]
+	}
 };
 
 export default config;


### PR DESCRIPTION
tailwindcss-animate isn't used no more and should be removed from docs and app

- cleans up the docs and the dependencies / config from tailwindcss-animate