### PR TITLE
chore: update mode-watcher & add fallback mode before stores load

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -81,7 +81,7 @@
 		"esm-env": "^1.0.0",
 		"formsnap": "^0.4.1",
 		"lucide-svelte": "^0.292.0",
-		"mode-watcher": "^0.0.7",
+		"mode-watcher": "^0.1.2",
 		"nanoid": "^5.0.3",
 		"radix-icons-svelte": "^1.2.1",
 		"svelte-headless-table": "^0.17.7",

--- a/apps/www/pnpm-lock.yaml
+++ b/apps/www/pnpm-lock.yaml
@@ -41,8 +41,8 @@ dependencies:
     specifier: ^0.292.0
     version: 0.292.0(svelte@4.2.2)
   mode-watcher:
-    specifier: ^0.0.7
-    version: 0.0.7(svelte@4.2.2)
+    specifier: ^0.1.2
+    version: 0.1.2(svelte@4.2.2)
   nanoid:
     specifier: ^5.0.3
     version: 5.0.3
@@ -3872,13 +3872,12 @@ packages:
       ufo: 1.1.2
     dev: true
 
-  /mode-watcher@0.0.7(svelte@4.2.2):
-    resolution: {integrity: sha512-3/RXHKzg9TjhkYo8YTx++Ai7a2Qd7BkYS3RFWaIhj0NPonXAF5JNegiZ3CTk1Q/k0wyhPQUlsWW0Y5ByCp6Y1g==}
+  /mode-watcher@0.1.2(svelte@4.2.2):
+    resolution: {integrity: sha512-XTdPCdqC3kqSvB+Q262Kor983YJkkB2Z3vj9uqg5IqKQpOdiz+xB99Jihp8sWbyM67drC7KKp0Nt5FzCypZi2g==}
     peerDependencies:
       svelte: ^4.0.0
     dependencies:
       svelte: 4.2.2
-      svelte-persisted-store: 0.7.0(svelte@4.2.2)
     dev: false
 
   /mri@1.2.0:
@@ -4759,15 +4758,6 @@ packages:
     engines: {node: '>=0.14'}
     peerDependencies:
       svelte: ^3.48.0 || ^4.0.0
-    dependencies:
-      svelte: 4.2.2
-    dev: false
-
-  /svelte-persisted-store@0.7.0(svelte@4.2.2):
-    resolution: {integrity: sha512-PczYS60ysScQ0DmTCPXQm5rwt8FfQzSlx0lCbljbE6hTCKqXaw2bP8KH1+B7QTPmuiy/QbAk4pjYpNCmZhjyRw==}
-    engines: {node: '>=0.14'}
-    peerDependencies:
-      svelte: ^3.48.0 || >4.0.0
     dependencies:
       svelte: 4.2.2
     dev: false

--- a/apps/www/src/lib/components/docs/theme-customizer/customizer.svelte
+++ b/apps/www/src/lib/components/docs/theme-customizer/customizer.svelte
@@ -121,7 +121,9 @@
 							"justify-start",
 							isActive && "border-2 border-primary"
 						)}
-						style="--theme-primary: hsl({theme?.activeColor[$mode]}"
+						style="--theme-primary: hsl({theme?.activeColor[
+							$mode ?? 'dark'
+						]}"
 					>
 						<span
 							class="mr-1 flex h-5 w-5 shrink-0 -translate-x-1 items-center justify-center rounded-full bg-[--theme-primary]"

--- a/apps/www/src/lib/components/docs/theme-customizer/theme-customizer.svelte
+++ b/apps/www/src/lib/components/docs/theme-customizer/theme-customizer.svelte
@@ -38,7 +38,7 @@
 										: "border-transparent"
 								)}
 								style="--theme-primary: hsl({theme?.activeColor[
-									$mode
+									$mode ?? 'dark'
 								]}"
 							>
 								<span


### PR DESCRIPTION
just wanted to update `mode-watcher`.

now with `mode-watcher` > `0.1.0`, `$mode` is (more accurately) `undefined` until the stores have loaded correctly.

this is usually not a problem for FOUC sensitive applications since those should rely on the presence of the `dark` class in the `html` element and use the `dark:` tailwind variant.

for less FOUC sensitive applications like the styling of these buttons, it should be perfectly fine to fallback to a certain theme (`"dark"` in this case). the fallback is not really needed but it's there so that `pnpm check` is happy

### Before submitting the PR, please make sure you do the following

- [x] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Follows the [contribution guidelines](https://github.com/huntabyte/shadcn-svelte/blob/main/CONTRIBUTING.md).
- [x] Format & lint the code with `pnpm format` and `pnpm lint`
