### PR TITLE
docs: update source link for date-picker

### DIFF
--- a/apps/www/src/content/components/date-picker.md
+++ b/apps/www/src/content/components/date-picker.md
@@ -2,7 +2,7 @@
 title: Date Picker
 description: A date picker component with range and presets.
 component: true
-source: https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/lib/registry/default/ui/date-picker
+source: https://github.com/huntabyte/shadcn-svelte/blob/main/apps/www/src/lib/registry/default/example/date-picker-demo.svelte
 ---
 
 <script>


### PR DESCRIPTION
Fix for #593.

The component source link for date picker gave 404.
Because the date picker component is a composition of multiple componenets. I changed the link to the demo code instead.

### Before submitting the PR, please make sure you do the following

- [x] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Follows the [contribution guidelines](https://github.com/huntabyte/shadcn-svelte/blob/main/CONTRIBUTING.md).
- [x] Format & lint the code with `pnpm format` and `pnpm lint`
