### PR TITLE
Fix backdrop blur support rule

### DIFF
--- a/apps/www/src/lib/components/docs/site-header.svelte
+++ b/apps/www/src/lib/components/docs/site-header.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <header
-	class="supports-backdrop-blur:bg-background/60 sticky top-0 z-40 w-full border-b bg-background/95 shadow-sm backdrop-blur"
+	class="supports-[backdrop-filter]:bg-background/60 sticky top-0 z-40 w-full border-b bg-background/95 shadow-sm backdrop-blur"
 >
 	<div class="container flex h-14 items-center">
 		<MainNav />


### PR DESCRIPTION
`supports-backdrop-blur:bg-background/60` does nothing

`supports-[backdrop-filter]:bg-background/60` does something!

see: https://github.com/shadcn-ui/ui/pull/1628