### PR TITLE
docs: associate label with input in example

### DIFF
--- a/apps/www/src/lib/registry/new-york/example/dialog-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/dialog-demo.svelte
@@ -18,11 +18,11 @@
 		</Dialog.Header>
 		<div class="grid gap-4 py-4">
 			<div class="grid grid-cols-4 items-center gap-4">
-				<Label class="text-right">Name</Label>
+				<Label for="name" class="text-right">Name</Label>
 				<Input id="name" value="Pedro Duarte" class="col-span-3" />
 			</div>
 			<div class="grid grid-cols-4 items-center gap-4">
-				<Label class="text-right">Username</Label>
+				<Label for="username" class="text-right">Username</Label>
 				<Input id="username" value="@peduarte" class="col-span-3" />
 			</div>
 		</div>


### PR DESCRIPTION
Fix browser warning in demo code regarding unassociated <input> in <label>

### Before submitting the PR, please make sure you do the following

- [ ] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Follows the [contribution guidelines](https://github.com/huntabyte/shadcn-svelte/blob/main/CONTRIBUTING.md).
- [ ] Format & lint the code with `pnpm format` and `pnpm lint`
