### PR TITLE
Removed `source` property from Combobox markdown file

### DIFF
--- a/apps/www/src/content/components/combobox.md
+++ b/apps/www/src/content/components/combobox.md
@@ -2,7 +2,6 @@
 title: Combobox
 description: Autocomplete input and command palette with a list of suggestions.
 component: true
-source: https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/lib/registry/default/ui/combobox
 ---
 
 <script>


### PR DESCRIPTION
Fixes #431
