### PR TITLE
feat: add support for `update utils` command

### DIFF
--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -17,6 +17,7 @@ import {
 	getRegistryIndex,
 	resolveTree
 } from "../utils/registry";
+import { UTILS } from "../utils/templates";
 import { transformImport } from "../utils/transformer";
 
 const updateOptionsSchema = z.object({
@@ -70,6 +71,29 @@ export const update = new Command()
 				);
 				process.exitCode = 1;
 				return;
+			}
+
+			// utils means update the utils.ts file
+			if (components && components.includes("utils")) {
+				// FIX: This is quick and dirty, finaly solution has to fix resolvedPaths.utils
+				const utilsPath = config.resolvedPaths.utils + ".ts";
+
+				if (!existsSync(utilsPath)) {
+					logger.error(`utils.ts '${utilsPath}' does not exist.`);
+					process.exitCode = 1;
+					return;
+				}
+
+				// utils.ts is not in the registry, it is a template.
+				// Just overwrite it.
+				await fs.writeFile(utilsPath, UTILS);
+
+				// if CLI was called only on utils, stop, o/w continue
+				if (components.length === 1) {
+					logger.info(`utils.ts has been succesfully updated.`);
+					logger.success(`Done.`);
+					return;
+				}
 			}
 
 			const registryIndex = await getRegistryIndex();


### PR DESCRIPTION
Hi,

I tried to implement the feature discussed in this issue #298.

The original issue is that there is no way to update the `utils.ts` file. I added a tiny bit of logic to enhance the `update` command by recognizing the special keyword `utils` as @huntabyte suggested in his [comment](https://github.com/huntabyte/shadcn-svelte/issues/298#issuecomment-1722601595).

If the CLI is called with only the argument `utils` then it stops after updating the `utils.ts` file. Otherwise, it continues as normal.

I'm not too much familiar with this code base, so please, correct me if:
- The utils file is actually in the registry, but from my exploration it is not.
- Tell me if it is normal for the `config.resolvedPaths.utils` value to not contain the file extension, like if it was a folder?

> From a previous contribution, I think I need to run a release command for semversionning. Please tell me what to do. I could not find any information on that matter in the `CONTRIBUTING.md`.

### Before submitting the PR, please make sure you do the following

- [x] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Follows the [contribution guidelines](https://github.com/huntabyte/shadcn-svelte/blob/main/CONTRIBUTING.md).
- [ ] Format & lint the code with `pnpm format` and `pnpm lint`

> `pnpm lint does not work in the folder `/package/cli`, I believe it should be replace by `pnpm format:check` which has been run and passed successfully.
