### PR TITLE
Footer no longer has a border

### DIFF
--- a/apps/www/src/lib/components/docs/site-footer.svelte
+++ b/apps/www/src/lib/components/docs/site-footer.svelte
@@ -3,7 +3,7 @@
 	import { Icons } from "./icons";
 </script>
 
-<footer class="border-t py-6 md:py-0">
+<footer class="py-6 md:px-8 md:py-0">
 	<div
 		class="container flex flex-col items-center justify-between gap-4 md:h-24 md:flex-row"
 	>


### PR DESCRIPTION
just that (and a `px-8` on medium, to align with the current footer on shadcn/ui)