### PR TITLE
Make table components clickable

### DIFF
--- a/apps/www/src/lib/registry/default/ui/table/table-cell.svelte
+++ b/apps/www/src/lib/registry/default/ui/table/table-cell.svelte
@@ -11,6 +11,8 @@
 <td
 	class={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
 	{...$$restProps}
+	on:click
+	on:keydown
 >
 	<slot />
 </td>

--- a/apps/www/src/lib/registry/default/ui/table/table-header.svelte
+++ b/apps/www/src/lib/registry/default/ui/table/table-header.svelte
@@ -8,6 +8,11 @@
 	export { className as class };
 </script>
 
-<thead class={cn("[&_tr]:border-b", className)} {...$$restProps}>
+<thead
+	class={cn("[&_tr]:border-b", className)}
+	{...$$restProps}
+	on:click
+	on:keydown
+>
 	<slot />
 </thead>

--- a/apps/www/src/lib/registry/default/ui/table/table-row.svelte
+++ b/apps/www/src/lib/registry/default/ui/table/table-row.svelte
@@ -16,6 +16,8 @@
 		className
 	)}
 	{...$$restProps}
+	on:click
+	on:keydown
 >
 	<slot />
 </tr>

--- a/apps/www/src/lib/registry/new-york/ui/table/table-cell.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/table/table-cell.svelte
@@ -14,6 +14,8 @@
 		className
 	)}
 	{...$$restProps}
+	on:click
+	on:keydown
 >
 	<slot />
 </td>

--- a/apps/www/src/lib/registry/new-york/ui/table/table-header.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/table/table-header.svelte
@@ -8,6 +8,11 @@
 	export { className as class };
 </script>
 
-<thead class={cn("[&_tr]:border-b", className)} {...$$restProps}>
+<thead
+	class={cn("[&_tr]:border-b", className)}
+	{...$$restProps}
+	on:click
+	on:keydown
+>
 	<slot />
 </thead>

--- a/apps/www/src/lib/registry/new-york/ui/table/table-row.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/table/table-row.svelte
@@ -16,6 +16,8 @@
 		className
 	)}
 	{...$$restProps}
+	on:click
+	on:keydown
 >
 	<slot />
 </tr>


### PR DESCRIPTION
Addresses issue https://github.com/huntabyte/shadcn-svelte/issues/464. This adds `on:click` and `on:keydown` to the following table components to make them clickable. The `on:keydown` is added for accessibility.

- table-cell.svelte
- table-header.svelte
- table-row.svelte