### PR TITLE
fix: add mode-watcher to Sonner registry deps

### DIFF
--- a/.changeset/new-lizards-marry.md
+++ b/.changeset/new-lizards-marry.md
@@ -1,0 +1,5 @@
+---
+"www": patch
+---
+
+fix: add mode-watcher to Sonner registry dependencies

--- a/apps/www/scripts/registry.ts
+++ b/apps/www/scripts/registry.ts
@@ -8,7 +8,7 @@ const DEPENDENCIES = new Map<string, string[]>([
 	["bits-ui", []],
 	["formsnap", ["zod", "sveltekit-superforms"]],
 	["cmdk-sv", ["bits-ui"]],
-	["svelte-sonner", []],
+	["svelte-sonner", ["mode-watcher"]],
 	["vaul-svelte", []]
 ]);
 // these are required dependencies for particular components
@@ -68,8 +68,9 @@ async function crawlExample(rootPath: string) {
 		if (dirent.isFile() && dirent.name.endsWith(".svelte")) {
 			const [name] = dirent.name.split(".svelte");
 			const file_path = join("example", dirent.name);
-			const { dependencies, registryDependencies } =
-				await getDependencies(join(rootPath, dirent.name));
+			const { dependencies, registryDependencies } = await getDependencies(
+				join(rootPath, dirent.name)
+			);
 
 			exampleRegistry.push({
 				name,
@@ -120,9 +121,7 @@ async function buildUIRegistry(componentPath: string, componentName: string) {
 			dependencies.add(dep)
 		);
 
-		deps.registryDependencies.forEach((dep) =>
-			registryDependencies.add(dep)
-		);
+		deps.registryDependencies.forEach((dep) => registryDependencies.add(dep));
 	}
 
 	return {

--- a/apps/www/scripts/registry.ts
+++ b/apps/www/scripts/registry.ts
@@ -68,9 +68,8 @@ async function crawlExample(rootPath: string) {
 		if (dirent.isFile() && dirent.name.endsWith(".svelte")) {
 			const [name] = dirent.name.split(".svelte");
 			const file_path = join("example", dirent.name);
-			const { dependencies, registryDependencies } = await getDependencies(
-				join(rootPath, dirent.name)
-			);
+			const { dependencies, registryDependencies } =
+				await getDependencies(join(rootPath, dirent.name));
 
 			exampleRegistry.push({
 				name,
@@ -121,7 +120,9 @@ async function buildUIRegistry(componentPath: string, componentName: string) {
 			dependencies.add(dep)
 		);
 
-		deps.registryDependencies.forEach((dep) => registryDependencies.add(dep));
+		deps.registryDependencies.forEach((dep) =>
+			registryDependencies.add(dep)
+		);
 	}
 
 	return {

--- a/apps/www/src/content/components/sonner.md
+++ b/apps/www/src/content/components/sonner.md
@@ -24,6 +24,16 @@ The Sonner component is provided by [svelte-sonner](https://svelte-sonner.vercel
 <Steps>
 
 <Step>
+	Setup theme support
+</Step>
+
+By default, Sonner will use the user's system preferences to determine whether to show the light or dark theme. To get around this, you can either pass in a custom `theme` prop to the component, or simply use `mode-watcher` which you can hardcode to `dark` or `light` mode should you wish.
+
+You can learn more about setting up Dark Mode support [here](/docs/dark-mode).
+
+If you wish to opt out of Dark Mode support, you can uninstall `mode-watcher` and remove the `theme` prop from the component after installing via CLI, or manually install the component and don't include `mode-watcher`
+
+<Step>
 	Run the following command:
 </Step>
 

--- a/apps/www/static/registry/index.json
+++ b/apps/www/static/registry/index.json
@@ -508,7 +508,8 @@
   {
     "name": "sonner",
     "dependencies": [
-      "svelte-sonner"
+      "svelte-sonner",
+      "mode-watcher"
     ],
     "registryDependencies": [],
     "files": [

--- a/apps/www/static/registry/styles/default/sonner.json
+++ b/apps/www/static/registry/styles/default/sonner.json
@@ -1,7 +1,8 @@
 {
   "name": "sonner",
   "dependencies": [
-    "svelte-sonner"
+    "svelte-sonner",
+    "mode-watcher"
   ],
   "registryDependencies": [],
   "files": [

--- a/apps/www/static/registry/styles/new-york/sonner.json
+++ b/apps/www/static/registry/styles/new-york/sonner.json
@@ -1,7 +1,8 @@
 {
   "name": "sonner",
   "dependencies": [
-    "svelte-sonner"
+    "svelte-sonner",
+    "mode-watcher"
   ],
   "registryDependencies": [],
   "files": [


### PR DESCRIPTION
The Sonner component needs us to specify a theme, otherwise it will default to the system preference. If the `<ModeWatcher />` component is not being used, it will also default to `"system"`. If you decide you do not want to use `mode-watcher`, you can simply remove it from your component and replace it with whatever you'd like.

This is aligned with how the original shadcn/ui's installation works, where `next-themes` is installed to keep the toast theme in sync with your app's theme.

Fixes: #595 

### Before submitting the PR, please make sure you do the following

- [x] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Follows the [contribution guidelines](https://github.com/huntabyte/shadcn-svelte/blob/main/CONTRIBUTING.md).
- [x] Format & lint the code with `pnpm format` and `pnpm lint`
