### PR TITLE
Fix: Tasks example: render column header instead of id

### DIFF
--- a/apps/www/src/routes/examples/tasks/(components)/data-table-column-header.svelte
+++ b/apps/www/src/routes/examples/tasks/(components)/data-table-column-header.svelte
@@ -16,7 +16,6 @@
 		};
 		filter: never;
 	};
-	export let title: string;
 
 	function handleAscSort(e: Event) {
 		if (props.sort.order === "asc") {
@@ -42,7 +41,7 @@
 					builders={[builder]}
 					class="-ml-3 h-8 data-[state=open]:bg-accent"
 				>
-					<span class="capitalize">{title}</span>
+					<slot />
 					{#if props.sort.order === "desc"}
 						<ArrowDown class="ml-2 h-4 w-4" />
 					{:else if props.sort.order === "asc"}

--- a/apps/www/src/routes/examples/tasks/(components)/data-table-column-header.svelte
+++ b/apps/www/src/routes/examples/tasks/(components)/data-table-column-header.svelte
@@ -62,7 +62,5 @@
 		</DropdownMenu.Root>
 	</div>
 {:else}
-	<span class="capitalize">
-		{title}
-	</span>
+	<slot />
 {/if}

--- a/apps/www/src/routes/examples/tasks/(components)/data-table.svelte
+++ b/apps/www/src/routes/examples/tasks/(components)/data-table.svelte
@@ -193,10 +193,11 @@
 								>
 									<Table.Head {...attrs}>
 										{#if cell.id !== "select" && cell.id !== "actions"}
-											<DataTableColumnHeader
-												{props}
-												title={cell.id}
-											/>
+											<DataTableColumnHeader {props}
+												><Render
+													of={cell.render()}
+												/></DataTableColumnHeader
+											>
 										{:else}
 											<Render of={cell.render()} />
 										{/if}


### PR DESCRIPTION
Tasks example renders column id in the column header, the header is a single word in the example, so the example doesn't show the error, but it doesn't render the actual column header. A header set to string 'Hello world' and an id set to 'helloWorld' would render as 'HelloWorld' without this change. This pull request fixes that.