### PR TITLE
fix: Added preventScroll to Popover.Root in Date Picker with Presets example

### DIFF
--- a/apps/www/src/lib/registry/default/example/date-picker-with-presets.svelte
+++ b/apps/www/src/lib/registry/default/example/date-picker-with-presets.svelte
@@ -26,7 +26,7 @@
 	];
 </script>
 
-<Popover.Root openFocus>
+<Popover.Root openFocus preventScroll>
 	<Popover.Trigger asChild let:builder>
 		<Button
 			variant="outline"

--- a/apps/www/src/lib/registry/new-york/example/date-picker-with-presets.svelte
+++ b/apps/www/src/lib/registry/new-york/example/date-picker-with-presets.svelte
@@ -26,7 +26,7 @@
 	];
 </script>
 
-<Popover.Root openFocus>
+<Popover.Root openFocus preventScroll>
 	<Popover.Trigger asChild let:builder>
 		<Button
 			variant="outline"


### PR DESCRIPTION
Addresses small issue described below (see also https://github.com/huntabyte/shadcn-svelte/issues/531)

When using Select (preventScroll set to true by default) inside a Popover (preventScroll set to false by default), there is an issue where overflow remains hidden if you click the Select component followed by clicking outside the area of the Popover component (no selection).

This is just a quick note for an adjustment on this in the Date Picker with Presets example: https://www.shadcn-svelte.com/docs/components/date-picker#with-presets
