### PR TITLE
fix: Passing ID to "Actions" column (docs)

### DIFF
--- a/apps/www/src/content/components/data-table.md
+++ b/apps/www/src/content/components/data-table.md
@@ -535,10 +535,10 @@ Now that we've defined our actions component, let's update our `actions` column 
       }
     }),
     table.column({
-      accessor: (item) => item,
+      accessor: "id",
       header: "",
       cell: ({ value }) => {
-        return createRender(DataTableActions, { id: value.id });
+        return createRender(DataTableActions, { id: value });
       }
     })
   ]);
@@ -620,10 +620,10 @@ Next, we'll add pagination to our table
       }
     }),
     table.column({
-      accessor: ({ email }) => email,
+      accessor: "id",
       header: "",
-      cell: (item) => {
-        return createRender(DataTableActions, { id: item.id });
+      cell: ({ value }) => {
+        return createRender(DataTableActions, { id: value });
       }
     })
   ]);
@@ -754,10 +754,10 @@ Let's enable the `addSortBy` plugin and import the icon we'll use to indicate th
       }
     }),
     table.column({
-      accessor: ({ email }) => email,
+      accessor: "id",
       header: "",
-      cell: (item) => {
-        return createRender(DataTableActions, { id: item.id });
+      cell: ({ value }) => {
+        return createRender(DataTableActions, { id: value });
       },
       plugins: {
         sort: {
@@ -926,10 +926,10 @@ We'll start by enabling the `addTableFilter` plugin and importing the `<Input />
       }
     }),
     table.column({
-      accessor: ({ email }) => email,
+      accessor: "id",
       header: "",
-      cell: (item) => {
-        return createRender(DataTableActions, { id: item.id });
+      cell: ({ value }) => {
+        return createRender(DataTableActions, { id: value });
       },
       plugins: {
         sort: {
@@ -1084,11 +1084,11 @@ Let's add the ability to control which columns are visible in our table.
       }
     }),
     table.column({
-      accessor: ({ email }) => email,
+      accessor: "id",
       header: "",
-      cell: (item) => {
-        return createRender(DataTableActions, { id: item.id });
-      }
+      cell: ({ value }) => {
+        return createRender(DataTableActions, { id: value });
+      },
       plugins: {
         sort: {
           disable: true
@@ -1290,10 +1290,10 @@ Next, we'll enable the `addSelectedRows` plugin and import the `<Checkbox />` co
       }
     }),
     table.column({
-      accessor: ({ email }) => email,
+      accessor: "id",
       header: "",
-      cell: (item) => {
-        return createRender(DataTableActions, { id: item.id });
+      cell: ({ value }) => {
+        return createRender(DataTableActions, { id: value });
       }
     })
   ]);

--- a/apps/www/src/content/components/data-table.md
+++ b/apps/www/src/content/components/data-table.md
@@ -535,10 +535,10 @@ Now that we've defined our actions component, let's update our `actions` column 
       }
     }),
     table.column({
-      accessor: ({ email }) => email,
+      accessor: (item) => item,
       header: "",
-      cell: (item) => {
-        return createRender(DataTableActions, { id: item.id });
+      cell: ({value}) => {
+        return createRender(DataTableActions, { id: value.id });
       }
     })
   ]);

--- a/apps/www/src/content/components/data-table.md
+++ b/apps/www/src/content/components/data-table.md
@@ -1241,8 +1241,7 @@ Next, we'll enable the `addSelectedRows` plugin and import the `<Checkbox />` co
   });
 
   const columns = table.createColumns([
-    table.column({
-      accessor: "id",
+    table.display({
       header: (_, { pluginStates }) => {
         const { allPageRowsSelected } = pluginStates.select;
         return createRender(DataTableCheckbox, {
@@ -1250,9 +1249,7 @@ Next, we'll enable the `addSelectedRows` plugin and import the `<Checkbox />` co
         });
       },
       cell: ({ row }, { pluginStates }) => {
-        const { getRowState } = pluginStates.select;
-        const { isSelected } = getRowState(row);
-
+        const { isSelected } = pluginStates.select.getRowState(row);
         return createRender(DataTableCheckbox, {
           checked: isSelected
         });

--- a/apps/www/src/content/components/data-table.md
+++ b/apps/www/src/content/components/data-table.md
@@ -537,7 +537,7 @@ Now that we've defined our actions component, let's update our `actions` column 
     table.column({
       accessor: (item) => item,
       header: "",
-      cell: ({value}) => {
+      cell: ({ value }) => {
         return createRender(DataTableActions, { id: value.id });
       }
     })


### PR DESCRIPTION
## Issue
An `undefined` value  was being passed in as props to the "Actions" column in the "Update columns definition" section. This is because the `accessor` was _only_ passing in the email value so the `cell` method had no knowledge of the ID of the associated item. Also, the ID value lives on the `item.value` not the `item`.