### PR TITLE
docs: Removed an un unnecessary closing Button tag

### DIFF
--- a/apps/www/src/content/components/drawer.md
+++ b/apps/www/src/content/components/drawer.md
@@ -54,8 +54,7 @@ npm install vaul-svelte
     </Drawer.Header>
     <Drawer.Footer>
       <Button>Submit</Button>
-      <Drawer.Close>Cancel</Button>
-      </Drawer.Close>
+      <Drawer.Close>Cancel</Drawer.Close>
     </Drawer.Footer>
   </Drawer.Content>
 </Drawer.Root>

--- a/apps/www/src/content/components/drawer.md
+++ b/apps/www/src/content/components/drawer.md
@@ -58,7 +58,6 @@ npm install vaul-svelte
     </Drawer.Footer>
   </Drawer.Content>
 </Drawer.Root>
-
 ```
 
 ## Examples


### PR DESCRIPTION
removed an unnecessary closing Button tag in the Drawer component, which caused a mismatched tag error.

### Before submitting the PR, please make sure you do the following

- [x] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Follows the [contribution guidelines](https://github.com/huntabyte/shadcn-svelte/blob/main/CONTRIBUTING.md).
- [x] Format & lint the code with `pnpm format` and `pnpm lint`
