### PR TITLE
Fix: Remove unused consolelog

### DIFF
--- a/apps/www/src/routes/examples/tasks/(components)/data-table.svelte
+++ b/apps/www/src/routes/examples/tasks/(components)/data-table.svelte
@@ -108,7 +108,6 @@
 			plugins: {
 				colFilter: {
 					fn: ({ filterValue, value }) => {
-						console.log("status", filterValue, value);
 						if (filterValue.length === 0) return true;
 						if (
 							!Array.isArray(filterValue) ||
@@ -138,7 +137,6 @@
 			plugins: {
 				colFilter: {
 					fn: ({ filterValue, value }) => {
-						console.log("priority", filterValue, value);
 						if (filterValue.length === 0) return true;
 						if (
 							!Array.isArray(filterValue) ||


### PR DESCRIPTION
I noticed that i missed 2 console logs in task example. This pull request removes them.