### PR TITLE
Fix: <Card.Title> example with `tag="p"`

### DIFF
--- a/.changeset/long-dingos-work.md
+++ b/.changeset/long-dingos-work.md
@@ -1,5 +1,0 @@
----
-"www": minor
----
-
-Correction of `Card.Title` example

--- a/.changeset/long-dingos-work.md
+++ b/.changeset/long-dingos-work.md
@@ -1,0 +1,5 @@
+---
+"www": minor
+---
+
+Correction of `Card.Title` example

--- a/apps/www/src/content/components/card.md
+++ b/apps/www/src/content/components/card.md
@@ -55,15 +55,13 @@ By default, the `<Card.Title>` component renders an `<h3>` element. You can chan
 For example:
 
 ```svelte
-<Card.Title tag="h2">This will render an H2</Card.Title>
+<Card.Title tag="h1">This will render an H2</Card.Title>
 ```
 
-```svelte
-<Card.Title tag="h5">This will render an H5</Card.Title>
-```
+...
 
 ```svelte
-<Card.Title tag="p">This will render a P tag</Card.Title>
+<Card.Title tag="h6">This will render an H5</Card.Title>
 ```
 
 ## Examples

--- a/apps/www/src/content/components/card.md
+++ b/apps/www/src/content/components/card.md
@@ -55,13 +55,13 @@ By default, the `<Card.Title>` component renders an `<h3>` element. You can chan
 For example:
 
 ```svelte
-<Card.Title tag="h1">This will render an H2</Card.Title>
+<Card.Title tag="h1">This will render an H1</Card.Title>
 ```
 
 ...
 
 ```svelte
-<Card.Title tag="h6">This will render an H5</Card.Title>
+<Card.Title tag="h6">This will render an H6</Card.Title>
 ```
 
 ## Examples


### PR DESCRIPTION
For context, see: #392

- I removed the example with `p` as it is semantically false.
- I changed the examples `tag="h2"` and `tag="h5"` to `tag="h1"` and `tag="h6"` as they are the upper and lower limit of heading.
- Added `...` to show that the property `tag` accept all value in-between the first and the second example.