### PR TITLE
fix: typo brand Github to GitHub

### DIFF
--- a/apps/www/src/routes/examples/authentication/(components)/user-auth-form.svelte
+++ b/apps/www/src/routes/examples/authentication/(components)/user-auth-form.svelte
@@ -58,6 +58,6 @@
 			<Icons.gitHub class="mr-2 h-4 w-4" />
 		{/if}
 		{" "}
-		Github
+		GitHub
 	</Button>
 </div>


### PR DESCRIPTION
Just fix brand name typo from Github to GitHub

### Before submitting the PR, please make sure you do the following

- [x] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Follows the [contribution guidelines](https://github.com/huntabyte/shadcn-svelte/blob/main/CONTRIBUTING.md).
- [x] Format & lint the code with `pnpm format` and `pnpm lint`
