### PR TITLE
Update command.md

### DIFF
--- a/apps/www/src/content/components/command.md
+++ b/apps/www/src/content/components/command.md
@@ -48,7 +48,7 @@ npm install cmdk-sv bits-ui
 
 ```svelte
 <script lang="ts">
-  import * as Command from "$lib/components/ui/collapsible";
+  import * as Command from "$lib/components/ui/command";
 </script>
 
 <Command.Root>


### PR DESCRIPTION
Seems there is a small mistake in the import statement of the usage example of the command component.

It imports from `collapsible` instead of `command`.