### PR TITLE
Remove unneeded SvelteKit alias

### DIFF
--- a/apps/www/src/content/installation.md
+++ b/apps/www/src/content/installation.md
@@ -89,8 +89,7 @@ const config = {
   kit: {
     // ... other config
     alias: {
-      $lib: "./src/lib",
-      "$lib/*": "./src/lib/*"
+      $lib: "./src/lib"
     }
   }
 };


### PR DESCRIPTION
I've found the 2nd version to be superfluous and all Shadcn components work without it. This is an opportunity to simplify for new users.

(Actually, the entire step could be removed because SvelteKit's default `$lib` alias without any changes to `alias: {}`, but I imagine specifying it gives explicit guidance to devs in case they overrode SvelteKit's default, so I didn't PR that.)