### PR TITLE
fix(cli): Handle tailwind.config.ts file properly in init

### DIFF
--- a/.changeset/wicked-eels-clap.md
+++ b/.changeset/wicked-eels-clap.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": patch
+---
+
+fix(cli): Handle tailwind.config.ts file properly in init

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -160,18 +160,7 @@ async function promptForConfig(
 			message: `Where is your ${highlight(
 				"tailwind.config.[cjs|js|ts]"
 			)} located?`,
-			initial: defaultConfig?.tailwind.config ?? DEFAULT_TAILWIND_CONFIG,
-			validate: (value) => {
-				if (existsSync(value)) {
-					return true;
-				}
-				logger.info("");
-				logger.error(
-					`${value} does not exist. Please enter a valid path.`
-				);
-				logger.info("");
-				return false;
-			}
+			initial: defaultConfig?.tailwind.config ?? DEFAULT_TAILWIND_CONFIG
 		},
 		{
 			type: "text",
@@ -271,7 +260,7 @@ async function runInit(cwd: string, config: Config) {
 
 	// Delete tailwind.config.cjs, if present
 	const cjsConfig = config.resolvedPaths.tailwindConfig.replace(
-		".js",
+		/\.(j|t)s$/,
 		".cjs"
 	);
 	await fs.unlink(cjsConfig).catch((e) => e); // throws when it DNE


### PR DESCRIPTION
# What has changed
I have removed the check that checks if the specified tailwind config file already exists and changed the replace regex that is used to delete the `.cjs` file.

# Motivation for the change
I was trying out this and so I made a new sveltekit project and tried to init shadcn.
It gave me option to use `tailwind.config.ts` as a config file so I tried to use that. I faced an error that `tailwind.config.ts` doesn't exists. It's dumb as the file is going to be replaced anyways.
So I renamed the file to `tailwind.config.ts` and ran the command again.
It seemed to work and made the file but quickly deleted the file afterwards.

Turns out `"tailwind.config.ts".replace(".js",".cjs")` returns `tailwind.config.ts` anyways. So the new config gets deleted instead of `.cjs` one

This PR addresses these 2 issues.
