### PR TITLE
chore: remove tailwindcssAnimate from docs

### DIFF
--- a/apps/www/src/content/installation.md
+++ b/apps/www/src/content/installation.md
@@ -189,8 +189,7 @@ const config = {
         sans: ["Inter", ...fontFamily.sans]
       }
     }
-  },
-  plugins: [tailwindcssAnimate]
+  }
 };
 
 export default config;


### PR DESCRIPTION
During project installation process I have noticed `tailwindcssAnimate` was not found, so I have installed it. But later I have found this pull request #236 that removes `tailwindcssAnimate` from project so I believe this inaccuracy should be removed from `installation.md` as well