### PR TITLE
fix: data table source link

### DIFF
--- a/apps/www/src/content/components/data-table.md
+++ b/apps/www/src/content/components/data-table.md
@@ -2,7 +2,7 @@
 title: Data Table
 description: Powerful table and datagrids built using Svelte Headless Table.
 component: true
-source: https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/lib/registry/default/examples/data-table-demo.svelte
+source: https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/lib/registry/default/example/data-table-demo.svelte
 ---
 
 <script>


### PR DESCRIPTION
Fixed the data-table link so it does not target a 404 page anymore