### PR TITLE
Added --proxy to init and update commands

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -15,6 +15,7 @@ import {
 	rawConfigSchema,
 	resolveConfigPaths
 } from "../utils/get-config";
+import { getEnvProxy } from "../utils/get-env-proxy";
 import { getPackageManager } from "../utils/get-package-manager";
 import { handleError } from "../utils/handle-error";
 import { logger } from "../utils/logger";
@@ -40,6 +41,10 @@ export const init = new Command()
 		"the working directory. defaults to the current directory.",
 		process.cwd()
 	)
+	.option(
+		"--proxy <proxy>",
+		"Initialize dependencies from registry using a proxy."
+	)
 	.action(async (options) => {
 		const cwd = path.resolve(options.cwd);
 
@@ -50,6 +55,18 @@ export const init = new Command()
 			"If you don't have these, follow the manual steps at https://shadcn-svelte.com/docs/installation."
 		);
 		logger.warn("");
+
+		const chosenProxy = options.proxy ?? getEnvProxy();
+		if (chosenProxy) {
+			const isCustom = !!options.proxy;
+			if (isCustom) process.env.HTTP_PROXY = options.proxy;
+
+			logger.warn(
+				`You are using a ${
+					isCustom ? "provided" : "system environment"
+				} proxy: ${chalk.green(chosenProxy)}`
+			);
+		}
 
 		if (!options.yes) {
 			const { proceed } = await prompts([


### PR DESCRIPTION
Fixes https://github.com/huntabyte/shadcn-svelte/issues/423

Hi

I just copied and pasted whatever happened to the `add` command in this PR https://github.com/huntabyte/shadcn-svelte/pull/402 to `init` and `update` commands.

I'm not sure if this works correctly or not!

Back then I wasn't able to access the registry without using a VPN/proxy, now I can! Sometimes and sometimes not.

For this reason, using the commands with and without using a proxy, sometimes worked and sometimes didn't.

Because of weird issues with my internet connection, I wasn't able to properly test things!

Feel free to close this PR and assign someone else to work on the issue.
