### PR TITLE
chore(build): use node runtime

### DIFF
--- a/apps/www/svelte.config.js
+++ b/apps/www/svelte.config.js
@@ -23,9 +23,7 @@ const config = {
 	extensions: [".svelte", ".md"],
 
 	kit: {
-		adapter: adapter({
-			runtime: "edge"
-		}),
+		adapter: adapter(),
 		alias: {
 			$components: "src/lib/components",
 			"$components/*": "src/lib/components/*",


### PR DESCRIPTION
Reverting from the edge runtime as users are experiencing issues with certain registry components. I'm not 100% able to confirm this is what is causing it, but considering these issues started happening after that change, we're rolling back to the node runtime until we can properly test everything works as expected at the edge.