### PR TITLE
feat: forward  `focusin` and `focusout` for `Input` components 

### DIFF
--- a/apps/www/src/lib/registry/default/ui/input/index.ts
+++ b/apps/www/src/lib/registry/default/ui/input/index.ts
@@ -8,6 +8,8 @@ export type InputEvents = {
 	change: FormInputEvent<Event>;
 	click: FormInputEvent<MouseEvent>;
 	focus: FormInputEvent<FocusEvent>;
+	focusin: FormInputEvent<FocusEvent>;
+	focusout: FormInputEvent<FocusEvent>;
 	keydown: FormInputEvent<KeyboardEvent>;
 	keypress: FormInputEvent<KeyboardEvent>;
 	keyup: FormInputEvent<KeyboardEvent>;

--- a/apps/www/src/lib/registry/default/ui/input/input.svelte
+++ b/apps/www/src/lib/registry/default/ui/input/input.svelte
@@ -21,6 +21,8 @@
 	on:change
 	on:click
 	on:focus
+	on:focusin
+	on:focusout
 	on:keydown
 	on:keypress
 	on:keyup

--- a/apps/www/src/lib/registry/new-york/ui/input/index.ts
+++ b/apps/www/src/lib/registry/new-york/ui/input/index.ts
@@ -8,6 +8,8 @@ export type InputEvents = {
 	change: FormInputEvent<Event>;
 	click: FormInputEvent<MouseEvent>;
 	focus: FormInputEvent<FocusEvent>;
+	focusin: FormInputEvent<FocusEvent>;
+	focusout: FormInputEvent<FocusEvent>;
 	keydown: FormInputEvent<KeyboardEvent>;
 	keypress: FormInputEvent<KeyboardEvent>;
 	keyup: FormInputEvent<KeyboardEvent>;

--- a/apps/www/src/lib/registry/new-york/ui/input/input.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/input/input.svelte
@@ -21,6 +21,8 @@
 	on:change
 	on:click
 	on:focus
+	on:focusin
+	on:focusout
 	on:keydown
 	on:keypress
 	on:keyup


### PR DESCRIPTION
I've recently found immense value in using the `focusout` and `focusin` events on input elements locally and realised this functionality is absent in the shadcn-svelte's Input component. Recognising the potential benefits to others, I've decided to contribute by integrating this feature into the library.

This enhancement allows for more dynamic and responsive user interactions. For instance, consider a scenario where you need to display a key securely that can toggle its visibility. Upon focusing out of the Input component, the key gets concealed again. Here's how you can utilise this feature:
```svelte
<div class="relative flex flex-row items-center text-muted-foreground">
	<Input
		type="password"
		class="my-2 pr-[54px]"
		value={key}
		readonly
		disabled
		bind:this={key_element}
		on:focusout={(event) => {
			const target = event.target;

			if (target instanceof HTMLInputElement) {
				target.type = 'password';
				target.disabled = true;
			}
		}}
	/>
	<Toggle
		variant="outline"
		class="absolute right-0 rounded-l-none shadow-none"
		aria-label="toggle key visibility"
		onPressedChange={() => {
			key_element.type = key_element.type === 'password' ? 'text' : 'password';

			if (key_element.type === 'text') {
				key_element.disabled = false;
				key_element.setSelectionRange(0, key_element.value.length);
				key_element.focus();
			} else {
				key_element.disabled = true;
			}
		}}
	>
		<Eye class="h-4 w-4" />
	</Toggle>
</div>
```