### PR TITLE
Wrong themes href

### DIFF
--- a/apps/www/src/lib/components/docs/nav/main-nav.svelte
+++ b/apps/www/src/lib/components/docs/nav/main-nav.svelte
@@ -36,7 +36,7 @@
 			Components
 		</a>
 		<a
-			href="/docs/components"
+			href="/theme"
 			class={cn(
 				"transition-colors hover:text-foreground/80",
 				$page.url.pathname.startsWith("/themes")


### PR DESCRIPTION
It was pointing to `/docs/components` instead for some reason