### PR TITLE
fix: duplicating ToC ids

### DIFF
--- a/apps/www/src/lib/components/docs/table-of-contents.svelte
+++ b/apps/www/src/lib/components/docs/table-of-contents.svelte
@@ -18,6 +18,8 @@
 		const hierarchy: TableOfContents = { items: [] };
 		let currentLevel: TableOfContentsItem | undefined = undefined;
 
+		const newIdSet: Set<string> = new Set();
+		let count = 1;
 		headings.forEach((heading: HTMLHeadingElement) => {
 			const level = parseInt(heading.tagName.charAt(1));
 			if (!heading.id) {
@@ -25,6 +27,11 @@
 					.replaceAll(/[^a-zA-Z0-9 ]/g, "")
 					.replaceAll(" ", "-")
 					.toLowerCase();
+				if (newIdSet.has(newId)) {
+					newId = `${newId}-${count}`;
+					count++;
+				}
+				newIdSet.add(newId);
 				heading.id = `${newId}`;
 			}
 


### PR DESCRIPTION
Closes: #433 

We're now ensuring that each heading `id` is unique when generating the table of contents.

### Before submitting the PR, please make sure you do the following

- [x] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Follows the [contribution guidelines](https://github.com/huntabyte/shadcn-svelte/blob/main/CONTRIBUTING.md).
- [x] Format & lint the code with `pnpm format` and `pnpm lint`
