### PR TITLE
fix(docs): installation instruction for plain svelte vite

### DIFF
--- a/apps/www/src/content/installation.md
+++ b/apps/www/src/content/installation.md
@@ -89,17 +89,18 @@ If you are _not_ using SvelteKit, then you'll need to update your path aliases i
   }
 }
 ```
+
 ```javascript title="vite.config.js" {1, 5-9}
-import path from 'path';
+import path from "path";
 
 export default defineConfig({
   // ... other options
   resolve: {
     alias: {
-      $lib: path.resolve("./src/lib"),
+      $lib: path.resolve("./src/lib")
     }
   }
-})
+});
 ```
 
 ### Run the CLI

--- a/apps/www/src/content/installation.md
+++ b/apps/www/src/content/installation.md
@@ -76,7 +76,7 @@ const config = {
 };
 ```
 
-If you are _not_ using SvelteKit, then you'll need to update your path aliases in your `tsconfig.json` and `vite.config.js`.
+If you are _not_ using SvelteKit, then you'll need to update your path aliases in your `tsconfig.json` and `vite.config.ts`.
 
 ```json title="tsconfig.json" {4-7}
 {
@@ -90,7 +90,7 @@ If you are _not_ using SvelteKit, then you'll need to update your path aliases i
 }
 ```
 
-```javascript title="vite.config.js" {1, 5-9}
+```js title="vite.config.ts" {1, 5-9}
 import path from "path";
 
 export default defineConfig({

--- a/apps/www/src/content/installation.md
+++ b/apps/www/src/content/installation.md
@@ -76,7 +76,7 @@ const config = {
 };
 ```
 
-If you are _not_ using SvelteKit, then you'll need to update your path aliases in your `tsconfig.json`.
+If you are _not_ using SvelteKit, then you'll need to update your path aliases in your `tsconfig.json` and `vite.config.js`.
 
 ```json title="tsconfig.json" {4-7}
 {
@@ -88,6 +88,18 @@ If you are _not_ using SvelteKit, then you'll need to update your path aliases i
     }
   }
 }
+```
+```javascript title="vite.config.js" {1, 5-9}
+import path from 'path';
+
+export default defineConfig({
+  // ... other options
+  resolve: {
+    alias: {
+      $lib: path.resolve("./src/lib"),
+    }
+  }
+})
 ```
 
 ### Run the CLI


### PR DESCRIPTION
## Why?
The installation instruction for plain svelte + vite (i.e. _not_ sveltekit) is missing step to also edit the `resolve` config in `vite.config.js`, so that vite can understand the `$lib` alias.

## Note:
I've read the contributing guide, and I think I don't need to open an issue because this PR is trivial enough.

### Before submitting the PR, please make sure you do the following

- [ ] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Follows the [contribution guidelines](https://github.com/huntabyte/shadcn-svelte/blob/main/CONTRIBUTING.md).
- [x] Format & lint the code with `pnpm format` and `pnpm lint`
