### PR TITLE
feat: make `Form.SelectTrigger` more flexible

### DIFF
--- a/apps/www/.eslintrc.cjs
+++ b/apps/www/.eslintrc.cjs
@@ -32,8 +32,7 @@ module.exports = {
 					"warn",
 					{
 						argsIgnorePattern: "^_",
-						varsIgnorePattern:
-							"^\\$\\$(Props|Events|Slots|Generic)$"
+						varsIgnorePattern: "^\\$\\$(Props|Events|Slots|Generic)$"
 					}
 				]
 			}

--- a/apps/www/.prettierrc
+++ b/apps/www/.prettierrc
@@ -2,7 +2,7 @@
 	"useTabs": true,
 	"singleQuote": false,
 	"trailingComma": "none",
-	"printWidth": 80,
+	"printWidth": 100,
 	"endOfLine": "lf",
 	"plugins": ["prettier-plugin-svelte"],
 	"pluginSearchDirs": false,

--- a/apps/www/mdsvex.config.js
+++ b/apps/www/mdsvex.config.js
@@ -17,10 +17,7 @@ const __dirname = fileURLToPath(new URL(".", import.meta.url));
 /** @type {import('mdsvex').MdsvexOptions} */
 export const mdsvexOptions = {
 	extensions: [".md"],
-	layout: path.resolve(
-		__dirname,
-		"./src/lib/components/docs/mdsvex/mdsvex.svelte"
-	),
+	layout: path.resolve(__dirname, "./src/lib/components/docs/mdsvex/mdsvex.svelte"),
 	smartypants: {
 		quotes: false,
 		ellipses: false,
@@ -45,10 +42,7 @@ export const mdsvexOptions = {
 						const match = codeEl.data?.meta.match(regex);
 						if (match) {
 							node.__event__ = match ? match[1] : null;
-							codeEl.data.meta = codeEl.data.meta.replace(
-								regex,
-								""
-							);
+							codeEl.data.meta = codeEl.data.meta.replace(regex, "");
 						}
 					}
 
@@ -63,10 +57,7 @@ export const mdsvexOptions = {
 			rehypePrettyCode,
 			{
 				theme: JSON.parse(
-					fs.readFileSync(
-						path.resolve(__dirname, "./other/themes/dark.json"),
-						"utf-8"
-					)
+					fs.readFileSync(path.resolve(__dirname, "./other/themes/dark.json"), "utf-8")
 				),
 				onVisitLine(node) {
 					if (node.children.length === 0) {
@@ -102,10 +93,7 @@ export function rehypeComponentExample() {
 	return async (tree) => {
 		const nameRegex = /name="([^"]+)"/;
 		visit(tree, (node, index, parent) => {
-			if (
-				node?.type === "raw" &&
-				node?.value?.startsWith("<ComponentPreview")
-			) {
+			if (node?.type === "raw" && node?.value?.startsWith("<ComponentPreview")) {
 				const match = node.value.match(nameRegex);
 				const name = match ? match[1] : null;
 
@@ -190,10 +178,7 @@ function rehypeComponentPreToPre() {
 		// Replace `Component.pre` tags with `pre` tags.
 		// This is a workaround to use rehype-pretty-code along with custom mdsvex components.
 		visit(tree, (node) => {
-			if (
-				node?.type === "element" &&
-				node?.tagName === "Components.pre"
-			) {
+			if (node?.type === "element" && node?.tagName === "Components.pre") {
 				node.tagName = "pre";
 			}
 

--- a/apps/www/other/rehype-component-example.ts
+++ b/apps/www/other/rehype-component-example.ts
@@ -11,10 +11,7 @@ export function rehypeComponentExample() {
 	return async (tree) => {
 		const nameRegex = /name="([^"]+)"/;
 		visit(tree, (node, index, parent) => {
-			if (
-				node?.type === "raw" &&
-				node?.value?.startsWith("<ComponentExample")
-			) {
+			if (node?.type === "raw" && node?.value?.startsWith("<ComponentExample")) {
 				const match = node.value.match(nameRegex);
 				const name = match ? match[1] : null;
 

--- a/apps/www/scripts/build-registry.ts
+++ b/apps/www/scripts/build-registry.ts
@@ -39,9 +39,7 @@ for (const style of styles) {
 			continue;
 		}
 
-		const resolveFiles = item.files.map(
-			(file) => `../src/lib/registry/${style.name}/${file}`
-		);
+		const resolveFiles = item.files.map((file) => `../src/lib/registry/${style.name}/${file}`);
 
 		const type = item.type.split(":")[1];
 		index += `
@@ -113,18 +111,13 @@ for (const style of styles) {
 // Build registry/styles/index.json.
 // ----------------------------------------------------------------------------
 const stylesJson = JSON.stringify(styles, null, 2);
-fs.writeFileSync(
-	path.join(REGISTRY_PATH, "styles/index.json"),
-	stylesJson,
-	"utf8"
-);
+fs.writeFileSync(path.join(REGISTRY_PATH, "styles/index.json"), stylesJson, "utf8");
 
 // ----------------------------------------------------------------------------
 // Build registry/index.json.
 // ----------------------------------------------------------------------------
 const names = result.data.filter(
-	(item) =>
-		item.type === "components:ui" && !REGISTRY_IGNORE.includes(item.name)
+	(item) => item.type === "components:ui" && !REGISTRY_IGNORE.includes(item.name)
 );
 const registryJson = JSON.stringify(names, null, 2);
 rimraf.sync(path.join(REGISTRY_PATH, "index.json"));
@@ -150,14 +143,8 @@ for (const [color, value] of Object.entries(colors)) {
 	if (Array.isArray(value)) {
 		colorsData[color] = value.map((item) => ({
 			...item,
-			rgbChannel: item.rgb.replace(
-				/^rgb\((\d+),(\d+),(\d+)\)$/,
-				"$1 $2 $3"
-			),
-			hslChannel: item.hsl.replace(
-				/^hsl\(([\d.]+),([\d.]+%),([\d.]+%)\)$/,
-				"$1 $2 $3"
-			)
+			rgbChannel: item.rgb.replace(/^rgb\((\d+),(\d+),(\d+)\)$/, "$1 $2 $3"),
+			hslChannel: item.hsl.replace(/^hsl\(([\d.]+),([\d.]+%),([\d.]+%)\)$/, "$1 $2 $3")
 		}));
 		continue;
 	}
@@ -165,14 +152,8 @@ for (const [color, value] of Object.entries(colors)) {
 	if (typeof value === "object") {
 		colorsData[color] = {
 			...value,
-			rgbChannel: value.rgb.replace(
-				/^rgb\((\d+),(\d+),(\d+)\)$/,
-				"$1 $2 $3"
-			),
-			hslChannel: value.hsl.replace(
-				/^hsl\(([\d.]+),([\d.]+%),([\d.]+%)\)$/,
-				"$1 $2 $3"
-			)
+			rgbChannel: value.rgb.replace(/^rgb\((\d+),(\d+),(\d+)\)$/, "$1 $2 $3"),
+			hslChannel: value.hsl.replace(/^hsl\(([\d.]+),([\d.]+%),([\d.]+%)\)$/, "$1 $2 $3")
 		};
 		continue;
 	}
@@ -281,17 +262,12 @@ for (const baseColor of ["slate", "gray", "zinc", "neutral", "stone", "lime"]) {
 		base["cssVars"][mode] = {};
 		for (const [key, value] of Object.entries(values)) {
 			if (typeof value === "string") {
-				const resolvedColor = value.replace(
-					/{{base}}-/g,
-					`${baseColor}-`
-				);
+				const resolvedColor = value.replace(/{{base}}-/g, `${baseColor}-`);
 				base["inlineColors"][mode][key] = resolvedColor;
 
 				const [resolvedBase, scale] = resolvedColor.split("-");
 				const color = scale
-					? colorsData[resolvedBase].find(
-							(item: any) => item.scale === parseInt(scale)
-					  )
+					? colorsData[resolvedBase].find((item: any) => item.scale === parseInt(scale))
 					: colorsData[resolvedBase];
 				if (color) {
 					base["cssVars"][mode][key] = color.hslChannel;
@@ -391,10 +367,6 @@ for (const theme of themes) {
 	);
 }
 
-fs.writeFileSync(
-	path.join(REGISTRY_PATH, `themes.css`),
-	themeCSS.join("\n"),
-	"utf8"
-);
+fs.writeFileSync(path.join(REGISTRY_PATH, `themes.css`), themeCSS.join("\n"), "utf8");
 
 console.log("✅ Done!");

--- a/apps/www/scripts/registry.ts
+++ b/apps/www/scripts/registry.ts
@@ -68,8 +68,9 @@ async function crawlExample(rootPath: string) {
 		if (dirent.isFile() && dirent.name.endsWith(".svelte")) {
 			const [name] = dirent.name.split(".svelte");
 			const file_path = join("example", dirent.name);
-			const { dependencies, registryDependencies } =
-				await getDependencies(join(rootPath, dirent.name));
+			const { dependencies, registryDependencies } = await getDependencies(
+				join(rootPath, dirent.name)
+			);
 
 			exampleRegistry.push({
 				name,
@@ -116,13 +117,9 @@ async function buildUIRegistry(componentPath: string, componentName: string) {
 		const deps = await getDependencies(join(componentPath, dirent.name));
 
 		deps.dependencies.forEach((dep) => dependencies.add(dep));
-		REQUIRED_COMPONENT_DEPS.get(componentName)?.forEach((dep) =>
-			dependencies.add(dep)
-		);
+		REQUIRED_COMPONENT_DEPS.get(componentName)?.forEach((dep) => dependencies.add(dep));
 
-		deps.registryDependencies.forEach((dep) =>
-			registryDependencies.add(dep)
-		);
+		deps.registryDependencies.forEach((dep) => registryDependencies.add(dep));
 	}
 
 	return {

--- a/apps/www/src/app.html
+++ b/apps/www/src/app.html
@@ -11,10 +11,7 @@
 		data-sveltekit-preload-data="hover"
 		class="min-h-screen bg-background antialiased font-sans"
 	>
-		<div
-			style="display: contents"
-			class="relative flex min-h-screen flex-col"
-		>
+		<div style="display: contents" class="relative flex min-h-screen flex-col">
 			%sveltekit.body%
 		</div>
 	</body>

--- a/apps/www/src/lib/components/docs/announcement.svelte
+++ b/apps/www/src/lib/components/docs/announcement.svelte
@@ -17,8 +17,6 @@
 >
 	🎉 <Separator class="mx-2 h-4" orientation="vertical" />{" "}
 	<span class="sm:hidden">New components and more.</span>
-	<span class="hidden sm:inline">
-		New components, cli updates and more.
-	</span>
+	<span class="hidden sm:inline"> New components, cli updates and more. </span>
 	<Icons.arrowRight class="ml-1 h-4 w-4" />
 </a>

--- a/apps/www/src/lib/components/docs/charts/bar.svelte
+++ b/apps/www/src/lib/components/docs/charts/bar.svelte
@@ -90,8 +90,7 @@
 						x="57"
 						y="-4"
 						fill="#888888"
-						text-anchor="end"
-						><tspan x="36" dy="0.355em">${tick}</tspan></text
+						text-anchor="end"><tspan x="36" dy="0.355em">${tick}</tspan></text
 					>
 				</g>
 			{/each}
@@ -112,9 +111,7 @@
 						fill="#888888"
 						text-anchor="middle"
 						><tspan x={barWidth / 2} dy="0.71em"
-							>{width > 380
-								? point.name
-								: formatMobile(point.name)}</tspan
+							>{width > 380 ? point.name : formatMobile(point.name)}</tspan
 						></text
 					>
 				</g>

--- a/apps/www/src/lib/components/docs/code-block-wrapper.svelte
+++ b/apps/www/src/lib/components/docs/code-block-wrapper.svelte
@@ -27,11 +27,7 @@
 				)}
 			>
 				<Collapsible.Trigger asChild let:builder>
-					<Button
-						variant="secondary"
-						builders={[builder]}
-						class="h-8 text-xs"
-					>
+					<Button variant="secondary" builders={[builder]} class="h-8 text-xs">
 						{open ? "Collapse" : expandButtonTitle}
 					</Button>
 				</Collapsible.Trigger>

--- a/apps/www/src/lib/components/docs/command-menu.svelte
+++ b/apps/www/src/lib/components/docs/command-menu.svelte
@@ -77,9 +77,7 @@
 								navItem.href && goto(navItem.href);
 							})}
 					>
-						<div
-							class="mr-2 flex h-4 w-4 items-center justify-center"
-						>
+						<div class="mr-2 flex h-4 w-4 items-center justify-center">
 							<Circle class="h-3 w-3" />
 						</div>
 						{navItem.title}
@@ -89,24 +87,15 @@
 		{/each}
 		<Command.Separator />
 		<Command.Group heading="Theme">
-			<Command.Item
-				value="light"
-				onSelect={() => runCommand(() => setMode("light"))}
-			>
+			<Command.Item value="light" onSelect={() => runCommand(() => setMode("light"))}>
 				<Sun class="mr-2 h-4 w-4" />
 				Light
 			</Command.Item>
-			<Command.Item
-				value="dark"
-				onSelect={() => runCommand(() => setMode("dark"))}
-			>
+			<Command.Item value="dark" onSelect={() => runCommand(() => setMode("dark"))}>
 				<Moon class="mr-2 h-4 w-4" />
 				Dark
 			</Command.Item>
-			<Command.Item
-				value="system"
-				onSelect={() => runCommand(() => resetMode())}
-			>
+			<Command.Item value="system" onSelect={() => runCommand(() => resetMode())}>
 				<Laptop class="mr-2 h-4 w-4" />
 				System
 			</Command.Item>

--- a/apps/www/src/lib/components/docs/component-example.svelte
+++ b/apps/www/src/lib/components/docs/component-example.svelte
@@ -13,15 +13,10 @@
 	export let align: "start" | "center" | "end" = "center";
 </script>
 
-<div
-	class={cn("group relative my-4 flex flex-col space-y-2", className)}
-	{...$$restProps}
->
+<div class={cn("group relative my-4 flex flex-col space-y-2", className)} {...$$restProps}>
 	<Tabs.Root value="preview" class="relative mr-auto w-full">
 		<div class="flex items-center justify-between pb-3">
-			<Tabs.List
-				class="w-full justify-start rounded-none border-b bg-transparent p-0"
-			>
+			<Tabs.List class="w-full justify-start rounded-none border-b bg-transparent p-0">
 				<Tabs.Trigger
 					value="preview"
 					class="relative rounded-none border-b-2 border-b-transparent bg-transparent px-4 pb-3 pt-2 font-semibold text-muted-foreground shadow-none transition-none data-[state=active]:border-b-primary data-[state=active]:text-foreground data-[state=active]:shadow-none"

--- a/apps/www/src/lib/components/docs/component-preview-manual.svelte
+++ b/apps/www/src/lib/components/docs/component-preview-manual.svelte
@@ -7,10 +7,7 @@
 	export { className as class };
 </script>
 
-<div
-	class={cn("group relative my-4 flex flex-col space-y-2", className)}
-	{...$$restProps}
->
+<div class={cn("group relative my-4 flex flex-col space-y-2", className)} {...$$restProps}>
 	<div class="relative mr-auto w-full">
 		<div class="relative rounded-md border">
 			<div class="flex items-center justify-between p-4">

--- a/apps/www/src/lib/components/docs/component-preview.svelte
+++ b/apps/www/src/lib/components/docs/component-preview.svelte
@@ -24,15 +24,10 @@
 	export let style = "";
 </script>
 
-<div
-	class={cn("group relative my-4 flex flex-col space-y-2", className)}
-	{...$$restProps}
->
+<div class={cn("group relative my-4 flex flex-col space-y-2", className)} {...$$restProps}>
 	<Tabs.Root value="preview" class="relative mr-auto w-full">
 		<div class="flex items-center justify-between pb-3">
-			<Tabs.List
-				class="w-full justify-start rounded-none border-b bg-transparent p-0"
-			>
+			<Tabs.List class="w-full justify-start rounded-none border-b bg-transparent p-0">
 				<Tabs.Trigger
 					value="preview"
 					class="relative h-9 rounded-none border-b-2 border-b-transparent bg-transparent px-4 pb-3 pt-2 font-semibold text-muted-foreground shadow-none transition-none data-[state=active]:border-b-primary data-[state=active]:text-foreground data-[state=active]:shadow-none"
@@ -66,12 +61,8 @@
 				>
 					<slot name="example">
 						{#await component}
-							<div
-								class="flex items-center text-sm text-muted-foreground"
-							>
-								<Icons.spinner
-									class="mr-2 h-4 w-4 animate-spin"
-								/>
+							<div class="flex items-center text-sm text-muted-foreground">
+								<Icons.spinner class="mr-2 h-4 w-4 animate-spin" />
 								Loading...
 							</div>
 						{:then Component}

--- a/apps/www/src/lib/components/docs/dashboard/dashboard-page.svelte
+++ b/apps/www/src/lib/components/docs/dashboard/dashboard-page.svelte
@@ -1,22 +1,9 @@
 <script lang="ts">
-	import {
-		Activity,
-		CreditCard,
-		DollarSign,
-		Download,
-		Users
-	} from "lucide-svelte";
+	import { Activity, CreditCard, DollarSign, Download, Users } from "lucide-svelte";
 	import { Button } from "@/registry/new-york/ui/button";
 	import * as Card from "@/registry/new-york/ui/card";
 	import * as Tabs from "@/registry/new-york/ui/tabs";
-	import {
-		DashboardMainNav,
-		Overview,
-		RecentSales,
-		Search,
-		UserNav,
-		TeamSwitcher
-	} from ".";
+	import { DashboardMainNav, Overview, RecentSales, Search, UserNav, TeamSwitcher } from ".";
 	import DatePickerWithRange from "@/registry/new-york/example/date-picker-with-range.svelte";
 </script>
 
@@ -61,12 +48,9 @@
 		<Tabs.Root value="overview" class="space-y-4">
 			<Tabs.List>
 				<Tabs.Trigger value="overview">Overview</Tabs.Trigger>
-				<Tabs.Trigger value="analytics" disabled>Analytics</Tabs.Trigger
-				>
+				<Tabs.Trigger value="analytics" disabled>Analytics</Tabs.Trigger>
 				<Tabs.Trigger value="reports" disabled>Reports</Tabs.Trigger>
-				<Tabs.Trigger value="notifications" disabled
-					>Notifications</Tabs.Trigger
-				>
+				<Tabs.Trigger value="notifications" disabled>Notifications</Tabs.Trigger>
 			</Tabs.List>
 			<Tabs.Content value="overview" class="space-y-4">
 				<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
@@ -74,64 +58,48 @@
 						<Card.Header
 							class="flex flex-row items-center justify-between space-y-0 pb-2"
 						>
-							<Card.Title class="text-sm font-medium"
-								>Total Revenue</Card.Title
-							>
+							<Card.Title class="text-sm font-medium">Total Revenue</Card.Title>
 							<DollarSign class="h-4 w-4 text-muted-foreground" />
 						</Card.Header>
 						<Card.Content>
 							<div class="text-2xl font-bold">$45,231.89</div>
-							<p class="text-xs text-muted-foreground">
-								+20.1% from last month
-							</p>
+							<p class="text-xs text-muted-foreground">+20.1% from last month</p>
 						</Card.Content>
 					</Card.Root>
 					<Card.Root>
 						<Card.Header
 							class="flex flex-row items-center justify-between space-y-0 pb-2"
 						>
-							<Card.Title class="text-sm font-medium"
-								>Subscriptions</Card.Title
-							>
+							<Card.Title class="text-sm font-medium">Subscriptions</Card.Title>
 							<Users class="h-4 w-4 text-muted-foreground" />
 						</Card.Header>
 						<Card.Content>
 							<div class="text-2xl font-bold">+2350</div>
-							<p class="text-xs text-muted-foreground">
-								+180.1% from last month
-							</p>
+							<p class="text-xs text-muted-foreground">+180.1% from last month</p>
 						</Card.Content>
 					</Card.Root>
 					<Card.Root>
 						<Card.Header
 							class="flex flex-row items-center justify-between space-y-0 pb-2"
 						>
-							<Card.Title class="text-sm font-medium"
-								>Sales</Card.Title
-							>
+							<Card.Title class="text-sm font-medium">Sales</Card.Title>
 							<CreditCard class="h-4 w-4 text-muted-foreground" />
 						</Card.Header>
 						<Card.Content>
 							<div class="text-2xl font-bold">+12,234</div>
-							<p class="text-xs text-muted-foreground">
-								+19% from last month
-							</p>
+							<p class="text-xs text-muted-foreground">+19% from last month</p>
 						</Card.Content>
 					</Card.Root>
 					<Card.Root>
 						<Card.Header
 							class="flex flex-row items-center justify-between space-y-0 pb-2"
 						>
-							<Card.Title class="text-sm font-medium"
-								>Active Now</Card.Title
-							>
+							<Card.Title class="text-sm font-medium">Active Now</Card.Title>
 							<Activity class="h-4 w-4 text-muted-foreground" />
 						</Card.Header>
 						<Card.Content>
 							<div class="text-2xl font-bold">+573</div>
-							<p class="text-xs text-muted-foreground">
-								+201 since last hour
-							</p>
+							<p class="text-xs text-muted-foreground">+201 since last hour</p>
 						</Card.Content>
 					</Card.Root>
 				</div>
@@ -147,9 +115,7 @@
 					<Card.Root class="col-span-3">
 						<Card.Header>
 							<Card.Title>Recent Sales</Card.Title>
-							<Card.Description>
-								You made 265 sales this month.
-							</Card.Description>
+							<Card.Description>You made 265 sales this month.</Card.Description>
 						</Card.Header>
 						<Card.Content>
 							<RecentSales />

--- a/apps/www/src/lib/components/docs/dashboard/main-nav.svelte
+++ b/apps/www/src/lib/components/docs/dashboard/main-nav.svelte
@@ -6,10 +6,7 @@
 </script>
 
 <nav class={cn("flex items-center space-x-4 lg:space-x-6", className)}>
-	<a
-		href="/examples/dashboard"
-		class="text-sm font-medium transition-colors hover:text-primary"
-	>
+	<a href="/examples/dashboard" class="text-sm font-medium transition-colors hover:text-primary">
 		Overview
 	</a>
 

--- a/apps/www/src/lib/components/docs/dashboard/recent-sales.svelte
+++ b/apps/www/src/lib/components/docs/dashboard/recent-sales.svelte
@@ -15,9 +15,7 @@
 		<div class="ml-auto font-medium">+$1,999.00</div>
 	</div>
 	<div class="flex items-center">
-		<Avatar.Root
-			class="flex h-9 w-9 items-center justify-center space-y-0 border"
-		>
+		<Avatar.Root class="flex h-9 w-9 items-center justify-center space-y-0 border">
 			<Avatar.Image src="/avatars/02.png" alt="Avatar" />
 			<Avatar.Fallback>JL</Avatar.Fallback>
 		</Avatar.Root>
@@ -34,9 +32,7 @@
 		</Avatar.Root>
 		<div class="ml-4 space-y-1">
 			<p class="text-sm font-medium leading-none">Isabella Nguyen</p>
-			<p class="text-sm text-muted-foreground">
-				isabella.nguyen@email.com
-			</p>
+			<p class="text-sm text-muted-foreground">isabella.nguyen@email.com</p>
 		</div>
 		<div class="ml-auto font-medium">+$299.00</div>
 	</div>

--- a/apps/www/src/lib/components/docs/dashboard/search.svelte
+++ b/apps/www/src/lib/components/docs/dashboard/search.svelte
@@ -3,9 +3,5 @@
 </script>
 
 <div>
-	<Input
-		type="search"
-		placeholder="Search..."
-		class="h-9 md:w-[100px] lg:w-[300px]"
-	/>
+	<Input type="search" placeholder="Search..." class="h-9 md:w-[100px] lg:w-[300px]" />
 </div>

--- a/apps/www/src/lib/components/docs/dashboard/team-switcher.svelte
+++ b/apps/www/src/lib/components/docs/dashboard/team-switcher.svelte
@@ -104,8 +104,7 @@
 									<Check
 										class={cn(
 											"ml-auto h-4 w-4",
-											selectedTeam.value !== team.value &&
-												"text-transparent"
+											selectedTeam.value !== team.value && "text-transparent"
 										)}
 									/>
 								</Command.Item>
@@ -159,9 +158,7 @@
 							</Select.Item>
 							<Select.Item value="pro">
 								<span class="font-medium">Pro</span> -
-								<span class="text-muted-foreground">
-									$9/month per user
-								</span>
+								<span class="text-muted-foreground"> $9/month per user </span>
 							</Select.Item>
 						</Select.Content>
 					</Select.Root>
@@ -169,9 +166,7 @@
 			</div>
 		</div>
 		<Dialog.Footer>
-			<Button variant="outline" on:click={() => (showTeamDialog = false)}>
-				Cancel
-			</Button>
+			<Button variant="outline" on:click={() => (showTeamDialog = false)}>Cancel</Button>
 			<Button type="submit">Continue</Button>
 		</Dialog.Footer>
 	</Dialog.Content>

--- a/apps/www/src/lib/components/docs/dashboard/user-nav.svelte
+++ b/apps/www/src/lib/components/docs/dashboard/user-nav.svelte
@@ -6,11 +6,7 @@
 
 <DropdownMenu.Root>
 	<DropdownMenu.Trigger asChild let:builder>
-		<Button
-			variant="ghost"
-			builders={[builder]}
-			class="relative h-8 w-8 rounded-full"
-		>
+		<Button variant="ghost" builders={[builder]} class="relative h-8 w-8 rounded-full">
 			<Avatar.Root class="h-8 w-8">
 				<Avatar.Image src="/avatars/01.png" alt="@shadcn" />
 				<Avatar.Fallback>SC</Avatar.Fallback>
@@ -21,9 +17,7 @@
 		<DropdownMenu.Label class="font-normal">
 			<div class="flex flex-col space-y-1">
 				<p class="text-sm font-medium leading-none">shadcn</p>
-				<p class="text-xs leading-none text-muted-foreground">
-					m@example.com
-				</p>
+				<p class="text-xs leading-none text-muted-foreground">m@example.com</p>
 			</div>
 		</DropdownMenu.Label>
 		<DropdownMenu.Separator />

--- a/apps/www/src/lib/components/docs/docs-pager.svelte
+++ b/apps/www/src/lib/components/docs/docs-pager.svelte
@@ -13,16 +13,12 @@
 		if (!slug) {
 			activeIndex = 1;
 		} else {
-			activeIndex = flattenedLinks.findIndex(
-				(link) => `/docs/${slug}` === link?.href
-			);
+			activeIndex = flattenedLinks.findIndex((link) => `/docs/${slug}` === link?.href);
 		}
 
 		const prev = activeIndex !== 0 ? flattenedLinks[activeIndex - 1] : null;
 		const next =
-			activeIndex !== flattenedLinks.length - 1
-				? flattenedLinks[activeIndex + 1]
-				: null;
+			activeIndex !== flattenedLinks.length - 1 ? flattenedLinks[activeIndex + 1] : null;
 		return {
 			prev,
 			next
@@ -32,9 +28,7 @@
 	function flatten(links: NavItemWithChildren[]): NavItem[] {
 		return links
 			.reduce<NavItem[]>((flat, link) => {
-				return flat.concat(
-					link.items?.length ? flatten(link.items) : link
-				);
+				return flat.concat(link.items?.length ? flatten(link.items) : link);
 			}, [])
 			.filter((link) => !link?.disabled);
 	}

--- a/apps/www/src/lib/components/docs/examples-nav/example-code-link.svelte
+++ b/apps/www/src/lib/components/docs/examples-nav/example-code-link.svelte
@@ -3,9 +3,7 @@
 	import { page } from "$app/stores";
 	import { examples } from "$lib/config/docs";
 
-	$: example = examples.find((example) =>
-		$page.url.pathname.startsWith(example.href)
-	);
+	$: example = examples.find((example) => $page.url.pathname.startsWith(example.href));
 </script>
 
 {#if example?.code}

--- a/apps/www/src/lib/components/docs/examples-nav/examples-nav.svelte
+++ b/apps/www/src/lib/components/docs/examples-nav/examples-nav.svelte
@@ -12,10 +12,7 @@
 	<div class="lg:max-w-none">
 		<!-- TODO: replace with srollarea component when it's ready -->
 		<div
-			class={cn(
-				"mb-4 flex items-center overflow-y-auto pb-3 md:pb-0",
-				className
-			)}
+			class={cn("mb-4 flex items-center overflow-y-auto pb-3 md:pb-0", className)}
 			{...$$restProps}
 		>
 			{#each examples as example, index (index)}

--- a/apps/www/src/lib/components/docs/hex-to-channels.svelte
+++ b/apps/www/src/lib/components/docs/hex-to-channels.svelte
@@ -7,11 +7,7 @@
 	let hex = "#030711";
 	let hsl: [number, number, number] = [0, 0, 0];
 	let rgb: [number, number, number] = [0, 0, 0];
-	$: if (
-		hex &&
-		((hex.length === 6 && hex[0] !== "#") ||
-			(hex.length === 7 && hex[0] === "#"))
-	) {
+	$: if (hex && ((hex.length === 6 && hex[0] !== "#") || (hex.length === 7 && hex[0] === "#"))) {
 		hsl = hexToHsl(hex);
 		rgb = hexToRgb(hex);
 	}

--- a/apps/www/src/lib/components/docs/icons/radix-svelte.svelte
+++ b/apps/www/src/lib/components/docs/icons/radix-svelte.svelte
@@ -4,12 +4,7 @@
 	type $$Props = IconProps;
 </script>
 
-<svg
-	xmlns="http://www.w3.org/2000/svg"
-	viewBox="0 0 24 24"
-	fill="none"
-	{...$$restProps}
->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" {...$$restProps}>
 	<path
 		fill-rule="evenodd"
 		clip-rule="evenodd"

--- a/apps/www/src/lib/components/docs/icons/radix.svelte
+++ b/apps/www/src/lib/components/docs/icons/radix.svelte
@@ -5,10 +5,7 @@
 </script>
 
 <svg viewBox="0 0 25 25" fill="none" {...$$restProps}>
-	<path
-		d="M12 25C7.58173 25 4 21.4183 4 17C4 12.5817 7.58173 9 12 9V25Z"
-		fill="currentcolor"
-	/>
+	<path d="M12 25C7.58173 25 4 21.4183 4 17C4 12.5817 7.58173 9 12 9V25Z" fill="currentcolor" />
 	<path d="M12 0H4V8H12V0Z" fill="currentcolor" />
 	<path
 		d="M17 8C19.2091 8 21 6.20914 21 4C21 1.79086 19.2091 0 17 0C14.7909 0 13 1.79086 13 4C13 6.20914 14.7909 8 17 8Z"

--- a/apps/www/src/lib/components/docs/mdsvex/blockquote.svelte
+++ b/apps/www/src/lib/components/docs/mdsvex/blockquote.svelte
@@ -5,9 +5,6 @@
 	export { className as class };
 </script>
 
-<blockquote
-	class={cn("mt-6 border-l-2 pl-6 italic", className)}
-	{...$$restProps}
->
+<blockquote class={cn("mt-6 border-l-2 pl-6 italic", className)} {...$$restProps}>
 	<slot />
 </blockquote>

--- a/apps/www/src/lib/components/docs/mdsvex/h1.svelte
+++ b/apps/www/src/lib/components/docs/mdsvex/h1.svelte
@@ -5,9 +5,6 @@
 	export { className as class };
 </script>
 
-<h1
-	class={cn("mt-2 scroll-m-20 text-4xl font-bold", className)}
-	{...$$restProps}
->
+<h1 class={cn("mt-2 scroll-m-20 text-4xl font-bold", className)} {...$$restProps}>
 	<slot />
 </h1>

--- a/apps/www/src/lib/components/docs/mdsvex/h3.svelte
+++ b/apps/www/src/lib/components/docs/mdsvex/h3.svelte
@@ -5,12 +5,6 @@
 	export { className as class };
 </script>
 
-<h3
-	class={cn(
-		"mt-8 scroll-m-20 text-xl font-semibold tracking-tight",
-		className
-	)}
-	{...$$restProps}
->
+<h3 class={cn("mt-8 scroll-m-20 text-xl font-semibold tracking-tight", className)} {...$$restProps}>
 	<slot />
 </h3>

--- a/apps/www/src/lib/components/docs/mdsvex/h4.svelte
+++ b/apps/www/src/lib/components/docs/mdsvex/h4.svelte
@@ -5,12 +5,6 @@
 	export { className as class };
 </script>
 
-<h4
-	class={cn(
-		"mt-8 scroll-m-20 text-lg font-semibold tracking-tight",
-		className
-	)}
-	{...$$restProps}
->
+<h4 class={cn("mt-8 scroll-m-20 text-lg font-semibold tracking-tight", className)} {...$$restProps}>
 	<slot />
 </h4>

--- a/apps/www/src/lib/components/docs/mdsvex/h5.svelte
+++ b/apps/www/src/lib/components/docs/mdsvex/h5.svelte
@@ -5,12 +5,6 @@
 	export { className as class };
 </script>
 
-<h5
-	class={cn(
-		"mt-8 scroll-m-20 text-lg font-semibold tracking-tight",
-		className
-	)}
-	{...$$restProps}
->
+<h5 class={cn("mt-8 scroll-m-20 text-lg font-semibold tracking-tight", className)} {...$$restProps}>
 	<slot />
 </h5>

--- a/apps/www/src/lib/components/docs/mdsvex/h6.svelte
+++ b/apps/www/src/lib/components/docs/mdsvex/h6.svelte
@@ -6,10 +6,7 @@
 </script>
 
 <h6
-	class={cn(
-		"mt-8 scroll-m-20 text-base font-semibold tracking-tight",
-		className
-	)}
+	class={cn("mt-8 scroll-m-20 text-base font-semibold tracking-tight", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/components/docs/mdsvex/p.svelte
+++ b/apps/www/src/lib/components/docs/mdsvex/p.svelte
@@ -5,9 +5,6 @@
 	export { className as class };
 </script>
 
-<p
-	class={cn("leading-7 [&:not(:first-child)]:mt-6", className)}
-	{...$$restProps}
->
+<p class={cn("leading-7 [&:not(:first-child)]:mt-6", className)} {...$$restProps}>
 	<slot />
 </p>

--- a/apps/www/src/lib/components/docs/mdsvex/pre.svelte
+++ b/apps/www/src/lib/components/docs/mdsvex/pre.svelte
@@ -21,7 +21,4 @@
 	{...$$restProps}>
 	<slot />
 </pre>
-<CopyButton
-	value={codeString}
-	class={cn("absolute right-4 top-4 pre-copy-btn")}
-/>
+<CopyButton value={codeString} class={cn("absolute right-4 top-4 pre-copy-btn")} />

--- a/apps/www/src/lib/components/docs/metadata.svelte
+++ b/apps/www/src/lib/components/docs/metadata.svelte
@@ -4,9 +4,7 @@
 
 	export let title: string = siteConfig.name;
 
-	$: title = $page.data?.title
-		? `${$page.data.title} - ${siteConfig.name}`
-		: siteConfig.name;
+	$: title = $page.data?.title ? `${$page.data.title} - ${siteConfig.name}` : siteConfig.name;
 </script>
 
 <svelte:head>

--- a/apps/www/src/lib/components/docs/mode-toggle.svelte
+++ b/apps/www/src/lib/components/docs/mode-toggle.svelte
@@ -18,14 +18,8 @@
 		</Button>
 	</DropdownMenu.Trigger>
 	<DropdownMenu.Content align="end">
-		<DropdownMenu.Item on:click={() => setMode("light")}>
-			Light
-		</DropdownMenu.Item>
-		<DropdownMenu.Item on:click={() => setMode("dark")}>
-			Dark
-		</DropdownMenu.Item>
-		<DropdownMenu.Item on:click={() => resetMode()}>
-			System
-		</DropdownMenu.Item>
+		<DropdownMenu.Item on:click={() => setMode("light")}>Light</DropdownMenu.Item>
+		<DropdownMenu.Item on:click={() => setMode("dark")}>Dark</DropdownMenu.Item>
+		<DropdownMenu.Item on:click={() => resetMode()}>System</DropdownMenu.Item>
 	</DropdownMenu.Content>
 </DropdownMenu.Root>

--- a/apps/www/src/lib/components/docs/nav/main-nav.svelte
+++ b/apps/www/src/lib/components/docs/nav/main-nav.svelte
@@ -17,9 +17,7 @@
 			href="/docs"
 			class={cn(
 				"transition-colors hover:text-foreground/80",
-				$page.url.pathname === "/docs"
-					? "text-foreground"
-					: "text-foreground/60"
+				$page.url.pathname === "/docs" ? "text-foreground" : "text-foreground/60"
 			)}
 		>
 			Docs
@@ -39,9 +37,7 @@
 			href="/themes"
 			class={cn(
 				"transition-colors hover:text-foreground/80",
-				$page.url.pathname.startsWith("/themes")
-					? "text-foreground"
-					: "text-foreground/60"
+				$page.url.pathname.startsWith("/themes") ? "text-foreground" : "text-foreground/60"
 			)}
 		>
 			Themes

--- a/apps/www/src/lib/components/docs/nav/mobile-link.svelte
+++ b/apps/www/src/lib/components/docs/nav/mobile-link.svelte
@@ -11,10 +11,7 @@
 
 <a
 	{href}
-	class={cn(
-		$page.url.pathname === href ? "text-foreground" : "text-foreground/60",
-		className
-	)}
+	class={cn($page.url.pathname === href ? "text-foreground" : "text-foreground/60", className)}
 	on:click={() => (open = false)}
 	{...$$restProps}
 >

--- a/apps/www/src/lib/components/docs/nav/mobile-nav.svelte
+++ b/apps/www/src/lib/components/docs/nav/mobile-nav.svelte
@@ -29,11 +29,7 @@
 			<div class="flex flex-col space-y-3">
 				{#each docsConfig.mainNav as navItem, index (navItem + index.toString())}
 					{#if navItem.href}
-						<MobileLink
-							href={navItem.href}
-							bind:open
-							class="text-foreground"
-						>
+						<MobileLink href={navItem.href} bind:open class="text-foreground">
 							{navItem.title}
 						</MobileLink>
 					{/if}

--- a/apps/www/src/lib/components/docs/page-header/page-header-description.svelte
+++ b/apps/www/src/lib/components/docs/page-header/page-header-description.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <p
-	class={cn(
-		"max-w-[750px] text-center text-lg text-muted-foreground sm:text-xl",
-		className
-	)}
+	class={cn("max-w-[750px] text-center text-lg text-muted-foreground sm:text-xl", className)}
 	{...$$restProps}
 >
 	{#if balanced}

--- a/apps/www/src/lib/components/docs/site-footer.svelte
+++ b/apps/www/src/lib/components/docs/site-footer.svelte
@@ -3,15 +3,9 @@
 </script>
 
 <footer class="py-6 md:px-8 md:py-0">
-	<div
-		class="container flex flex-col items-center justify-between gap-4 md:h-24 md:flex-row"
-	>
-		<div
-			class="flex flex-col items-center gap-4 px-8 md:flex-row md:gap-2 md:px-0"
-		>
-			<p
-				class="text-center text-sm leading-loose text-muted-foreground md:text-left"
-			>
+	<div class="container flex flex-col items-center justify-between gap-4 md:h-24 md:flex-row">
+		<div class="flex flex-col items-center gap-4 px-8 md:flex-row md:gap-2 md:px-0">
+			<p class="text-center text-sm leading-loose text-muted-foreground md:text-left">
 				Built & designed by{" "}
 				<a
 					href={siteConfig.links.shadTwitter}

--- a/apps/www/src/lib/components/docs/site-header.svelte
+++ b/apps/www/src/lib/components/docs/site-header.svelte
@@ -1,11 +1,5 @@
 <script lang="ts">
-	import {
-		Icons,
-		ModeToggle,
-		MainNav,
-		MobileNav,
-		CommandMenu
-	} from "@/components/docs";
+	import { Icons, ModeToggle, MainNav, MobileNav, CommandMenu } from "@/components/docs";
 	import { buttonVariants } from "@/registry/new-york/ui/button";
 	import { siteConfig } from "$lib/config/site";
 	import { cn } from "$lib/utils";
@@ -17,18 +11,12 @@
 	<div class="container flex h-14 max-w-screen-2xl items-center">
 		<MainNav />
 		<MobileNav />
-		<div
-			class="flex flex-1 items-center justify-between space-x-2 md:justify-end"
-		>
+		<div class="flex flex-1 items-center justify-between space-x-2 md:justify-end">
 			<div class="w-full flex-1 md:w-auto md:flex-none">
 				<CommandMenu />
 			</div>
 			<nav class="flex items-center">
-				<a
-					href={siteConfig.links.github}
-					target="_blank"
-					rel="noopener noreferrer"
-				>
+				<a href={siteConfig.links.github} target="_blank" rel="noopener noreferrer">
 					<div
 						class={cn(
 							buttonVariants({
@@ -42,11 +30,7 @@
 						<span class="sr-only">GitHub</span>
 					</div>
 				</a>
-				<a
-					href={siteConfig.links.twitter}
-					target="_blank"
-					rel="noreferrer"
-				>
+				<a href={siteConfig.links.twitter} target="_blank" rel="noreferrer">
 					<div
 						class={cn(
 							buttonVariants({
@@ -57,9 +41,7 @@
 						)}
 					>
 						<Icons.twitter class="h-3 w-3 fill-current" />
-						<span class="sr-only"
-							>X (formerly known as Twitter)</span
-						>
+						<span class="sr-only">X (formerly known as Twitter)</span>
 					</div>
 				</a>
 				<ModeToggle />

--- a/apps/www/src/lib/components/docs/steps.svelte
+++ b/apps/www/src/lib/components/docs/steps.svelte
@@ -1,6 +1,3 @@
-<div
-	class="[&>h3]:step steps mb-12 ml-4 border-l pl-8 [counter-reset:step]"
-	{...$$restProps}
->
+<div class="[&>h3]:step steps mb-12 ml-4 border-l pl-8 [counter-reset:step]" {...$$restProps}>
 	<slot />
 </div>

--- a/apps/www/src/lib/components/docs/table-of-contents.svelte
+++ b/apps/www/src/lib/components/docs/table-of-contents.svelte
@@ -13,9 +13,7 @@
 			return { items: [] };
 		}
 
-		const headings: HTMLHeadingElement[] = Array.from(
-			div.querySelectorAll("h2, h3")
-		);
+		const headings: HTMLHeadingElement[] = Array.from(div.querySelectorAll("h2, h3"));
 		const hierarchy: TableOfContents = { items: [] };
 		let currentLevel: TableOfContentsItem | undefined = undefined;
 

--- a/apps/www/src/lib/components/docs/tailwind-indicator.svelte
+++ b/apps/www/src/lib/components/docs/tailwind-indicator.svelte
@@ -2,9 +2,7 @@
 	class="fixed bottom-1 left-1 z-50 flex h-6 w-6 items-center justify-center rounded-full bg-gray-800 p-3 font-mono text-xs text-white"
 >
 	<div class="block sm:hidden">xs</div>
-	<div class="hidden sm:block md:hidden lg:hidden xl:hidden 2xl:hidden">
-		sm
-	</div>
+	<div class="hidden sm:block md:hidden lg:hidden xl:hidden 2xl:hidden">sm</div>
 	<div class="hidden md:block lg:hidden xl:hidden 2xl:hidden">md</div>
 	<div class="hidden lg:block xl:hidden 2xl:hidden">lg</div>
 	<div class="hidden xl:block 2xl:hidden">xl</div>

--- a/apps/www/src/lib/components/docs/theme-customizer/customizer-code.svelte
+++ b/apps/www/src/lib/components/docs/theme-customizer/customizer-code.svelte
@@ -22,67 +22,72 @@
 		<pre
 			class="max-h-[450px] overflow-x-auto rounded-lg border bg-zinc-950 dark:bg-zinc-900"
 			use:setCodeString>
-            <code
-				class="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm">
+            <code class="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm">
                 <span class="line text-white">@layer base &#123;</span>
                 <span class="line text-white">  :root &#123;</span>
-                <span class="line text-white">    --background:{" "}{activeTheme
-						?.cssVars.light["background"]};</span
+                <span class="line text-white">    --background:{" "}{activeTheme?.cssVars.light[
+						"background"
+					]};</span
 				>
-            <span class="line text-white">    --foreground:{" "}{activeTheme
-						?.cssVars.light["foreground"]};</span
+            <span class="line text-white">    --foreground:{" "}{activeTheme?.cssVars.light[
+						"foreground"
+					]};</span
 				>
             {#each prefixes as prefix}
-					<span
-						class="line text-white">    --{prefix}:{" "}{activeTheme
-							?.cssVars.light[prefix]};</span
+					<span class="line text-white">    --{prefix}:{" "}{activeTheme?.cssVars.light[
+							prefix
+						]};</span
 					>
               <span
-						class="line text-white">    --{prefix}-foreground:{" "}{activeTheme
-							?.cssVars.light[`${prefix}-foreground`]};</span
+						class="line text-white">    --{prefix}-foreground:{" "}{activeTheme?.cssVars
+							.light[`${prefix}-foreground`]};</span
 					>
 				{/each}
-                <span class="line text-white">    --border:{" "}{activeTheme
-						?.cssVars.light["border"]};</span
+                <span class="line text-white">    --border:{" "}{activeTheme?.cssVars.light[
+						"border"
+					]};</span
 				>
-                  <span class="line text-white">    --input:{" "}{activeTheme
-						?.cssVars.light["input"]};</span
+                  <span class="line text-white">    --input:{" "}{activeTheme?.cssVars.light[
+						"input"
+					]};</span
 				>
-                  <span class="line text-white">    --ring:{" "}{activeTheme
-						?.cssVars.light["ring"]};</span
+                  <span class="line text-white">    --ring:{" "}{activeTheme?.cssVars.light[
+						"ring"
+					]};</span
 				>
-                  <span
-					class="line text-white">    --radius: {$config.radius}rem;</span
-				>
+                  <span class="line text-white">    --radius: {$config.radius}rem;</span>
                   <span class="line text-white">  &#125;</span>
                   <span class="line text-white" />
                   <span class="line text-white">  .dark &#123;</span>
-                  <span
-					class="line text-white">    --background:{" "}{activeTheme
-						?.cssVars.dark["background"]};</span
+                  <span class="line text-white">    --background:{" "}{activeTheme?.cssVars.dark[
+						"background"
+					]};</span
 				>
-                  <span
-					class="line text-white">    --foreground:{" "}{activeTheme
-						?.cssVars.dark["foreground"]};</span
+                  <span class="line text-white">    --foreground:{" "}{activeTheme?.cssVars.dark[
+						"foreground"
+					]};</span
 				>
                   {#each prefixes as prefix}
-					<span
-						class="line text-white">    --{prefix}:{" "}{activeTheme
-							?.cssVars.dark[prefix]};</span
+					<span class="line text-white">    --{prefix}:{" "}{activeTheme?.cssVars.dark[
+							prefix
+						]};</span
 					>
             <span
-						class="line text-white">    --{prefix}-foreground:{" "}{activeTheme
-							?.cssVars.dark[`${prefix}-foreground`]};</span
+						class="line text-white">    --{prefix}-foreground:{" "}{activeTheme?.cssVars
+							.dark[`${prefix}-foreground`]};</span
 					>
 				{/each}
-                <span class="line text-white">    --border:{" "}{activeTheme
-						?.cssVars.dark["border"]};</span
+                <span class="line text-white">    --border:{" "}{activeTheme?.cssVars.dark[
+						"border"
+					]};</span
 				>
-                  <span class="line text-white">    --input:{" "}{activeTheme
-						?.cssVars.dark["input"]};</span
+                  <span class="line text-white">    --input:{" "}{activeTheme?.cssVars.dark[
+						"input"
+					]};</span
 				>
-                  <span class="line text-white">    --ring:{" "}{activeTheme
-						?.cssVars.dark["ring"]};</span
+                  <span class="line text-white">    --ring:{" "}{activeTheme?.cssVars.dark[
+						"ring"
+					]};</span
 				>
                   <span class="line text-white">  &#125;</span>
                   <span class="line text-white">&#125;</span>

--- a/apps/www/src/lib/components/docs/theme-customizer/customizer.svelte
+++ b/apps/www/src/lib/components/docs/theme-customizer/customizer.svelte
@@ -13,9 +13,7 @@
 <ThemeWrapper defaultTheme="zinc" class="flex flex-col space-y-4 md:space-y-6">
 	<div class="flex items-start">
 		<div class="space-y-1 pr-2">
-			<div class="font-semibold leading-none tracking-tight">
-				Customize
-			</div>
+			<div class="font-semibold leading-none tracking-tight">Customize</div>
 			<div class="text-xs text-muted-foreground">
 				Pick a style and color for your components.
 			</div>
@@ -52,21 +50,19 @@
 						sideOffset={-20}
 					>
 						<p class="font-medium">
-							What is the difference between the New York and
-							Default style?
+							What is the difference between the New York and Default style?
 						</p>
 						<p>
-							A style comes with its own set of components,
-							animations, icons and more.
+							A style comes with its own set of components, animations, icons and
+							more.
 						</p>
 						<p>
-							The <span class="font-medium">Default</span> style has
-							larger inputs, uses lucide-svelte for icons.
+							The <span class="font-medium">Default</span> style has larger inputs, uses
+							lucide-svelte for icons.
 						</p>
 						<p>
-							The <span class="font-medium">New York</span> style ships
-							with smaller buttons and cards with shadows. It uses
-							icons from Radix Icons.
+							The <span class="font-medium">New York</span> style ships with smaller buttons
+							and cards with shadows. It uses icons from Radix Icons.
 						</p>
 					</Popover.Content>
 				</Popover.Root>
@@ -80,9 +76,7 @@
 							...prev,
 							style: "default"
 						}))}
-					class={cn(
-						$config.style === "default" && "border-2 border-primary"
-					)}
+					class={cn($config.style === "default" && "border-2 border-primary")}
 				>
 					Default
 				</Button>
@@ -94,10 +88,7 @@
 							...prev,
 							style: "new-york"
 						}))}
-					class={cn(
-						$config.style === "new-york" &&
-							"border-2 border-primary"
-					)}
+					class={cn($config.style === "new-york" && "border-2 border-primary")}
 				>
 					New York
 				</Button>
@@ -117,13 +108,8 @@
 								theme: theme.name
 							}));
 						}}
-						class={cn(
-							"justify-start",
-							isActive && "border-2 border-primary"
-						)}
-						style="--theme-primary: hsl({theme?.activeColor[
-							$mode ?? 'dark'
-						]}"
+						class={cn("justify-start", isActive && "border-2 border-primary")}
+						style="--theme-primary: hsl({theme?.activeColor[$mode ?? 'dark']}"
 					>
 						<span
 							class="mr-1 flex h-5 w-5 shrink-0 -translate-x-1 items-center justify-center rounded-full bg-[--theme-primary]"
@@ -151,10 +137,7 @@
 								radius: valueFloat
 							}));
 						}}
-						class={cn(
-							$config.radius === valueFloat &&
-								"border-2 border-primary"
-						)}
+						class={cn($config.radius === valueFloat && "border-2 border-primary")}
 					>
 						{value}
 					</Button>

--- a/apps/www/src/lib/components/docs/theme-customizer/theme-customizer.svelte
+++ b/apps/www/src/lib/components/docs/theme-customizer/theme-customizer.svelte
@@ -33,9 +33,7 @@
 								}}
 								class={cn(
 									"flex h-9 w-9 items-center justify-center rounded-full border-2 text-xs",
-									isActive
-										? "border-[--theme-primary]"
-										: "border-transparent"
+									isActive ? "border-[--theme-primary]" : "border-transparent"
 								)}
 								style="--theme-primary: hsl({theme?.activeColor[
 									$mode === 'dark' ? 'dark' : 'light'

--- a/apps/www/src/lib/config/components.ts
+++ b/apps/www/src/lib/config/components.ts
@@ -61,10 +61,7 @@ export const components = [
 	{
 		component: "badge",
 		name: "Badge",
-		files: [
-			"src/lib/components/ui/badge/Badge.svelte",
-			"src/lib/components/ui/badge/index.ts"
-		]
+		files: ["src/lib/components/ui/badge/Badge.svelte", "src/lib/components/ui/badge/index.ts"]
 	},
 	{
 		component: "button",
@@ -153,19 +150,13 @@ export const components = [
 	{
 		component: "input",
 		name: "Input",
-		files: [
-			"src/lib/components/ui/input/Input.svelte",
-			"src/lib/components/ui/input/index.ts"
-		]
+		files: ["src/lib/components/ui/input/Input.svelte", "src/lib/components/ui/input/index.ts"]
 	},
 	{
 		component: "label",
 		name: "Label",
 		dependencies: ["radix-svelte"],
-		files: [
-			"src/lib/components/ui/label/Label.svelte",
-			"src/lib/components/ui/label/index.ts"
-		]
+		files: ["src/lib/components/ui/label/Label.svelte", "src/lib/components/ui/label/index.ts"]
 	},
 	//   {
 	//     component: "menubar",

--- a/apps/www/src/lib/config/site.ts
+++ b/apps/www/src/lib/config/site.ts
@@ -2,8 +2,7 @@ export const siteConfig = {
 	name: "shadcn-svelte",
 	url: "https://shadcn-svelte.com",
 	ogImage: "https://shadcn-svelte.com/og.png",
-	description:
-		"Beautifully designed components built with Melt UI and Tailwind CSS.",
+	description: "Beautifully designed components built with Melt UI and Tailwind CSS.",
 	links: {
 		twitter: "https://twitter.com/huntabyte",
 		github: "https://github.com/huntabyte/shadcn-svelte",

--- a/apps/www/src/lib/registry/default/example/accordion-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/accordion-demo.svelte
@@ -5,15 +5,12 @@
 <Accordion.Root class="w-full sm:max-w-[70%]">
 	<Accordion.Item value="item-1">
 		<Accordion.Trigger>Is it accessible?</Accordion.Trigger>
-		<Accordion.Content>
-			Yes. It adheres to the WAI-ARIA design pattern.
-		</Accordion.Content>
+		<Accordion.Content>Yes. It adheres to the WAI-ARIA design pattern.</Accordion.Content>
 	</Accordion.Item>
 	<Accordion.Item value="item-2">
 		<Accordion.Trigger>Is it styled?</Accordion.Trigger>
 		<Accordion.Content>
-			Yes. It comes with default styles that matches the other components'
-			aesthetic.
+			Yes. It comes with default styles that matches the other components' aesthetic.
 		</Accordion.Content>
 	</Accordion.Item>
 	<Accordion.Item value="item-3">

--- a/apps/www/src/lib/registry/default/example/alert-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/alert-demo.svelte
@@ -6,7 +6,5 @@
 <Alert.Root>
 	<Terminal class="h-4 w-4" />
 	<Alert.Title>Heads up!</Alert.Title>
-	<Alert.Description>
-		You can add components to your app using the cli.
-	</Alert.Description>
+	<Alert.Description>You can add components to your app using the cli.</Alert.Description>
 </Alert.Root>

--- a/apps/www/src/lib/registry/default/example/alert-destructive.svelte
+++ b/apps/www/src/lib/registry/default/example/alert-destructive.svelte
@@ -6,7 +6,5 @@
 <Alert.Root variant="destructive">
 	<AlertCircle class="h-4 w-4" />
 	<Alert.Title>Error</Alert.Title>
-	<Alert.Description>
-		Your session has expired. Please login again.
-	</Alert.Description>
+	<Alert.Description>Your session has expired. Please login again.</Alert.Description>
 </Alert.Root>

--- a/apps/www/src/lib/registry/default/example/alert-dialog-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/alert-dialog-demo.svelte
@@ -11,8 +11,8 @@
 		<AlertDialog.Header>
 			<AlertDialog.Title>Are you absolutely sure?</AlertDialog.Title>
 			<AlertDialog.Description>
-				This action cannot be undone. This will permanently delete your
-				account and remove your data from our servers.
+				This action cannot be undone. This will permanently delete your account and remove
+				your data from our servers.
 			</AlertDialog.Description>
 		</AlertDialog.Header>
 		<AlertDialog.Footer>

--- a/apps/www/src/lib/registry/default/example/calendar-with-selects.svelte
+++ b/apps/www/src/lib/registry/default/example/calendar-with-selects.svelte
@@ -3,11 +3,7 @@
 	import * as Calendar from "@/registry/default/ui/calendar";
 	import * as Select from "@/registry/default/ui/select";
 	import { cn } from "$lib/utils";
-	import {
-		DateFormatter,
-		getLocalTimeZone,
-		today
-	} from "@internationalized/date";
+	import { DateFormatter, getLocalTimeZone, today } from "@internationalized/date";
 
 	type $$Props = CalendarPrimitive.Props;
 	type $$Events = CalendarPrimitive.Events;
@@ -69,9 +65,7 @@
 	bind:placeholder
 >
 	<Calendar.Header>
-		<Calendar.Heading
-			class="flex items-center justify-between w-full gap-2"
-		>
+		<Calendar.Heading class="flex items-center justify-between w-full gap-2">
 			<Select.Root
 				selected={defaultMonth}
 				items={monthOptions}

--- a/apps/www/src/lib/registry/default/example/card-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/card-demo.svelte
@@ -29,23 +29,15 @@
 		<div class=" flex items-center space-x-4 rounded-md border p-4">
 			<BellRing />
 			<div class="flex-1 space-y-1">
-				<p class="text-sm font-medium leading-none">
-					Push Notifications
-				</p>
-				<p class="text-sm text-muted-foreground">
-					Send notifications to device.
-				</p>
+				<p class="text-sm font-medium leading-none">Push Notifications</p>
+				<p class="text-sm text-muted-foreground">Send notifications to device.</p>
 			</div>
 			<Switch />
 		</div>
 		<div>
 			{#each notifications as notification, idx (idx)}
-				<div
-					class="mb-4 grid grid-cols-[25px_1fr] items-start pb-4 last:mb-0 last:pb-0"
-				>
-					<span
-						class="flex h-2 w-2 translate-y-1 rounded-full bg-sky-500"
-					/>
+				<div class="mb-4 grid grid-cols-[25px_1fr] items-start pb-4 last:mb-0 last:pb-0">
+					<span class="flex h-2 w-2 translate-y-1 rounded-full bg-sky-500" />
 					<div class="space-y-1">
 						<p class="text-sm font-medium leading-none">
 							{notification.title}

--- a/apps/www/src/lib/registry/default/example/card-with-form.svelte
+++ b/apps/www/src/lib/registry/default/example/card-with-form.svelte
@@ -28,9 +28,7 @@
 <Card.Root class="w-[350px]">
 	<Card.Header>
 		<Card.Title>Create project</Card.Title>
-		<Card.Description
-			>Deploy your new project in one-click.</Card.Description
-		>
+		<Card.Description>Deploy your new project in one-click.</Card.Description>
 	</Card.Header>
 	<Card.Content>
 		<form>
@@ -47,9 +45,7 @@
 						</Select.Trigger>
 						<Select.Content>
 							{#each frameworks as framework}
-								<Select.Item
-									value={framework.value}
-									label={framework.label}
+								<Select.Item value={framework.value} label={framework.label}
 									>{framework.label}</Select.Item
 								>
 							{/each}

--- a/apps/www/src/lib/registry/default/example/cards/activity-goal.svelte
+++ b/apps/www/src/lib/registry/default/example/cards/activity-goal.svelte
@@ -29,9 +29,7 @@
 			</Button>
 			<div class="flex-1 text-center">
 				<div class="text-5xl font-bold tracking-tighter">{goal}</div>
-				<div class="text-[0.70rem] uppercase text-muted-foreground">
-					Calories/day
-				</div>
+				<div class="text-[0.70rem] uppercase text-muted-foreground">Calories/day</div>
 			</div>
 
 			<Button

--- a/apps/www/src/lib/registry/default/example/cards/all.svelte
+++ b/apps/www/src/lib/registry/default/example/cards/all.svelte
@@ -13,9 +13,7 @@
 	import CardsChat from "./chat.svelte";
 </script>
 
-<div
-	class="md:grids-col-2 grid md:gap-4 lg:grid-cols-10 xl:grid-cols-11 xl:gap-4"
->
+<div class="md:grids-col-2 grid md:gap-4 lg:grid-cols-10 xl:grid-cols-11 xl:gap-4">
 	<div class="space-y-4 lg:col-span-4 xl:col-span-6 xl:space-y-4">
 		<CardsStats />
 		<div class="grid gap-1 sm:grid-cols-[280px_1fr] md:hidden">

--- a/apps/www/src/lib/registry/default/example/cards/chat.svelte
+++ b/apps/www/src/lib/registry/default/example/cards/chat.svelte
@@ -143,13 +143,10 @@
 		<Dialog.Header class="px-4 pb-4 pt-5">
 			<Dialog.Title>New message</Dialog.Title>
 			<Dialog.Description>
-				Invite a user to this thread. This will create a new group
-				message.
+				Invite a user to this thread. This will create a new group message.
 			</Dialog.Description>
 		</Dialog.Header>
-		<Command.Root
-			class="overflow-hidden rounded-t-none border-t bg-transparent"
-		>
+		<Command.Root class="overflow-hidden rounded-t-none border-t bg-transparent">
 			<Command.Input placeholder="Search user..." />
 			<Command.List>
 				<Command.Empty>No users found.</Command.Empty>
@@ -171,8 +168,7 @@
 						>
 							<Avatar.Root>
 								<Avatar.Image src={user.avatar} alt="Image" />
-								<Avatar.Fallback>{user.name[0]}</Avatar.Fallback
-								>
+								<Avatar.Fallback>{user.name[0]}</Avatar.Fallback>
 							</Avatar.Root>
 							<div class="ml-2">
 								<p class="text-sm font-medium leading-none">
@@ -183,38 +179,27 @@
 								</p>
 							</div>
 							{#if selectedUsers.includes(user)}
-								<Check
-									class="ml-auto flex h-5 w-5 text-primary"
-								/>
+								<Check class="ml-auto flex h-5 w-5 text-primary" />
 							{/if}
 						</Command.Item>
 					{/each}
 				</Command.Group>
 			</Command.List>
 		</Command.Root>
-		<Dialog.Footer
-			class="flex items-center border-t p-4 sm:justify-between"
-		>
+		<Dialog.Footer class="flex items-center border-t p-4 sm:justify-between">
 			{#if selectedUsers.length}
 				<div class="flex -space-x-2 overflow-hidden">
 					{#each selectedUsers as user}
-						<Avatar.Root
-							class="inline-block border-2 border-background"
-						>
+						<Avatar.Root class="inline-block border-2 border-background">
 							<Avatar.Image src={user.avatar} />
 							<Avatar.Fallback>{user.name[0]}</Avatar.Fallback>
 						</Avatar.Root>
 					{/each}
 				</div>
 			{:else}
-				<p class="text-sm text-muted-foreground">
-					Select users to add to this thread.
-				</p>
+				<p class="text-sm text-muted-foreground">Select users to add to this thread.</p>
 			{/if}
-			<Button
-				disabled={selectedUsers.length < 2}
-				on:click={() => (open = false)}
-			>
+			<Button disabled={selectedUsers.length < 2} on:click={() => (open = false)}>
 				Continue
 			</Button>
 		</Dialog.Footer>

--- a/apps/www/src/lib/registry/default/example/cards/cookie-settings.svelte
+++ b/apps/www/src/lib/registry/default/example/cards/cookie-settings.svelte
@@ -14,11 +14,8 @@
 		<div class="flex items-center justify-between space-x-4">
 			<Label for="necessary" class="flex flex-col space-y-1">
 				<span>Strictly Necessary</span>
-				<span
-					class="text-xs font-normal leading-snug text-muted-foreground"
-				>
-					These cookies are essential in order to use the website and
-					use its features.
+				<span class="text-xs font-normal leading-snug text-muted-foreground">
+					These cookies are essential in order to use the website and use its features.
 				</span>
 			</Label>
 			<Switch id="necessary" checked aria-label="Necessary" />
@@ -26,11 +23,8 @@
 		<div class="flex items-center justify-between space-x-4">
 			<Label for="functional" class="flex flex-col space-y-1">
 				<span>Functional Cookies</span>
-				<span
-					class="text-xs font-normal leading-snug text-muted-foreground"
-				>
-					These cookies allow the website to provide personalized
-					functionality.
+				<span class="text-xs font-normal leading-snug text-muted-foreground">
+					These cookies allow the website to provide personalized functionality.
 				</span>
 			</Label>
 			<Switch id="functional" aria-label="Functional" />
@@ -38,11 +32,8 @@
 		<div class="flex items-center justify-between space-x-4">
 			<Label for="performance" class="flex flex-col space-y-1">
 				<span>Performance Cookies</span>
-				<span
-					class="text-xs font-normal leading-snug text-muted-foreground"
-				>
-					These cookies help to improve the performance of the
-					website.
+				<span class="text-xs font-normal leading-snug text-muted-foreground">
+					These cookies help to improve the performance of the website.
 				</span>
 			</Label>
 			<Switch id="performance" aria-label="Performance" />

--- a/apps/www/src/lib/registry/default/example/cards/create-account.svelte
+++ b/apps/www/src/lib/registry/default/example/cards/create-account.svelte
@@ -9,9 +9,7 @@
 <Card.Root>
 	<Card.Header class="space-y-1">
 		<Card.Title class="text-2xl">Create an account</Card.Title>
-		<Card.Description>
-			Enter your email below to create your account
-		</Card.Description>
+		<Card.Description>Enter your email below to create your account</Card.Description>
 	</Card.Header>
 	<Card.Content class="grid gap-4">
 		<div class="grid grid-cols-2 gap-6">
@@ -29,9 +27,7 @@
 				<span class="w-full border-t" />
 			</div>
 			<div class="relative flex justify-center text-xs uppercase">
-				<span class="bg-card px-2 text-muted-foreground">
-					Or continue with
-				</span>
+				<span class="bg-card px-2 text-muted-foreground"> Or continue with </span>
 			</div>
 		</div>
 		<div class="grid gap-2">

--- a/apps/www/src/lib/registry/default/example/cards/data-table.svelte
+++ b/apps/www/src/lib/registry/default/example/cards/data-table.svelte
@@ -1,10 +1,5 @@
 <script lang="ts">
-	import {
-		createTable,
-		Subscribe,
-		Render,
-		createRender
-	} from "svelte-headless-table";
+	import { createTable, Subscribe, Render, createRender } from "svelte-headless-table";
 	import {
 		addSortBy,
 		addPagination,
@@ -142,15 +137,8 @@
 		})
 	]);
 
-	const {
-		headerRows,
-		pageRows,
-		tableAttrs,
-		tableBodyAttrs,
-		flatColumns,
-		pluginStates,
-		rows
-	} = table.createViewModel(columns);
+	const { headerRows, pageRows, tableAttrs, tableBodyAttrs, flatColumns, pluginStates, rows } =
+		table.createViewModel(columns);
 
 	const { sortKeys } = pluginStates.sort;
 
@@ -185,20 +173,14 @@
 			/>
 			<DropdownMenu.Root>
 				<DropdownMenu.Trigger asChild let:builder>
-					<Button
-						variant="outline"
-						class="ml-auto"
-						builders={[builder]}
-					>
+					<Button variant="outline" class="ml-auto" builders={[builder]}>
 						Columns <ChevronDown class="ml-2 h-4 w-4" />
 					</Button>
 				</DropdownMenu.Trigger>
 				<DropdownMenu.Content>
 					{#each flatColumns as col}
 						{#if hideableCols.includes(col.id)}
-							<DropdownMenu.CheckboxItem
-								bind:checked={hideForId[col.id]}
-							>
+							<DropdownMenu.CheckboxItem bind:checked={hideForId[col.id]}>
 								{col.header}
 							</DropdownMenu.CheckboxItem>
 						{/if}
@@ -221,30 +203,21 @@
 									>
 										<Table.Head
 											{...attrs}
-											class={cn(
-												"[&:has([role=checkbox])]:pl-3"
-											)}
+											class={cn("[&:has([role=checkbox])]:pl-3")}
 										>
 											{#if cell.id === "amount"}
-												<div
-													class="text-right font-medium"
-												>
-													<Render
-														of={cell.render()}
-													/>
+												<div class="text-right font-medium">
+													<Render of={cell.render()} />
 												</div>
 											{:else if cell.id === "email"}
 												<Button
 													variant="ghost"
 													on:click={props.sort.toggle}
 												>
-													<Render
-														of={cell.render()}
-													/>
+													<Render of={cell.render()} />
 													<ArrowUpDown
 														class={cn(
-															$sortKeys[0]?.id ===
-																cell.id &&
+															$sortKeys[0]?.id === cell.id &&
 																"text-foreground",
 															"ml-2 h-4 w-4"
 														)}
@@ -265,8 +238,7 @@
 						<Subscribe rowAttrs={row.attrs()} let:rowAttrs>
 							<Table.Row
 								{...rowAttrs}
-								data-state={$selectedDataIds[row.id] &&
-									"selected"}
+								data-state={$selectedDataIds[row.id] && "selected"}
 							>
 								{#each row.cells as cell (cell.id)}
 									<Subscribe attrs={cell.attrs()} let:attrs>
@@ -275,18 +247,12 @@
 											{...attrs}
 										>
 											{#if cell.id === "amount"}
-												<div
-													class="text-right font-medium"
-												>
-													<Render
-														of={cell.render()}
-													/>
+												<div class="text-right font-medium">
+													<Render of={cell.render()} />
 												</div>
 											{:else if cell.id === "status"}
 												<div class="capitalize">
-													<Render
-														of={cell.render()}
-													/>
+													<Render of={cell.render()} />
 												</div>
 											{:else}
 												<Render of={cell.render()} />

--- a/apps/www/src/lib/registry/default/example/cards/github.svelte
+++ b/apps/www/src/lib/registry/default/example/cards/github.svelte
@@ -11,13 +11,10 @@
 		<div class="space-y-1">
 			<Card.Title>shadcn-svelte</Card.Title>
 			<Card.Description>
-				Beautifully designed components built with Melt UI and Tailwind
-				CSS.
+				Beautifully designed components built with Melt UI and Tailwind CSS.
 			</Card.Description>
 		</div>
-		<div
-			class="flex items-center space-x-1 rounded-md bg-secondary text-secondary-foreground"
-		>
+		<div class="flex items-center space-x-1 rounded-md bg-secondary text-secondary-foreground">
 			<Button variant="secondary" class="px-3 shadow-none">
 				<Star class="mr-2 h-4 w-4" />
 				Star
@@ -25,28 +22,16 @@
 			<Separator orientation="vertical" class="h-[20px]" />
 			<DropdownMenu.Root>
 				<DropdownMenu.Trigger asChild let:builder>
-					<Button
-						builders={[builder]}
-						variant="secondary"
-						class="px-2 shadow-none"
-					>
-						<ChevronDown
-							class="h-4 w-4 text-secondary-foreground"
-						/>
+					<Button builders={[builder]} variant="secondary" class="px-2 shadow-none">
+						<ChevronDown class="h-4 w-4 text-secondary-foreground" />
 					</Button>
 				</DropdownMenu.Trigger>
 				<DropdownMenu.Content class="w-[200px]" align="end">
 					<DropdownMenu.Label>Suggested Lists</DropdownMenu.Label>
 					<DropdownMenu.Separator />
-					<DropdownMenu.CheckboxItem checked>
-						Future Ideas
-					</DropdownMenu.CheckboxItem>
-					<DropdownMenu.CheckboxItem
-						>My Stack</DropdownMenu.CheckboxItem
-					>
-					<DropdownMenu.CheckboxItem
-						>Inspiration</DropdownMenu.CheckboxItem
-					>
+					<DropdownMenu.CheckboxItem checked>Future Ideas</DropdownMenu.CheckboxItem>
+					<DropdownMenu.CheckboxItem>My Stack</DropdownMenu.CheckboxItem>
+					<DropdownMenu.CheckboxItem>Inspiration</DropdownMenu.CheckboxItem>
 					<DropdownMenu.Separator />
 					<DropdownMenu.Item>
 						<Plus class="mr-2 h-4 w-4" /> Create List

--- a/apps/www/src/lib/registry/default/example/cards/notifications.svelte
+++ b/apps/www/src/lib/registry/default/example/cards/notifications.svelte
@@ -6,9 +6,7 @@
 <Card.Root>
 	<Card.Header>
 		<Card.Title>Notifications</Card.Title>
-		<Card.Description>
-			Choose what you want to be notified about.
-		</Card.Description>
+		<Card.Description>Choose what you want to be notified about.</Card.Description>
 	</Card.Header>
 	<Card.Content class="grid gap-1 p-1.5">
 		<div
@@ -17,20 +15,14 @@
 			<Bell class="h-5 w-5" />
 			<div class="space-y-1">
 				<p class="text-sm font-medium leading-none">Everything</p>
-				<p class="text-sm text-muted-foreground">
-					Email digest, mentions & all activity.
-				</p>
+				<p class="text-sm text-muted-foreground">Email digest, mentions & all activity.</p>
 			</div>
 		</div>
-		<div
-			class="flex items-center space-x-4 rounded-md bg-accent p-2 text-accent-foreground"
-		>
+		<div class="flex items-center space-x-4 rounded-md bg-accent p-2 text-accent-foreground">
 			<AtSign class="h-5 w-5" />
 			<div class="space-y-1">
 				<p class="text-sm font-medium leading-none">Available</p>
-				<p class="text-sm text-muted-foreground">
-					Only mentions and comments.
-				</p>
+				<p class="text-sm text-muted-foreground">Only mentions and comments.</p>
 			</div>
 		</div>
 		<div
@@ -39,9 +31,7 @@
 			<BellOff class="h-5 w-5" />
 			<div class="space-y-1">
 				<p class="text-sm font-medium leading-none">Ignoring</p>
-				<p class="text-sm text-muted-foreground">
-					Turn off all notifications.
-				</p>
+				<p class="text-sm text-muted-foreground">Turn off all notifications.</p>
 			</div>
 		</div>
 	</Card.Content>

--- a/apps/www/src/lib/registry/default/example/cards/payment-method.svelte
+++ b/apps/www/src/lib/registry/default/example/cards/payment-method.svelte
@@ -26,9 +26,7 @@
 <Card.Root>
 	<Card.Header>
 		<Card.Title>Payment Method</Card.Title>
-		<Card.Description>
-			Add a new payment method to your account.
-		</Card.Description>
+		<Card.Description>Add a new payment method to your account.</Card.Description>
 	</Card.Header>
 	<Card.Content class="grid gap-6">
 		<RadioGroup.Root value="card" class="grid grid-cols-3 gap-4">
@@ -36,12 +34,7 @@
 				for="card"
 				class="flex flex-col items-center justify-between rounded-md border-2 border-muted bg-transparent p-4 hover:bg-accent hover:text-accent-foreground [&:has([data-state=checked])]:border-primary"
 			>
-				<RadioGroup.Item
-					value="card"
-					id="card"
-					class="sr-only"
-					aria-label="Card"
-				/>
+				<RadioGroup.Item value="card" id="card" class="sr-only" aria-label="Card" />
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
 					viewBox="0 0 24 24"
@@ -61,12 +54,7 @@
 				for="paypal"
 				class="flex flex-col items-center justify-between rounded-md border-2 border-muted bg-transparent p-4 hover:bg-accent hover:text-accent-foreground [&:has([data-state=checked])]:border-primary"
 			>
-				<RadioGroup.Item
-					value="paypal"
-					id="paypal"
-					class="sr-only"
-					aria-label="Paypal"
-				/>
+				<RadioGroup.Item value="paypal" id="paypal" class="sr-only" aria-label="Paypal" />
 				<Icons.paypal class="mb-3 h-6 w-6" />
 				Paypal
 			</Label>
@@ -74,12 +62,7 @@
 				for="apple"
 				class="flex flex-col items-center justify-between rounded-md border-2 border-muted bg-transparent p-4 hover:bg-accent hover:text-accent-foreground [&:has([data-state=checked])]:border-primary"
 			>
-				<RadioGroup.Item
-					value="apple"
-					id="apple"
-					class="sr-only"
-					aria-label="Apple"
-				/>
+				<RadioGroup.Item value="apple" id="apple" class="sr-only" aria-label="Apple" />
 				<Icons.apple class="mb-3 h-6 w-6" />
 				Apple
 			</Label>
@@ -105,9 +88,7 @@
 					</Select.Trigger>
 					<Select.Content>
 						{#each months as month, i}
-							<Select.Item value={i + 1} label={month}
-								>{month}</Select.Item
-							>
+							<Select.Item value={i + 1} label={month}>{month}</Select.Item>
 						{/each}
 					</Select.Content>
 				</Select.Root>

--- a/apps/www/src/lib/registry/default/example/cards/report-issue.svelte
+++ b/apps/www/src/lib/registry/default/example/cards/report-issue.svelte
@@ -52,9 +52,7 @@
 <Card.Root>
 	<Card.Header>
 		<Card.Title>Report an issue</Card.Title>
-		<Card.Description
-			>What area are you having problems with?</Card.Description
-		>
+		<Card.Description>What area are you having problems with?</Card.Description>
 	</Card.Header>
 	<Card.Content class="grid gap-6">
 		<div class="grid grid-cols-2 gap-4">

--- a/apps/www/src/lib/registry/default/example/cards/share.svelte
+++ b/apps/www/src/lib/registry/default/example/cards/share.svelte
@@ -42,9 +42,7 @@
 <Card.Root>
 	<Card.Header>
 		<Card.Title>Share this document</Card.Title>
-		<Card.Description>
-			Anyone with the link can view this document.
-		</Card.Description>
+		<Card.Description>Anyone with the link can view this document.</Card.Description>
 	</Card.Header>
 	<Card.Content>
 		<div class="flex space-x-2">
@@ -61,9 +59,7 @@
 						<div class="flex items-center space-x-4">
 							<Avatar.Root>
 								<Avatar.Image src={person.avatar} />
-								<Avatar.Fallback
-									>{name[0][0] + name[1][0]}</Avatar.Fallback
-								>
+								<Avatar.Fallback>{name[0][0] + name[1][0]}</Avatar.Fallback>
 							</Avatar.Root>
 							<div>
 								<p class="text-sm font-medium leading-none">
@@ -80,9 +76,7 @@
 							</Select.Trigger>
 							<Select.Content>
 								{#each permissions as permission}
-									<Select.Item
-										value={permission.value}
-										label={permission.label}
+									<Select.Item value={permission.value} label={permission.label}
 										>{permission.label}</Select.Item
 									>
 								{/each}

--- a/apps/www/src/lib/registry/default/example/cards/stats.svelte
+++ b/apps/www/src/lib/registry/default/example/cards/stats.svelte
@@ -5,9 +5,7 @@
 
 <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-2">
 	<Card.Root>
-		<Card.Header
-			class="flex flex-row items-center justify-between space-y-0 pb-2"
-		>
+		<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-2">
 			<Card.Title class="text-base font-normal">Total Revenue</Card.Title>
 		</Card.Header>
 		<Card.Content>
@@ -19,9 +17,7 @@
 		</Card.Content>
 	</Card.Root>
 	<Card.Root>
-		<Card.Header
-			class="flex flex-row items-center justify-between space-y-0 pb-2"
-		>
+		<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-2">
 			<Card.Title class="text-base font-normal">Subscriptions</Card.Title>
 		</Card.Header>
 		<Card.Content>

--- a/apps/www/src/lib/registry/default/example/cards/team-members.svelte
+++ b/apps/www/src/lib/registry/default/example/cards/team-members.svelte
@@ -11,9 +11,7 @@
 <Card.Root>
 	<Card.Header>
 		<Card.Title>Team Members</Card.Title>
-		<Card.Description>
-			Invite your team members to collaborate.
-		</Card.Description>
+		<Card.Description>Invite your team members to collaborate.</Card.Description>
 	</Card.Header>
 	<Card.Content class="grid gap-6">
 		<div class="flex items-center justify-between space-x-4">
@@ -31,9 +29,7 @@
 				<Popover.Trigger asChild>
 					<Button variant="outline" size="sm" class="ml-auto">
 						Owner{" "}
-						<ChevronDownIcon
-							class="ml-2 h-4 w-4 text-muted-foreground"
-						/>
+						<ChevronDownIcon class="ml-2 h-4 w-4 text-muted-foreground" />
 					</Button>
 				</Popover.Trigger>
 				<Popover.Content class="p-0" align="end">
@@ -95,9 +91,7 @@
 				<Popover.Trigger asChild>
 					<Button variant="outline" size="sm" class="ml-auto">
 						Member{" "}
-						<ChevronDownIcon
-							class="ml-2 h-4 w-4 text-muted-foreground"
-						/>
+						<ChevronDownIcon class="ml-2 h-4 w-4 text-muted-foreground" />
 					</Button>
 				</Popover.Trigger>
 				<Popover.Content class="p-0" align="end">
@@ -151,9 +145,7 @@
 					<Avatar.Fallback>IN</Avatar.Fallback>
 				</Avatar.Root>
 				<div>
-					<p class="text-sm font-medium leading-none">
-						Isabella Nguyen
-					</p>
+					<p class="text-sm font-medium leading-none">Isabella Nguyen</p>
 					<p class="text-sm text-muted-foreground">i@example.com</p>
 				</div>
 			</div>
@@ -161,9 +153,7 @@
 				<Popover.Trigger asChild>
 					<Button variant="outline" size="sm" class="ml-auto">
 						Member{" "}
-						<ChevronDownIcon
-							class="ml-2 h-4 w-4 text-muted-foreground"
-						/>
+						<ChevronDownIcon class="ml-2 h-4 w-4 text-muted-foreground" />
 					</Button>
 				</Popover.Trigger>
 				<Popover.Content class="p-0" align="end">

--- a/apps/www/src/lib/registry/default/example/checkbox-form-single.svelte
+++ b/apps/www/src/lib/registry/default/example/checkbox-form-single.svelte
@@ -22,17 +22,13 @@
 	class="space-y-6"
 >
 	<Form.Field {config} name="mobile">
-		<Form.Item
-			class="flex flex-row items-start space-x-3 space-y-0 rounded-md border p-4"
-		>
+		<Form.Item class="flex flex-row items-start space-x-3 space-y-0 rounded-md border p-4">
 			<Form.Checkbox />
 			<div class="space-y-1 leading-none">
-				<Form.Label
-					>Use different settings for my mobile devices</Form.Label
-				>
+				<Form.Label>Use different settings for my mobile devices</Form.Label>
 				<Form.Description>
-					You can manage your mobile notifications in the <a
-						href="/examples/forms">mobile settings</a
+					You can manage your mobile notifications in the <a href="/examples/forms"
+						>mobile settings</a
 					> page.
 				</Form.Description>
 			</div>

--- a/apps/www/src/lib/registry/default/example/collapsible-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/collapsible-demo.svelte
@@ -8,26 +8,15 @@
 	<div class="flex items-center justify-between space-x-4 px-4">
 		<h4 class="text-sm font-semibold">@huntabyte starred 3 repositories</h4>
 		<Collapsible.Trigger asChild let:builder>
-			<Button
-				builders={[builder]}
-				variant="ghost"
-				size="sm"
-				class="w-9 p-0"
-			>
+			<Button builders={[builder]} variant="ghost" size="sm" class="w-9 p-0">
 				<ChevronsUpDown class="h-4 w-4" />
 				<span class="sr-only">Toggle</span>
 			</Button>
 		</Collapsible.Trigger>
 	</div>
-	<div class="rounded-md border px-4 py-3 font-mono text-sm">
-		@huntabyte/bits-ui
-	</div>
+	<div class="rounded-md border px-4 py-3 font-mono text-sm">@huntabyte/bits-ui</div>
 	<Collapsible.Content class="space-y-2">
-		<div class="rounded-md border px-4 py-3 font-mono text-sm">
-			@melt-ui/melt-ui
-		</div>
-		<div class="rounded-md border px-4 py-3 font-mono text-sm">
-			@sveltejs/svelte
-		</div>
+		<div class="rounded-md border px-4 py-3 font-mono text-sm">@melt-ui/melt-ui</div>
+		<div class="rounded-md border px-4 py-3 font-mono text-sm">@sveltejs/svelte</div>
 	</Collapsible.Content>
 </Collapsible.Root>

--- a/apps/www/src/lib/registry/default/example/combobox-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/combobox-demo.svelte
@@ -32,9 +32,7 @@
 	let open = false;
 	let value = "";
 
-	$: selectedValue =
-		frameworks.find((f) => f.value === value)?.label ??
-		"Select a framework...";
+	$: selectedValue = frameworks.find((f) => f.value === value)?.label ?? "Select a framework...";
 
 	// We want to refocus the trigger button when the user selects
 	// an item from the list so users can continue navigating the

--- a/apps/www/src/lib/registry/default/example/combobox-dropdown-menu.svelte
+++ b/apps/www/src/lib/registry/default/example/combobox-dropdown-menu.svelte
@@ -33,21 +33,14 @@
 	class="flex w-full flex-col items-start justify-between rounded-md border px-4 py-3 sm:flex-row sm:items-center"
 >
 	<p class="text-sm font-medium leading-none">
-		<span
-			class="mr-2 rounded-lg bg-primary px-2 py-1 text-xs text-primary-foreground"
-		>
+		<span class="mr-2 rounded-lg bg-primary px-2 py-1 text-xs text-primary-foreground">
 			{selectedLabel}
 		</span>
 		<span class="text-muted-foreground">Create a new project</span>
 	</p>
 	<DropdownMenu.Root bind:open let:ids>
 		<DropdownMenu.Trigger asChild let:builder>
-			<Button
-				builders={[builder]}
-				variant="ghost"
-				size="sm"
-				aria-label="Open menu"
-			>
+			<Button builders={[builder]} variant="ghost" size="sm" aria-label="Open menu">
 				<MoreHorizontal />
 			</Button>
 		</DropdownMenu.Trigger>
@@ -70,10 +63,7 @@
 					</DropdownMenu.SubTrigger>
 					<DropdownMenu.SubContent class="p-0">
 						<Command.Root value={selectedLabel}>
-							<Command.Input
-								autofocus
-								placeholder="Filter label..."
-							/>
+							<Command.Input autofocus placeholder="Filter label..." />
 							<Command.List>
 								<Command.Empty>No label found.</Command.Empty>
 								<Command.Group>
@@ -82,9 +72,7 @@
 											value={label}
 											onSelect={(value) => {
 												selectedLabel = value;
-												closeAndFocusTrigger(
-													ids.trigger
-												);
+												closeAndFocusTrigger(ids.trigger);
 											}}
 										>
 											{label}

--- a/apps/www/src/lib/registry/default/example/combobox-form.svelte
+++ b/apps/www/src/lib/registry/default/example/combobox-form.svelte
@@ -16,12 +16,9 @@
 	type Language = (typeof languages)[number]["value"];
 
 	export const formSchema = z.object({
-		language: z.enum(
-			languages.map((f) => f.value) as [Language, ...Language[]],
-			{
-				errorMap: () => ({ message: "Please select a valid language." })
-			}
-		)
+		language: z.enum(languages.map((f) => f.value) as [Language, ...Language[]], {
+			errorMap: () => ({ message: "Please select a valid language." })
+		})
 	});
 
 	export type FormSchema = typeof formSchema;
@@ -77,20 +74,14 @@
 								!value && "text-muted-foreground"
 							)}
 						>
-							{languages.find((f) => f.value === value)?.label ??
-								"Select language"}
-							<ChevronsUpDown
-								class="ml-2 h-4 w-4 shrink-0 opacity-50"
-							/>
+							{languages.find((f) => f.value === value)?.label ?? "Select language"}
+							<ChevronsUpDown class="ml-2 h-4 w-4 shrink-0 opacity-50" />
 						</Button>
 					</Form.Control>
 				</Popover.Trigger>
 				<Popover.Content class="w-[200px] p-0">
 					<Command.Root>
-						<Command.Input
-							autofocus
-							placeholder="Search language..."
-						/>
+						<Command.Input autofocus placeholder="Search language..." />
 						<Command.Empty>No language found.</Command.Empty>
 						<Command.Group>
 							{#each languages as language}
@@ -104,8 +95,7 @@
 									<Check
 										class={cn(
 											"mr-2 h-4 w-4",
-											language.value !== value &&
-												"text-transparent"
+											language.value !== value && "text-transparent"
 										)}
 									/>
 									{language.label}

--- a/apps/www/src/lib/registry/default/example/combobox-popover.svelte
+++ b/apps/www/src/lib/registry/default/example/combobox-popover.svelte
@@ -1,11 +1,5 @@
 <script lang="ts">
-	import {
-		ArrowUpCircle,
-		CheckCircle2,
-		Circle,
-		HelpCircle,
-		XCircle
-	} from "lucide-svelte";
+	import { ArrowUpCircle, CheckCircle2, Circle, HelpCircle, XCircle } from "lucide-svelte";
 	import * as Command from "@/registry/default/ui/command";
 	import * as Popover from "@/registry/default/ui/popover";
 	import { Button } from "@/registry/default/ui/button";
@@ -73,10 +67,7 @@
 				class="w-[150px] justify-start"
 			>
 				{#if selectedStatus}
-					<svelte:component
-						this={selectedStatus.icon}
-						class="mr-2 h-4 w-4 shrink-0"
-					/>
+					<svelte:component this={selectedStatus.icon} class="mr-2 h-4 w-4 shrink-0" />
 					{selectedStatus.label}
 				{:else}
 					+ Set status
@@ -101,8 +92,7 @@
 									this={status.icon}
 									class={cn(
 										"mr-2 h-4 w-4",
-										status.value !==
-											selectedStatus?.value &&
+										status.value !== selectedStatus?.value &&
 											"text-foreground/40"
 									)}
 								/>

--- a/apps/www/src/lib/registry/default/example/command-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/command-demo.svelte
@@ -1,12 +1,5 @@
 <script lang="ts">
-	import {
-		Calculator,
-		Calendar,
-		CreditCard,
-		Settings,
-		Smile,
-		User
-	} from "lucide-svelte";
+	import { Calculator, Calendar, CreditCard, Settings, Smile, User } from "lucide-svelte";
 	import * as Command from "@/registry/default/ui/command";
 </script>
 

--- a/apps/www/src/lib/registry/default/example/command-dialog.svelte
+++ b/apps/www/src/lib/registry/default/example/command-dialog.svelte
@@ -1,12 +1,5 @@
 <script lang="ts">
-	import {
-		Calculator,
-		Calendar,
-		CreditCard,
-		Settings,
-		Smile,
-		User
-	} from "lucide-svelte";
+	import { Calculator, Calendar, CreditCard, Settings, Smile, User } from "lucide-svelte";
 	import * as Command from "@/registry/default/ui/command";
 	import { onMount } from "svelte";
 

--- a/apps/www/src/lib/registry/default/example/context-menu-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/context-menu-demo.svelte
@@ -51,12 +51,8 @@
 		<ContextMenu.RadioGroup bind:value>
 			<ContextMenu.Label inset>People</ContextMenu.Label>
 			<ContextMenu.Separator />
-			<ContextMenu.RadioItem value="pedro">
-				Pedro Duarte
-			</ContextMenu.RadioItem>
-			<ContextMenu.RadioItem value="colm">
-				Colm Tuite
-			</ContextMenu.RadioItem>
+			<ContextMenu.RadioItem value="pedro">Pedro Duarte</ContextMenu.RadioItem>
+			<ContextMenu.RadioItem value="colm">Colm Tuite</ContextMenu.RadioItem>
 		</ContextMenu.RadioGroup>
 	</ContextMenu.Content>
 </ContextMenu.Root>

--- a/apps/www/src/lib/registry/default/example/dark-mode-dropdown-menu.svelte
+++ b/apps/www/src/lib/registry/default/example/dark-mode-dropdown-menu.svelte
@@ -19,14 +19,8 @@
 		</Button>
 	</DropdownMenu.Trigger>
 	<DropdownMenu.Content align="end">
-		<DropdownMenu.Item on:click={() => setMode("light")}>
-			Light
-		</DropdownMenu.Item>
-		<DropdownMenu.Item on:click={() => setMode("dark")}>
-			Dark
-		</DropdownMenu.Item>
-		<DropdownMenu.Item on:click={() => resetMode()}>
-			System
-		</DropdownMenu.Item>
+		<DropdownMenu.Item on:click={() => setMode("light")}>Light</DropdownMenu.Item>
+		<DropdownMenu.Item on:click={() => setMode("dark")}>Dark</DropdownMenu.Item>
+		<DropdownMenu.Item on:click={() => resetMode()}>System</DropdownMenu.Item>
 	</DropdownMenu.Content>
 </DropdownMenu.Root>

--- a/apps/www/src/lib/registry/default/example/data-table-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/data-table-demo.svelte
@@ -1,10 +1,5 @@
 <script lang="ts">
-	import {
-		createTable,
-		Subscribe,
-		Render,
-		createRender
-	} from "svelte-headless-table";
+	import { createTable, Subscribe, Render, createRender } from "svelte-headless-table";
 	import {
 		addSortBy,
 		addPagination,
@@ -148,15 +143,8 @@
 		})
 	]);
 
-	const {
-		headerRows,
-		pageRows,
-		tableAttrs,
-		tableBodyAttrs,
-		flatColumns,
-		pluginStates,
-		rows
-	} = table.createViewModel(columns);
+	const { headerRows, pageRows, tableAttrs, tableBodyAttrs, flatColumns, pluginStates, rows } =
+		table.createViewModel(columns);
 
 	const { sortKeys } = pluginStates.sort;
 
@@ -193,9 +181,7 @@
 			<DropdownMenu.Content>
 				{#each flatColumns as col}
 					{#if hideableCols.includes(col.id)}
-						<DropdownMenu.CheckboxItem
-							bind:checked={hideForId[col.id]}
-						>
+						<DropdownMenu.CheckboxItem bind:checked={hideForId[col.id]}>
 							{col.header}
 						</DropdownMenu.CheckboxItem>
 					{/if}
@@ -218,24 +204,18 @@
 								>
 									<Table.Head
 										{...attrs}
-										class={cn(
-											"[&:has([role=checkbox])]:pl-3"
-										)}
+										class={cn("[&:has([role=checkbox])]:pl-3")}
 									>
 										{#if cell.id === "amount"}
 											<div class="text-right font-medium">
 												<Render of={cell.render()} />
 											</div>
 										{:else if cell.id === "email"}
-											<Button
-												variant="ghost"
-												on:click={props.sort.toggle}
-											>
+											<Button variant="ghost" on:click={props.sort.toggle}>
 												<Render of={cell.render()} />
 												<ArrowUpDown
 													class={cn(
-														$sortKeys[0]?.id ===
-															cell.id &&
+														$sortKeys[0]?.id === cell.id &&
 															"text-foreground",
 														"ml-2 h-4 w-4"
 													)}
@@ -260,10 +240,7 @@
 						>
 							{#each row.cells as cell (cell.id)}
 								<Subscribe attrs={cell.attrs()} let:attrs>
-									<Table.Cell
-										class="[&:has([role=checkbox])]:pl-3"
-										{...attrs}
-									>
+									<Table.Cell class="[&:has([role=checkbox])]:pl-3" {...attrs}>
 										{#if cell.id === "amount"}
 											<div class="text-right font-medium">
 												<Render of={cell.render()} />

--- a/apps/www/src/lib/registry/default/example/data-table/data-table-actions.svelte
+++ b/apps/www/src/lib/registry/default/example/data-table/data-table-actions.svelte
@@ -8,12 +8,7 @@
 
 <DropdownMenu.Root>
 	<DropdownMenu.Trigger asChild let:builder>
-		<Button
-			variant="ghost"
-			builders={[builder]}
-			size="icon"
-			class="relative w-8 h-8 p-0"
-		>
+		<Button variant="ghost" builders={[builder]} size="icon" class="relative w-8 h-8 p-0">
 			<span class="sr-only">Open menu</span>
 			<MoreHorizontal class="w-4 h-4" />
 		</Button>
@@ -21,9 +16,7 @@
 	<DropdownMenu.Content>
 		<DropdownMenu.Group>
 			<DropdownMenu.Label>Actions</DropdownMenu.Label>
-			<DropdownMenu.Item
-				on:click={() => navigator.clipboard.writeText(id)}
-			>
+			<DropdownMenu.Item on:click={() => navigator.clipboard.writeText(id)}>
 				Copy payment ID
 			</DropdownMenu.Item>
 		</DropdownMenu.Group>

--- a/apps/www/src/lib/registry/default/example/date-picker-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/date-picker-demo.svelte
@@ -1,10 +1,6 @@
 <script lang="ts">
 	import { Calendar as CalendarIcon } from "lucide-svelte";
-	import {
-		type DateValue,
-		DateFormatter,
-		getLocalTimeZone
-	} from "@internationalized/date";
+	import { type DateValue, DateFormatter, getLocalTimeZone } from "@internationalized/date";
 	import { cn } from "$lib/utils";
 	import { Button } from "@/registry/default/ui/button";
 	import { Calendar } from "@/registry/default/ui/calendar";
@@ -28,9 +24,7 @@
 			builders={[builder]}
 		>
 			<CalendarIcon class="mr-2 h-4 w-4" />
-			{value
-				? df.format(value.toDate(getLocalTimeZone()))
-				: "Pick a date"}
+			{value ? df.format(value.toDate(getLocalTimeZone())) : "Pick a date"}
 		</Button>
 	</Popover.Trigger>
 	<Popover.Content class="w-auto p-0">

--- a/apps/www/src/lib/registry/default/example/date-picker-form.svelte
+++ b/apps/www/src/lib/registry/default/example/date-picker-form.svelte
@@ -2,9 +2,7 @@
 	import { z } from "zod";
 
 	export const formSchema = z.object({
-		dob: z
-			.string()
-			.refine((v) => v, { message: "A date of birth is required." })
+		dob: z.string().refine((v) => v, { message: "A date of birth is required." })
 	});
 
 	export type FormSchema = typeof formSchema;
@@ -41,9 +39,7 @@
 		dateStyle: "long"
 	});
 
-	let value: DateValue | undefined = $formStore.dob
-		? parseDate($formStore.dob)
-		: undefined;
+	let value: DateValue | undefined = $formStore.dob ? parseDate($formStore.dob) : undefined;
 
 	let placeholder: DateValue = today(getLocalTimeZone());
 </script>
@@ -70,9 +66,7 @@
 							!value && "text-muted-foreground"
 						)}
 					>
-						{value
-							? df.format(value.toDate(getLocalTimeZone()))
-							: "Pick a date"}
+						{value ? df.format(value.toDate(getLocalTimeZone())) : "Pick a date"}
 						<CalendarIcon class="ml-auto h-4 w-4 opacity-50" />
 					</Popover.Trigger>
 				</Form.Control>
@@ -94,9 +88,7 @@
 					/>
 				</Popover.Content>
 			</Popover.Root>
-			<Form.Description>
-				Your date of birth is used to calculator your age
-			</Form.Description>
+			<Form.Description>Your date of birth is used to calculator your age</Form.Description>
 			<Form.Validation />
 		</Form.Item>
 	</Form.Field>

--- a/apps/www/src/lib/registry/default/example/date-picker-with-presets.svelte
+++ b/apps/www/src/lib/registry/default/example/date-picker-with-presets.svelte
@@ -37,9 +37,7 @@
 			builders={[builder]}
 		>
 			<CalendarIcon class="mr-2 h-4 w-4" />
-			{value
-				? df.format(value.toDate(getLocalTimeZone()))
-				: "Pick a date"}
+			{value ? df.format(value.toDate(getLocalTimeZone())) : "Pick a date"}
 		</Button>
 	</Popover.Trigger>
 	<Popover.Content class="flex w-auto flex-col space-y-2 p-2">

--- a/apps/www/src/lib/registry/default/example/dialog-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/dialog-demo.svelte
@@ -6,9 +6,7 @@
 </script>
 
 <Dialog.Root>
-	<Dialog.Trigger class={buttonVariants({ variant: "outline" })}>
-		Edit Profile
-	</Dialog.Trigger>
+	<Dialog.Trigger class={buttonVariants({ variant: "outline" })}>Edit Profile</Dialog.Trigger>
 	<Dialog.Content class="sm:max-w-[425px]">
 		<Dialog.Header>
 			<Dialog.Title>Edit profile</Dialog.Title>

--- a/apps/www/src/lib/registry/default/example/drawer-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/drawer-demo.svelte
@@ -77,9 +77,7 @@
 		<div class="mx-auto w-full max-w-sm">
 			<Drawer.Header>
 				<Drawer.Title>Move Goal</Drawer.Title>
-				<Drawer.Description
-					>Set your daily activity goal.</Drawer.Description
-				>
+				<Drawer.Description>Set your daily activity goal.</Drawer.Description>
 			</Drawer.Header>
 			<div class="p-4 pb-0">
 				<div class="flex items-center justify-center space-x-2">
@@ -97,9 +95,7 @@
 						<div class="text-7xl font-bold tracking-tighter">
 							{goal}
 						</div>
-						<div
-							class="text-[0.70rem] uppercase text-muted-foreground"
-						>
+						<div class="text-[0.70rem] uppercase text-muted-foreground">
 							Calories/day
 						</div>
 					</div>
@@ -116,20 +112,14 @@
 				</div>
 				<div class="mt-3 h-[120px]">
 					<VisXYContainer {data} height={60}>
-						<VisGroupedBar
-							{x}
-							{y}
-							color={"hsl(var(--primary) / 0.2)"}
-						/>
+						<VisGroupedBar {x} {y} color={"hsl(var(--primary) / 0.2)"} />
 					</VisXYContainer>
 				</div>
 			</div>
 			<Drawer.Footer>
 				<Button>Submit</Button>
 				<Drawer.Close asChild let:builder>
-					<Button builders={[builder]} variant="outline"
-						>Cancel</Button
-					>
+					<Button builders={[builder]} variant="outline">Cancel</Button>
 				</Drawer.Close>
 			</Drawer.Footer>
 		</div>

--- a/apps/www/src/lib/registry/default/example/drawer-dialog.svelte
+++ b/apps/www/src/lib/registry/default/example/drawer-dialog.svelte
@@ -19,8 +19,7 @@
 			<Dialog.Header>
 				<Dialog.Title>Edit profile</Dialog.Title>
 				<Dialog.Description>
-					Make changes to your profile here. Click save when you're
-					done.
+					Make changes to your profile here. Click save when you're done.
 				</Dialog.Description>
 			</Dialog.Header>
 			<form class="grid items-start gap-4">
@@ -45,8 +44,7 @@
 			<Drawer.Header class="text-left">
 				<Drawer.Title>Edit profile</Drawer.Title>
 				<Drawer.Description>
-					Make changes to your profile here. Click save when you're
-					done.
+					Make changes to your profile here. Click save when you're done.
 				</Drawer.Description>
 			</Drawer.Header>
 			<form class="grid items-start gap-4 px-4">
@@ -62,9 +60,7 @@
 			</form>
 			<Drawer.Footer class="pt-2">
 				<Drawer.Close asChild let:builder>
-					<Button variant="outline" builders={[builder]}
-						>Cancel</Button
-					>
+					<Button variant="outline" builders={[builder]}>Cancel</Button>
 				</Drawer.Close>
 			</Drawer.Footer>
 		</Drawer.Content>

--- a/apps/www/src/lib/registry/default/example/dropdown-menu-checkboxes.svelte
+++ b/apps/www/src/lib/registry/default/example/dropdown-menu-checkboxes.svelte
@@ -20,8 +20,6 @@
 		<DropdownMenu.CheckboxItem bind:checked={showActivityBar} disabled>
 			Activity Bar
 		</DropdownMenu.CheckboxItem>
-		<DropdownMenu.CheckboxItem bind:checked={showPanel}>
-			Panel
-		</DropdownMenu.CheckboxItem>
+		<DropdownMenu.CheckboxItem bind:checked={showPanel}>Panel</DropdownMenu.CheckboxItem>
 	</DropdownMenu.Content>
 </DropdownMenu.Root>

--- a/apps/www/src/lib/registry/default/example/dropdown-menu-radio-group.svelte
+++ b/apps/www/src/lib/registry/default/example/dropdown-menu-radio-group.svelte
@@ -14,9 +14,7 @@
 		<DropdownMenu.Separator />
 		<DropdownMenu.RadioGroup bind:value={position}>
 			<DropdownMenu.RadioItem value="top">Top</DropdownMenu.RadioItem>
-			<DropdownMenu.RadioItem value="bottom"
-				>Bottom</DropdownMenu.RadioItem
-			>
+			<DropdownMenu.RadioItem value="bottom">Bottom</DropdownMenu.RadioItem>
 			<DropdownMenu.RadioItem value="right">Right</DropdownMenu.RadioItem>
 		</DropdownMenu.RadioGroup>
 	</DropdownMenu.Content>

--- a/apps/www/src/lib/registry/default/example/form-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/form-demo.svelte
@@ -26,9 +26,7 @@
 		<Form.Item>
 			<Form.Label>Username</Form.Label>
 			<Form.Input />
-			<Form.Description
-				>This is your public display name.</Form.Description
-			>
+			<Form.Description>This is your public display name.</Form.Description>
 			<Form.Validation />
 		</Form.Item>
 	</Form.Field>

--- a/apps/www/src/lib/registry/default/example/hover-card-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/hover-card-demo.svelte
@@ -24,9 +24,7 @@
 				<p class="text-sm">Cybernetically enhanced web apps.</p>
 				<div class="flex items-center pt-2">
 					<CalendarDays class="mr-2 h-4 w-4 opacity-70" />{" "}
-					<span class="text-xs text-muted-foreground">
-						Joined September 2022
-					</span>
+					<span class="text-xs text-muted-foreground"> Joined September 2022 </span>
 				</div>
 			</div>
 		</div>

--- a/apps/www/src/lib/registry/default/example/pagination-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/pagination-demo.svelte
@@ -25,10 +25,7 @@
 				</Pagination.Item>
 			{:else}
 				<Pagination.Item>
-					<Pagination.Link
-						{page}
-						isActive={currentPage == page.value}
-					>
+					<Pagination.Link {page} isActive={currentPage == page.value}>
 						{page.value}
 					</Pagination.Link>
 				</Pagination.Item>

--- a/apps/www/src/lib/registry/default/example/popover-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/popover-demo.svelte
@@ -13,9 +13,7 @@
 		<div class="grid gap-4">
 			<div class="space-y-2">
 				<h4 class="font-medium leading-none">Dimensions</h4>
-				<p class="text-sm text-muted-foreground">
-					Set the dimensions for the layer.
-				</p>
+				<p class="text-sm text-muted-foreground">Set the dimensions for the layer.</p>
 			</div>
 			<div class="grid gap-2">
 				<div class="grid grid-cols-3 items-center gap-4">

--- a/apps/www/src/lib/registry/default/example/radio-group-form.svelte
+++ b/apps/www/src/lib/registry/default/example/radio-group-form.svelte
@@ -33,14 +33,11 @@
 			<Form.RadioGroup class="flex flex-col space-y-1">
 				<Form.Item class="flex items-center space-x-3 space-y-0">
 					<Form.RadioItem value="all" id="all" />
-					<Label for="all" class="font-normal">All new messages</Label
-					>
+					<Label for="all" class="font-normal">All new messages</Label>
 				</Form.Item>
 				<Form.Item class="flex items-center space-x-3 space-y-0">
 					<Form.RadioItem value="mentions" id="mentions" />
-					<Label for="mentions" class="font-normal"
-						>Direct messages and mentions</Label
-					>
+					<Label for="mentions" class="font-normal">Direct messages and mentions</Label>
 				</Form.Item>
 				<Form.Item class="flex items-center space-x-3 space-y-0">
 					<Form.RadioItem value="none" id="none" />

--- a/apps/www/src/lib/registry/default/example/select-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/select-demo.svelte
@@ -18,9 +18,7 @@
 		<Select.Group>
 			<Select.Label>Fruits</Select.Label>
 			{#each fruits as fruit}
-				<Select.Item value={fruit.value} label={fruit.label}
-					>{fruit.label}</Select.Item
-				>
+				<Select.Item value={fruit.value} label={fruit.label}>{fruit.label}</Select.Item>
 			{/each}
 		</Select.Group>
 	</Select.Content>

--- a/apps/www/src/lib/registry/default/example/select-form.svelte
+++ b/apps/www/src/lib/registry/default/example/select-form.svelte
@@ -2,9 +2,7 @@
 	import { z } from "zod";
 
 	export const formSchema = z.object({
-		email: z
-			.string({ required_error: "Please select an email to display" })
-			.email()
+		email: z.string({ required_error: "Please select an email to display" }).email()
 	});
 
 	export type FormSchema = typeof formSchema;
@@ -29,25 +27,15 @@
 		<Form.Item>
 			<Form.Label>Email</Form.Label>
 			<Form.Select>
-				<Form.SelectTrigger
-					placeholder="Select a verified email to display"
-				/>
+				<Form.SelectTrigger placeholder="Select a verified email to display" />
 				<Form.SelectContent>
-					<Form.SelectItem value="m@example.com"
-						>m@example.com</Form.SelectItem
-					>
-					<Form.SelectItem value="m@google.com"
-						>m@google.com</Form.SelectItem
-					>
-					<Form.SelectItem value="m@support.com"
-						>m@support.com</Form.SelectItem
-					>
+					<Form.SelectItem value="m@example.com">m@example.com</Form.SelectItem>
+					<Form.SelectItem value="m@google.com">m@google.com</Form.SelectItem>
+					<Form.SelectItem value="m@support.com">m@support.com</Form.SelectItem>
 				</Form.SelectContent>
 			</Form.Select>
 			<Form.Description>
-				You can manage email address in your <a href="/examples/forms"
-					>email settings</a
-				>.
+				You can manage email address in your <a href="/examples/forms">email settings</a>.
 			</Form.Description>
 			<Form.Validation />
 		</Form.Item>

--- a/apps/www/src/lib/registry/default/example/separator-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/separator-demo.svelte
@@ -5,9 +5,7 @@
 <div>
 	<div class="space-y-1">
 		<h4 class="text-sm font-medium leading-none">Radix Primitives</h4>
-		<p class="text-sm text-muted-foreground">
-			An open-source UI component library.
-		</p>
+		<p class="text-sm text-muted-foreground">An open-source UI component library.</p>
 	</div>
 	<Separator class="my-4" />
 	<div class="flex h-5 items-center space-x-4 text-sm">

--- a/apps/www/src/lib/registry/default/example/sheet-side.svelte
+++ b/apps/www/src/lib/registry/default/example/sheet-side.svelte
@@ -17,34 +17,22 @@
 				<Sheet.Header>
 					<Sheet.Title>Edit profile</Sheet.Title>
 					<Sheet.Description>
-						Make changes to your profile here. Click save when
-						you're done.
+						Make changes to your profile here. Click save when you're done.
 					</Sheet.Description>
 				</Sheet.Header>
 				<div class="grid gap-4 py-4">
 					<div class="grid grid-cols-4 items-center gap-4">
 						<Label for="name" class="text-right">Name</Label>
-						<Input
-							id="name"
-							value="Pedro Duarte"
-							class="col-span-3"
-						/>
+						<Input id="name" value="Pedro Duarte" class="col-span-3" />
 					</div>
 					<div class="grid grid-cols-4 items-center gap-4">
-						<Label for="username" class="text-right">Username</Label
-						>
-						<Input
-							id="username"
-							value="@peduarte"
-							class="col-span-3"
-						/>
+						<Label for="username" class="text-right">Username</Label>
+						<Input id="username" value="@peduarte" class="col-span-3" />
 					</div>
 				</div>
 				<Sheet.Footer>
 					<Sheet.Close asChild let:builder>
-						<Button builders={[builder]} type="submit"
-							>Save changes</Button
-						>
+						<Button builders={[builder]} type="submit">Save changes</Button>
 					</Sheet.Close>
 				</Sheet.Footer>
 			</Sheet.Content>

--- a/apps/www/src/lib/registry/default/example/switch-form.svelte
+++ b/apps/www/src/lib/registry/default/example/switch-form.svelte
@@ -26,23 +26,18 @@
 		<legend class="mb-4 text-lg font-medium"> Email Notifications </legend>
 		<div class="space-y-4">
 			<Form.Field {config} name="marketing_emails">
-				<Form.Item
-					class="flex flex-row items-center justify-between rounded-lg border p-4"
-				>
+				<Form.Item class="flex flex-row items-center justify-between rounded-lg border p-4">
 					<div class="space-y-0.5">
 						<Form.Label>Marketing emails</Form.Label>
 						<Form.Description>
-							Receive emails about new products, features, and
-							more.
+							Receive emails about new products, features, and more.
 						</Form.Description>
 					</div>
 					<Form.Switch />
 				</Form.Item>
 			</Form.Field>
 			<Form.Field {config} name="security_emails">
-				<Form.Item
-					class="flex flex-row items-center justify-between rounded-lg border p-4"
-				>
+				<Form.Item class="flex flex-row items-center justify-between rounded-lg border p-4">
 					<div class="space-y-0.5">
 						<Form.Label>Security emails</Form.Label>
 						<Form.Description>

--- a/apps/www/src/lib/registry/default/example/table-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/table-demo.svelte
@@ -63,8 +63,7 @@
 				<Table.Cell class="font-medium">{invoice.invoice}</Table.Cell>
 				<Table.Cell>{invoice.paymentStatus}</Table.Cell>
 				<Table.Cell>{invoice.paymentMethod}</Table.Cell>
-				<Table.Cell class="text-right">{invoice.totalAmount}</Table.Cell
-				>
+				<Table.Cell class="text-right">{invoice.totalAmount}</Table.Cell>
 			</Table.Row>
 		{/each}
 	</Table.Body>

--- a/apps/www/src/lib/registry/default/example/tabs-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/tabs-demo.svelte
@@ -16,8 +16,7 @@
 			<Card.Header>
 				<Card.Title>Account</Card.Title>
 				<Card.Description>
-					Make changes to your account here. Click save when you're
-					done.
+					Make changes to your account here. Click save when you're done.
 				</Card.Description>
 			</Card.Header>
 			<Card.Content class="space-y-2">
@@ -40,8 +39,7 @@
 			<Card.Header>
 				<Card.Title>Password</Card.Title>
 				<Card.Description>
-					Change your password here. After saving, you'll be logged
-					out.
+					Change your password here. After saving, you'll be logged out.
 				</Card.Description>
 			</Card.Header>
 			<Card.Content class="space-y-2">

--- a/apps/www/src/lib/registry/default/example/textarea-form.svelte
+++ b/apps/www/src/lib/registry/default/example/textarea-form.svelte
@@ -28,10 +28,7 @@
 	<Form.Field {config} name="bio">
 		<Form.Item>
 			<Form.Label>Bio</Form.Label>
-			<Form.Textarea
-				placeholder="Tell us a little bit about yourself"
-				class="resize-none"
-			/>
+			<Form.Textarea placeholder="Tell us a little bit about yourself" class="resize-none" />
 			<Form.Description>
 				You can <span>@mention</span> other users and organizations.
 			</Form.Description>

--- a/apps/www/src/lib/registry/default/example/textarea-with-text.svelte
+++ b/apps/www/src/lib/registry/default/example/textarea-with-text.svelte
@@ -6,7 +6,5 @@
 <div class="grid w-full gap-1.5">
 	<Label for="message-2">Your Message</Label>
 	<Textarea placeholder="Type your message here." id="message-2" />
-	<p class="text-sm text-muted-foreground">
-		Your message will be copied to the support team.
-	</p>
+	<p class="text-sm text-muted-foreground">Your message will be copied to the support team.</p>
 </div>

--- a/apps/www/src/lib/registry/default/example/typography-blockquote.svelte
+++ b/apps/www/src/lib/registry/default/example/typography-blockquote.svelte
@@ -1,4 +1,4 @@
 <blockquote class="mt-6 border-l-2 pl-6 italic">
-	"After all," he said, "everyone enjoys a good joke, so it's only fair that
-	they should pay for the privilege."
+	"After all," he said, "everyone enjoys a good joke, so it's only fair that they should pay for
+	the privilege."
 </blockquote>

--- a/apps/www/src/lib/registry/default/example/typography-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/typography-demo.svelte
@@ -3,9 +3,9 @@
 		The Joke Tax Chronicles
 	</h1>
 	<p class="leading-7 [&:not(:first-child)]:mt-6">
-		Once upon a time, in a far-off land, there was a very lazy king who
-		spent all day lounging on his throne. One day, his advisors came to him
-		with a problem: the kingdom was running out of money.
+		Once upon a time, in a far-off land, there was a very lazy king who spent all day lounging
+		on his throne. One day, his advisors came to him with a problem: the kingdom was running out
+		of money.
 	</p>
 	<h2
 		class="mt-10 scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight transition-colors first:mt-0"
@@ -15,24 +15,18 @@
 	<p class="leading-7 [&:not(:first-child)]:mt-6">
 		The king thought long and hard, and finally came up with{" "}
 		<!-- svelte-ignore a11y-invalid-attribute -->
-		<a
-			href="#"
-			class="font-medium text-primary underline underline-offset-4"
-		>
+		<a href="#" class="font-medium text-primary underline underline-offset-4">
 			a brilliant plan
 		</a>
 		: he would tax the jokes in the kingdom.
 	</p>
 	<blockquote class="mt-6 border-l-2 pl-6 italic">
-		"After all," he said, "everyone enjoys a good joke, so it's only fair
-		that they should pay for the privilege."
+		"After all," he said, "everyone enjoys a good joke, so it's only fair that they should pay
+		for the privilege."
 	</blockquote>
-	<h3 class="mt-8 scroll-m-20 text-2xl font-semibold tracking-tight">
-		The Joke Tax
-	</h3>
+	<h3 class="mt-8 scroll-m-20 text-2xl font-semibold tracking-tight">The Joke Tax</h3>
 	<p class="leading-7 [&:not(:first-child)]:mt-6">
-		The king's subjects were not amused. They grumbled and complained, but
-		the king was firm:
+		The king's subjects were not amused. They grumbled and complained, but the king was firm:
 	</p>
 	<ul class="my-6 ml-6 list-disc [&>li]:mt-2">
 		<li>1st level of puns: 5 gold coins</li>
@@ -40,31 +34,25 @@
 		<li>3rd level of one-liners : 20 gold coins</li>
 	</ul>
 	<p class="leading-7 [&:not(:first-child)]:mt-6">
-		As a result, people stopped telling jokes, and the kingdom fell into a
-		gloom. But there was one person who refused to let the king's
-		foolishness get him down: a court jester named Jokester.
+		As a result, people stopped telling jokes, and the kingdom fell into a gloom. But there was
+		one person who refused to let the king's foolishness get him down: a court jester named
+		Jokester.
 	</p>
-	<h3 class="mt-8 scroll-m-20 text-2xl font-semibold tracking-tight">
-		Jokester's Revolt
-	</h3>
+	<h3 class="mt-8 scroll-m-20 text-2xl font-semibold tracking-tight">Jokester's Revolt</h3>
 	<p class="leading-7 [&:not(:first-child)]:mt-6">
-		Jokester began sneaking into the castle in the middle of the night and
-		leaving jokes all over the place: under the king's pillow, in his soup,
-		even in the royal toilet. The king was furious, but he couldn't seem to
-		stop Jokester.
+		Jokester began sneaking into the castle in the middle of the night and leaving jokes all
+		over the place: under the king's pillow, in his soup, even in the royal toilet. The king was
+		furious, but he couldn't seem to stop Jokester.
 	</p>
 	<p class="leading-7 [&:not(:first-child)]:mt-6">
-		And then, one day, the people of the kingdom discovered that the jokes
-		left by Jokester were so funny that they couldn't help but laugh. And
-		once they started laughing, they couldn't stop.
+		And then, one day, the people of the kingdom discovered that the jokes left by Jokester were
+		so funny that they couldn't help but laugh. And once they started laughing, they couldn't
+		stop.
 	</p>
-	<h3 class="mt-8 scroll-m-20 text-2xl font-semibold tracking-tight">
-		The People's Rebellion
-	</h3>
+	<h3 class="mt-8 scroll-m-20 text-2xl font-semibold tracking-tight">The People's Rebellion</h3>
 	<p class="leading-7 [&:not(:first-child)]:mt-6">
-		The people of the kingdom, feeling uplifted by the laughter, started to
-		tell jokes and puns again, and soon the entire kingdom was in on the
-		joke.
+		The people of the kingdom, feeling uplifted by the laughter, started to tell jokes and puns
+		again, and soon the entire kingdom was in on the joke.
 	</p>
 	<div class="my-6 w-full overflow-y-auto">
 		<table class="w-full">
@@ -123,12 +111,12 @@
 		</table>
 	</div>
 	<p class="leading-7 [&:not(:first-child)]:mt-6">
-		The king, seeing how much happier his subjects were, realized the error
-		of his ways and repealed the joke tax. Jokester was declared a hero, and
-		the kingdom lived happily ever after.
+		The king, seeing how much happier his subjects were, realized the error of his ways and
+		repealed the joke tax. Jokester was declared a hero, and the kingdom lived happily ever
+		after.
 	</p>
 	<p class="leading-7 [&:not(:first-child)]:mt-6">
-		The moral of the story is: never underestimate the power of a good laugh
-		and always be careful of bad ideas.
+		The moral of the story is: never underestimate the power of a good laugh and always be
+		careful of bad ideas.
 	</p>
 </div>

--- a/apps/www/src/lib/registry/default/example/typography-h4.svelte
+++ b/apps/www/src/lib/registry/default/example/typography-h4.svelte
@@ -1,3 +1,1 @@
-<h4 class="scroll-m-20 text-xl font-semibold tracking-tight">
-	People stopped telling jokes
-</h4>
+<h4 class="scroll-m-20 text-xl font-semibold tracking-tight">People stopped telling jokes</h4>

--- a/apps/www/src/lib/registry/default/example/typography-inline-code.svelte
+++ b/apps/www/src/lib/registry/default/example/typography-inline-code.svelte
@@ -1,5 +1,3 @@
-<code
-	class="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold"
->
+<code class="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold">
 	radix-svelte
 </code>

--- a/apps/www/src/lib/registry/default/example/typography-lead.svelte
+++ b/apps/www/src/lib/registry/default/example/typography-lead.svelte
@@ -1,4 +1,3 @@
 <p class="text-xl text-muted-foreground">
-	A modal dialog that interrupts the user with important content and expects a
-	response.
+	A modal dialog that interrupts the user with important content and expects a response.
 </p>

--- a/apps/www/src/lib/registry/default/example/typography-p.svelte
+++ b/apps/www/src/lib/registry/default/example/typography-p.svelte
@@ -1,4 +1,4 @@
 <p class="leading-7 [&:not(:first-child)]:mt-6">
-	The king, seeing how much happier his subjects were, realized the error of
-	his ways and repealed the joke tax.
+	The king, seeing how much happier his subjects were, realized the error of his ways and repealed
+	the joke tax.
 </p>

--- a/apps/www/src/lib/registry/default/ui/accordion/accordion-item.svelte
+++ b/apps/www/src/lib/registry/default/ui/accordion/accordion-item.svelte
@@ -9,10 +9,6 @@
 	export { className as class };
 </script>
 
-<AccordionPrimitive.Item
-	{value}
-	class={cn("border-b", className)}
-	{...$$restProps}
->
+<AccordionPrimitive.Item {value} class={cn("border-b", className)} {...$$restProps}>
 	<slot />
 </AccordionPrimitive.Item>

--- a/apps/www/src/lib/registry/default/ui/alert-dialog/alert-dialog-cancel.svelte
+++ b/apps/www/src/lib/registry/default/ui/alert-dialog/alert-dialog-cancel.svelte
@@ -11,11 +11,7 @@
 </script>
 
 <AlertDialogPrimitive.Cancel
-	class={cn(
-		buttonVariants({ variant: "outline" }),
-		"mt-2 sm:mt-0",
-		className
-	)}
+	class={cn(buttonVariants({ variant: "outline" }), "mt-2 sm:mt-0", className)}
 	{...$$restProps}
 	on:click
 	on:keydown

--- a/apps/www/src/lib/registry/default/ui/alert-dialog/alert-dialog-footer.svelte
+++ b/apps/www/src/lib/registry/default/ui/alert-dialog/alert-dialog-footer.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <div
-	class={cn(
-		"flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-		className
-	)}
+	class={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/default/ui/alert-dialog/alert-dialog-header.svelte
+++ b/apps/www/src/lib/registry/default/ui/alert-dialog/alert-dialog-header.svelte
@@ -8,9 +8,6 @@
 	export { className as class };
 </script>
 
-<div
-	class={cn("flex flex-col space-y-2 text-center sm:text-left", className)}
-	{...$$restProps}
->
+<div class={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...$$restProps}>
 	<slot />
 </div>

--- a/apps/www/src/lib/registry/default/ui/alert-dialog/alert-dialog-overlay.svelte
+++ b/apps/www/src/lib/registry/default/ui/alert-dialog/alert-dialog-overlay.svelte
@@ -16,9 +16,6 @@
 <AlertDialogPrimitive.Overlay
 	{transition}
 	{transitionConfig}
-	class={cn(
-		"fixed inset-0 z-50 bg-background/80 backdrop-blur-sm ",
-		className
-	)}
+	class={cn("fixed inset-0 z-50 bg-background/80 backdrop-blur-sm ", className)}
 	{...$$restProps}
 />

--- a/apps/www/src/lib/registry/default/ui/alert-dialog/alert-dialog-title.svelte
+++ b/apps/www/src/lib/registry/default/ui/alert-dialog/alert-dialog-title.svelte
@@ -9,10 +9,6 @@
 	export { className as class };
 </script>
 
-<AlertDialogPrimitive.Title
-	class={cn("text-lg font-semibold", className)}
-	{level}
-	{...$$restProps}
->
+<AlertDialogPrimitive.Title class={cn("text-lg font-semibold", className)} {level} {...$$restProps}>
 	<slot />
 </AlertDialogPrimitive.Title>

--- a/apps/www/src/lib/registry/default/ui/alert/alert.svelte
+++ b/apps/www/src/lib/registry/default/ui/alert/alert.svelte
@@ -12,10 +12,6 @@
 	export { className as class };
 </script>
 
-<div
-	class={cn(alertVariants({ variant }), className)}
-	{...$$restProps}
-	role="alert"
->
+<div class={cn(alertVariants({ variant }), className)} {...$$restProps} role="alert">
 	<slot />
 </div>

--- a/apps/www/src/lib/registry/default/ui/avatar/avatar-fallback.svelte
+++ b/apps/www/src/lib/registry/default/ui/avatar/avatar-fallback.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <AvatarPrimitive.Fallback
-	class={cn(
-		"flex h-full w-full items-center justify-center rounded-full bg-muted",
-		className
-	)}
+	class={cn("flex h-full w-full items-center justify-center rounded-full bg-muted", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/default/ui/avatar/avatar.svelte
+++ b/apps/www/src/lib/registry/default/ui/avatar/avatar.svelte
@@ -11,10 +11,7 @@
 
 <AvatarPrimitive.Root
 	{delayMs}
-	class={cn(
-		"relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
-		className
-	)}
+	class={cn("relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/default/ui/badge/index.ts
+++ b/apps/www/src/lib/registry/default/ui/badge/index.ts
@@ -5,8 +5,7 @@ export const badgeVariants = tv({
 	base: "inline-flex items-center border rounded-full px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none select-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
 	variants: {
 		variant: {
-			default:
-				"bg-primary hover:bg-primary/80 border-transparent text-primary-foreground",
+			default: "bg-primary hover:bg-primary/80 border-transparent text-primary-foreground",
 			secondary:
 				"bg-secondary hover:bg-secondary/80 border-transparent text-secondary-foreground",
 			destructive:

--- a/apps/www/src/lib/registry/default/ui/button/index.ts
+++ b/apps/www/src/lib/registry/default/ui/button/index.ts
@@ -7,12 +7,10 @@ const buttonVariants = tv({
 	variants: {
 		variant: {
 			default: "bg-primary text-primary-foreground hover:bg-primary/90",
-			destructive:
-				"bg-destructive text-destructive-foreground hover:bg-destructive/90",
+			destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
 			outline:
 				"border border-input bg-background hover:bg-accent hover:text-accent-foreground",
-			secondary:
-				"bg-secondary text-secondary-foreground hover:bg-secondary/80",
+			secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
 			ghost: "hover:bg-accent hover:text-accent-foreground",
 			link: "text-primary underline-offset-4 hover:underline"
 		},

--- a/apps/www/src/lib/registry/default/ui/calendar/calendar-grid.svelte
+++ b/apps/www/src/lib/registry/default/ui/calendar/calendar-grid.svelte
@@ -8,9 +8,6 @@
 	export { className as class };
 </script>
 
-<CalendarPrimitive.Grid
-	class={cn("w-full border-collapse space-y-1", className)}
-	{...$$restProps}
->
+<CalendarPrimitive.Grid class={cn("w-full border-collapse space-y-1", className)} {...$$restProps}>
 	<slot />
 </CalendarPrimitive.Grid>

--- a/apps/www/src/lib/registry/default/ui/calendar/calendar-head-cell.svelte
+++ b/apps/www/src/lib/registry/default/ui/calendar/calendar-head-cell.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <CalendarPrimitive.HeadCell
-	class={cn(
-		"text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
-		className
-	)}
+	class={cn("text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/default/ui/calendar/calendar-header.svelte
+++ b/apps/www/src/lib/registry/default/ui/calendar/calendar-header.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <CalendarPrimitive.Header
-	class={cn(
-		"flex justify-between pt-1 relative items-center w-full",
-		className
-	)}
+	class={cn("flex justify-between pt-1 relative items-center w-full", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/default/ui/calendar/calendar-months.svelte
+++ b/apps/www/src/lib/registry/default/ui/calendar/calendar-months.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <div
-	class={cn(
-		"flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0 mt-4",
-		className
-	)}
+	class={cn("flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0 mt-4", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/default/ui/card/card.svelte
+++ b/apps/www/src/lib/registry/default/ui/card/card.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <div
-	class={cn(
-		"rounded-lg border bg-card text-card-foreground shadow-sm",
-		className
-	)}
+	class={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/default/ui/command/command-empty.svelte
+++ b/apps/www/src/lib/registry/default/ui/command/command-empty.svelte
@@ -7,9 +7,6 @@
 	export { className as class };
 </script>
 
-<CommandPrimitive.Empty
-	class={cn("py-6 text-center text-sm", className)}
-	{...$$restProps}
->
+<CommandPrimitive.Empty class={cn("py-6 text-center text-sm", className)} {...$$restProps}>
 	<slot />
 </CommandPrimitive.Empty>

--- a/apps/www/src/lib/registry/default/ui/command/command-separator.svelte
+++ b/apps/www/src/lib/registry/default/ui/command/command-separator.svelte
@@ -7,7 +7,4 @@
 	export { className as class };
 </script>
 
-<CommandPrimitive.Separator
-	class={cn("-mx-1 h-px bg-border", className)}
-	{...$$restProps}
-/>
+<CommandPrimitive.Separator class={cn("-mx-1 h-px bg-border", className)} {...$$restProps} />

--- a/apps/www/src/lib/registry/default/ui/command/command-shortcut.svelte
+++ b/apps/www/src/lib/registry/default/ui/command/command-shortcut.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <span
-	class={cn(
-		"ml-auto text-xs tracking-widest text-muted-foreground",
-		className
-	)}
+	class={cn("ml-auto text-xs tracking-widest text-muted-foreground", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/default/ui/context-menu/context-menu-label.svelte
+++ b/apps/www/src/lib/registry/default/ui/context-menu/context-menu-label.svelte
@@ -12,11 +12,7 @@
 </script>
 
 <ContextMenuPrimitive.Label
-	class={cn(
-		"px-2 py-1.5 text-sm font-semibold text-foreground",
-		inset && "pl-8",
-		className
-	)}
+	class={cn("px-2 py-1.5 text-sm font-semibold text-foreground", inset && "pl-8", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/default/ui/context-menu/context-menu-shortcut.svelte
+++ b/apps/www/src/lib/registry/default/ui/context-menu/context-menu-shortcut.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <span
-	class={cn(
-		"ml-auto text-xs tracking-widest text-muted-foreground",
-		className
-	)}
+	class={cn("ml-auto text-xs tracking-widest text-muted-foreground", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/default/ui/dialog/dialog-footer.svelte
+++ b/apps/www/src/lib/registry/default/ui/dialog/dialog-footer.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <div
-	class={cn(
-		"flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-		className
-	)}
+	class={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/default/ui/dialog/dialog-header.svelte
+++ b/apps/www/src/lib/registry/default/ui/dialog/dialog-header.svelte
@@ -8,9 +8,6 @@
 	export { className as class };
 </script>
 
-<div
-	class={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)}
-	{...$$restProps}
->
+<div class={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...$$restProps}>
 	<slot />
 </div>

--- a/apps/www/src/lib/registry/default/ui/dialog/dialog-overlay.svelte
+++ b/apps/www/src/lib/registry/default/ui/dialog/dialog-overlay.svelte
@@ -16,9 +16,6 @@
 <DialogPrimitive.Overlay
 	{transition}
 	{transitionConfig}
-	class={cn(
-		"fixed inset-0 z-50 bg-background/80 backdrop-blur-sm",
-		className
-	)}
+	class={cn("fixed inset-0 z-50 bg-background/80 backdrop-blur-sm", className)}
 	{...$$restProps}
 />

--- a/apps/www/src/lib/registry/default/ui/drawer/drawer-footer.svelte
+++ b/apps/www/src/lib/registry/default/ui/drawer/drawer-footer.svelte
@@ -11,10 +11,6 @@
 	export { className as class };
 </script>
 
-<div
-	bind:this={el}
-	class={cn("mt-auto flex flex-col gap-2 p-4", className)}
-	{...$$restProps}
->
+<div bind:this={el} class={cn("mt-auto flex flex-col gap-2 p-4", className)} {...$$restProps}>
 	<slot />
 </div>

--- a/apps/www/src/lib/registry/default/ui/drawer/drawer.svelte
+++ b/apps/www/src/lib/registry/default/ui/drawer/drawer.svelte
@@ -7,11 +7,6 @@
 	export let activeSnapPoint: $$Props["activeSnapPoint"] = undefined;
 </script>
 
-<DrawerPrimitive.Root
-	{shouldScaleBackground}
-	bind:open
-	bind:activeSnapPoint
-	{...$$restProps}
->
+<DrawerPrimitive.Root {shouldScaleBackground} bind:open bind:activeSnapPoint {...$$restProps}>
 	<slot />
 </DrawerPrimitive.Root>

--- a/apps/www/src/lib/registry/default/ui/dropdown-menu/dropdown-menu-shortcut.svelte
+++ b/apps/www/src/lib/registry/default/ui/dropdown-menu/dropdown-menu-shortcut.svelte
@@ -8,9 +8,6 @@
 	export { className as class };
 </script>
 
-<span
-	class={cn("ml-auto text-xs tracking-widest opacity-60", className)}
-	{...$$restProps}
->
+<span class={cn("ml-auto text-xs tracking-widest opacity-60", className)} {...$$restProps}>
 	<slot />
 </span>

--- a/apps/www/src/lib/registry/default/ui/form/form-description.svelte
+++ b/apps/www/src/lib/registry/default/ui/form/form-description.svelte
@@ -8,9 +8,6 @@
 	export { className as class };
 </script>
 
-<FormPrimitive.Description
-	class={cn("text-sm text-muted-foreground", className)}
-	{...$$restProps}
->
+<FormPrimitive.Description class={cn("text-sm text-muted-foreground", className)} {...$$restProps}>
 	<slot />
 </FormPrimitive.Description>

--- a/apps/www/src/lib/registry/default/ui/form/form-label.svelte
+++ b/apps/www/src/lib/registry/default/ui/form/form-label.svelte
@@ -12,10 +12,6 @@
 	const { errors, ids } = getFormField();
 </script>
 
-<Label
-	for={$ids.input}
-	class={cn($errors && "text-destructive", className)}
-	{...$$restProps}
->
+<Label for={$ids.input} class={cn($errors && "text-destructive", className)} {...$$restProps}>
 	<slot />
 </Label>

--- a/apps/www/src/lib/registry/default/ui/form/form-select-trigger.svelte
+++ b/apps/www/src/lib/registry/default/ui/form/form-select-trigger.svelte
@@ -7,17 +7,12 @@
 		placeholder?: string;
 	};
 	type $$Events = SelectPrimitive.TriggerEvents;
-	const { attrStore } = getFormField();
+	const { attrStore, value } = getFormField();
 	export let placeholder = "";
 </script>
 
-<Select.Trigger
-	{...$$restProps}
-	{...$attrStore}
-	on:click
-	on:keydown
-	type="button"
->
-	<Select.Value {placeholder} />
-	<slot />
+<Select.Trigger {...$$restProps} {...$attrStore} on:click on:keydown type="button">
+	<slot value={$value}>
+		<Select.Value {placeholder} />
+	</slot>
 </Select.Trigger>

--- a/apps/www/src/lib/registry/default/ui/form/form-textarea.svelte
+++ b/apps/www/src/lib/registry/default/ui/form/form-textarea.svelte
@@ -2,10 +2,7 @@
 	import { getFormField } from "formsnap";
 	import type { HTMLTextareaAttributes } from "svelte/elements";
 	import type { TextareaGetFormField } from ".";
-	import {
-		Textarea,
-		type TextareaEvents
-	} from "@/registry/default/ui/textarea";
+	import { Textarea, type TextareaEvents } from "@/registry/default/ui/textarea";
 
 	type $$Props = HTMLTextareaAttributes;
 	type $$Events = TextareaEvents;

--- a/apps/www/src/lib/registry/default/ui/form/index.ts
+++ b/apps/www/src/lib/registry/default/ui/form/index.ts
@@ -27,10 +27,7 @@ const SelectGroup = SelectComp.Group;
 const SelectItem = SelectComp.Item;
 const SelectSeparator = SelectComp.Separator;
 
-export type TextareaGetFormField = Omit<
-	ReturnType<typeof getFormField>,
-	"value"
-> & {
+export type TextareaGetFormField = Omit<ReturnType<typeof getFormField>, "value"> & {
 	value: Writable<string>;
 };
 

--- a/apps/www/src/lib/registry/default/ui/menubar/menubar-separator.svelte
+++ b/apps/www/src/lib/registry/default/ui/menubar/menubar-separator.svelte
@@ -8,7 +8,4 @@
 	export { className as class };
 </script>
 
-<MenubarPrimitive.Separator
-	class={cn("-mx-1 my-1 h-px bg-muted", className)}
-	{...$$restProps}
-/>
+<MenubarPrimitive.Separator class={cn("-mx-1 my-1 h-px bg-muted", className)} {...$$restProps} />

--- a/apps/www/src/lib/registry/default/ui/menubar/menubar-shortcut.svelte
+++ b/apps/www/src/lib/registry/default/ui/menubar/menubar-shortcut.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <span
-	class={cn(
-		"ml-auto text-xs tracking-widest text-muted-foreground",
-		className
-	)}
+	class={cn("ml-auto text-xs tracking-widest text-muted-foreground", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/default/ui/menubar/menubar.svelte
+++ b/apps/www/src/lib/registry/default/ui/menubar/menubar.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <MenubarPrimitive.Root
-	class={cn(
-		"flex h-10 items-center space-x-1 rounded-md border bg-background p-1",
-		className
-	)}
+	class={cn("flex h-10 items-center space-x-1 rounded-md border bg-background p-1", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/default/ui/pagination/pagination.svelte
+++ b/apps/www/src/lib/registry/default/ui/pagination/pagination.svelte
@@ -28,10 +28,7 @@
 	asChild
 	{...$$restProps}
 >
-	<nav
-		{...builder}
-		class={cn("mx-auto flex flex-col w-full items-center", className)}
-	>
+	<nav {...builder} class={cn("mx-auto flex flex-col w-full items-center", className)}>
 		<slot {pages} {range} {currentPage} />
 	</nav>
 </PaginationPrimitive.Root>

--- a/apps/www/src/lib/registry/default/ui/progress/progress.svelte
+++ b/apps/www/src/lib/registry/default/ui/progress/progress.svelte
@@ -11,16 +11,11 @@
 </script>
 
 <ProgressPrimitive.Root
-	class={cn(
-		"relative h-4 w-full overflow-hidden rounded-full bg-secondary",
-		className
-	)}
+	class={cn("relative h-4 w-full overflow-hidden rounded-full bg-secondary", className)}
 	{...$$restProps}
 >
 	<div
 		class="h-full w-full flex-1 bg-primary transition-all"
-		style={`transform: translateX(-${
-			100 - (100 * (value ?? 0)) / (max ?? 1)
-		}%)`}
+		style={`transform: translateX(-${100 - (100 * (value ?? 0)) / (max ?? 1)}%)`}
 	/>
 </ProgressPrimitive.Root>

--- a/apps/www/src/lib/registry/default/ui/radio-group/radio-group.svelte
+++ b/apps/www/src/lib/registry/default/ui/radio-group/radio-group.svelte
@@ -9,10 +9,6 @@
 	export { className as class };
 </script>
 
-<RadioGroupPrimitive.Root
-	bind:value
-	class={cn("grid gap-2", className)}
-	{...$$restProps}
->
+<RadioGroupPrimitive.Root bind:value class={cn("grid gap-2", className)} {...$$restProps}>
 	<slot />
 </RadioGroupPrimitive.Root>

--- a/apps/www/src/lib/registry/default/ui/range-calendar/range-calendar-head-cell.svelte
+++ b/apps/www/src/lib/registry/default/ui/range-calendar/range-calendar-head-cell.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <RangeCalendarPrimitive.HeadCell
-	class={cn(
-		"text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
-		className
-	)}
+	class={cn("text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/default/ui/range-calendar/range-calendar-header.svelte
+++ b/apps/www/src/lib/registry/default/ui/range-calendar/range-calendar-header.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <RangeCalendarPrimitive.Header
-	class={cn(
-		"flex justify-between pt-1 relative items-center w-full",
-		className
-	)}
+	class={cn("flex justify-between pt-1 relative items-center w-full", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/default/ui/range-calendar/range-calendar-months.svelte
+++ b/apps/www/src/lib/registry/default/ui/range-calendar/range-calendar-months.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <div
-	class={cn(
-		"flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0 mt-4",
-		className
-	)}
+	class={cn("flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0 mt-4", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/default/ui/range-calendar/range-calendar.svelte
+++ b/apps/www/src/lib/registry/default/ui/range-calendar/range-calendar.svelte
@@ -48,10 +48,7 @@
 						<RangeCalendar.GridRow class="w-full mt-2">
 							{#each weekDates as date}
 								<RangeCalendar.Cell {date}>
-									<RangeCalendar.Day
-										{date}
-										month={month.value}
-									/>
+									<RangeCalendar.Day {date} month={month.value} />
 								</RangeCalendar.Cell>
 							{/each}
 						</RangeCalendar.GridRow>

--- a/apps/www/src/lib/registry/default/ui/select/select-separator.svelte
+++ b/apps/www/src/lib/registry/default/ui/select/select-separator.svelte
@@ -8,7 +8,4 @@
 	export { className as class };
 </script>
 
-<SelectPrimitive.Separator
-	class={cn("-mx-1 my-1 h-px bg-muted", className)}
-	{...$$restProps}
-/>
+<SelectPrimitive.Separator class={cn("-mx-1 my-1 h-px bg-muted", className)} {...$$restProps} />

--- a/apps/www/src/lib/registry/default/ui/sheet/sheet-content.svelte
+++ b/apps/www/src/lib/registry/default/ui/sheet/sheet-content.svelte
@@ -1,12 +1,6 @@
 <script lang="ts">
 	import { Dialog as SheetPrimitive } from "bits-ui";
-	import {
-		SheetOverlay,
-		SheetPortal,
-		sheetTransitions,
-		sheetVariants,
-		type Side
-	} from ".";
+	import { SheetOverlay, SheetPortal, sheetTransitions, sheetVariants, type Side } from ".";
 	import { X } from "lucide-svelte";
 	import { cn } from "$lib/utils";
 	import { fly } from "svelte/transition";

--- a/apps/www/src/lib/registry/default/ui/sheet/sheet-description.svelte
+++ b/apps/www/src/lib/registry/default/ui/sheet/sheet-description.svelte
@@ -8,9 +8,6 @@
 	export { className as class };
 </script>
 
-<SheetPrimitive.Description
-	class={cn("text-sm text-muted-foreground", className)}
-	{...$$restProps}
->
+<SheetPrimitive.Description class={cn("text-sm text-muted-foreground", className)} {...$$restProps}>
 	<slot />
 </SheetPrimitive.Description>

--- a/apps/www/src/lib/registry/default/ui/sheet/sheet-footer.svelte
+++ b/apps/www/src/lib/registry/default/ui/sheet/sheet-footer.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <div
-	class={cn(
-		"flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-		className
-	)}
+	class={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/default/ui/sheet/sheet-header.svelte
+++ b/apps/www/src/lib/registry/default/ui/sheet/sheet-header.svelte
@@ -8,9 +8,6 @@
 	export { className as class };
 </script>
 
-<div
-	class={cn("flex flex-col space-y-2 text-center sm:text-left", className)}
-	{...$$restProps}
->
+<div class={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...$$restProps}>
 	<slot />
 </div>

--- a/apps/www/src/lib/registry/default/ui/sheet/sheet-overlay.svelte
+++ b/apps/www/src/lib/registry/default/ui/sheet/sheet-overlay.svelte
@@ -16,9 +16,6 @@
 <SheetPrimitive.Overlay
 	{transition}
 	{transitionConfig}
-	class={cn(
-		"fixed inset-0 z-50 bg-background/80 backdrop-blur-sm ",
-		className
-	)}
+	class={cn("fixed inset-0 z-50 bg-background/80 backdrop-blur-sm ", className)}
 	{...$$restProps}
 />

--- a/apps/www/src/lib/registry/default/ui/skeleton/skeleton.svelte
+++ b/apps/www/src/lib/registry/default/ui/skeleton/skeleton.svelte
@@ -8,7 +8,4 @@
 	export { className as class };
 </script>
 
-<div
-	class={cn("animate-pulse rounded-md bg-muted", className)}
-	{...$$restProps}
-/>
+<div class={cn("animate-pulse rounded-md bg-muted", className)} {...$$restProps} />

--- a/apps/www/src/lib/registry/default/ui/slider/slider.svelte
+++ b/apps/www/src/lib/registry/default/ui/slider/slider.svelte
@@ -11,15 +11,10 @@
 
 <SliderPrimitive.Root
 	bind:value
-	class={cn(
-		"relative flex w-full touch-none select-none items-center",
-		className
-	)}
+	class={cn("relative flex w-full touch-none select-none items-center", className)}
 	{...$$restProps}
 >
-	<span
-		class="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary"
-	>
+	<span class="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
 		<SliderPrimitive.Range class="absolute h-full bg-primary" />
 	</span>
 	<SliderPrimitive.Thumb

--- a/apps/www/src/lib/registry/default/ui/sonner/sonner.svelte
+++ b/apps/www/src/lib/registry/default/ui/sonner/sonner.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-	import {
-		Toaster as Sonner,
-		type ToasterProps as SonnerProps
-	} from "svelte-sonner";
+	import { Toaster as Sonner, type ToasterProps as SonnerProps } from "svelte-sonner";
 	import { mode } from "mode-watcher";
 
 	type $$Props = SonnerProps;
@@ -15,10 +12,8 @@
 		classes: {
 			toast: "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
 			description: "group-[.toast]:text-muted-foreground",
-			actionButton:
-				"group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
-			cancelButton:
-				"group-[.toast]:bg-muted group-[.toast]:text-muted-foreground"
+			actionButton: "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+			cancelButton: "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground"
 		}
 	}}
 	{...$$restProps}

--- a/apps/www/src/lib/registry/default/ui/table/table-caption.svelte
+++ b/apps/www/src/lib/registry/default/ui/table/table-caption.svelte
@@ -8,9 +8,6 @@
 	export { className as class };
 </script>
 
-<caption
-	class={cn("mt-4 text-sm text-muted-foreground", className)}
-	{...$$restProps}
->
+<caption class={cn("mt-4 text-sm text-muted-foreground", className)} {...$$restProps}>
 	<slot />
 </caption>

--- a/apps/www/src/lib/registry/default/ui/table/table-footer.svelte
+++ b/apps/www/src/lib/registry/default/ui/table/table-footer.svelte
@@ -8,9 +8,6 @@
 	export { className as class };
 </script>
 
-<tfoot
-	class={cn("bg-primary font-medium text-primary-foreground", className)}
-	{...$$restProps}
->
+<tfoot class={cn("bg-primary font-medium text-primary-foreground", className)} {...$$restProps}>
 	<slot />
 </tfoot>

--- a/apps/www/src/lib/registry/default/ui/table/table-header.svelte
+++ b/apps/www/src/lib/registry/default/ui/table/table-header.svelte
@@ -9,11 +9,6 @@
 </script>
 
 <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
-<thead
-	class={cn("[&_tr]:border-b", className)}
-	{...$$restProps}
-	on:click
-	on:keydown
->
+<thead class={cn("[&_tr]:border-b", className)} {...$$restProps} on:click on:keydown>
 	<slot />
 </thead>

--- a/apps/www/src/lib/registry/default/ui/table/table.svelte
+++ b/apps/www/src/lib/registry/default/ui/table/table.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <div class="w-full overflow-auto">
-	<table
-		class={cn("w-full caption-bottom text-sm", className)}
-		{...$$restProps}
-	>
+	<table class={cn("w-full caption-bottom text-sm", className)} {...$$restProps}>
 		<slot />
 	</table>
 </div>

--- a/apps/www/src/lib/registry/default/ui/toggle-group/toggle-group.svelte
+++ b/apps/www/src/lib/registry/default/ui/toggle-group/toggle-group.svelte
@@ -6,8 +6,7 @@
 	import { cn } from "$lib/utils";
 
 	type T = $$Generic<"single" | "multiple">;
-	type $$Props = ToggleGroupPrimitive.Props<T> &
-		VariantProps<typeof toggleVariants>;
+	type $$Props = ToggleGroupPrimitive.Props<T> & VariantProps<typeof toggleVariants>;
 
 	let className: string | undefined | null = undefined;
 	export { className as class };

--- a/apps/www/src/lib/registry/new-york/example/accordion-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/accordion-demo.svelte
@@ -5,15 +5,12 @@
 <Accordion.Root class="w-full sm:max-w-[70%]">
 	<Accordion.Item value="item-1">
 		<Accordion.Trigger>Is it accessible?</Accordion.Trigger>
-		<Accordion.Content>
-			Yes. It adheres to the WAI-ARIA design pattern.
-		</Accordion.Content>
+		<Accordion.Content>Yes. It adheres to the WAI-ARIA design pattern.</Accordion.Content>
 	</Accordion.Item>
 	<Accordion.Item value="item-2">
 		<Accordion.Trigger>Is it styled?</Accordion.Trigger>
 		<Accordion.Content>
-			Yes. It comes with default styles that matches the other components'
-			aesthetic.
+			Yes. It comes with default styles that matches the other components' aesthetic.
 		</Accordion.Content>
 	</Accordion.Item>
 	<Accordion.Item value="item-3">

--- a/apps/www/src/lib/registry/new-york/example/alert-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/alert-demo.svelte
@@ -6,7 +6,5 @@
 <Alert.Root>
 	<Rocket class="h-4 w-4" />
 	<Alert.Title>Heads up!</Alert.Title>
-	<Alert.Description>
-		You can add components to your app using the cli.
-	</Alert.Description>
+	<Alert.Description>You can add components to your app using the cli.</Alert.Description>
 </Alert.Root>

--- a/apps/www/src/lib/registry/new-york/example/alert-destructive.svelte
+++ b/apps/www/src/lib/registry/new-york/example/alert-destructive.svelte
@@ -6,7 +6,5 @@
 <Alert.Root variant="destructive">
 	<ExclamationTriangle class="h-4 w-4" />
 	<Alert.Title>Error</Alert.Title>
-	<Alert.Description>
-		Your session has expired. Please login again.
-	</Alert.Description>
+	<Alert.Description>Your session has expired. Please login again.</Alert.Description>
 </Alert.Root>

--- a/apps/www/src/lib/registry/new-york/example/alert-dialog-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/alert-dialog-demo.svelte
@@ -11,8 +11,8 @@
 		<AlertDialog.Header>
 			<AlertDialog.Title>Are you absolutely sure?</AlertDialog.Title>
 			<AlertDialog.Description>
-				This action cannot be undone. This will permanently delete your
-				account and remove your data from our servers.
+				This action cannot be undone. This will permanently delete your account and remove
+				your data from our servers.
 			</AlertDialog.Description>
 		</AlertDialog.Header>
 		<AlertDialog.Footer>

--- a/apps/www/src/lib/registry/new-york/example/calendar-with-selects.svelte
+++ b/apps/www/src/lib/registry/new-york/example/calendar-with-selects.svelte
@@ -3,11 +3,7 @@
 	import * as Calendar from "@/registry/new-york/ui/calendar";
 	import * as Select from "@/registry/new-york/ui/select";
 	import { cn } from "$lib/utils";
-	import {
-		DateFormatter,
-		getLocalTimeZone,
-		today
-	} from "@internationalized/date";
+	import { DateFormatter, getLocalTimeZone, today } from "@internationalized/date";
 
 	type $$Props = CalendarPrimitive.Props;
 	type $$Events = CalendarPrimitive.Events;
@@ -69,9 +65,7 @@
 	let:weekdays
 >
 	<Calendar.Header>
-		<Calendar.Heading
-			class="flex items-center justify-between w-full gap-2"
-		>
+		<Calendar.Heading class="flex items-center justify-between w-full gap-2">
 			<Select.Root
 				selected={defaultMonth}
 				items={monthOptions}

--- a/apps/www/src/lib/registry/new-york/example/card-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/card-demo.svelte
@@ -29,23 +29,15 @@
 		<div class="flex items-center space-x-4 rounded-md border p-4">
 			<Bell />
 			<div class="flex-1 space-y-1">
-				<p class="text-sm font-medium leading-none">
-					Push Notifications
-				</p>
-				<p class="text-sm text-muted-foreground">
-					Send notifications to device.
-				</p>
+				<p class="text-sm font-medium leading-none">Push Notifications</p>
+				<p class="text-sm text-muted-foreground">Send notifications to device.</p>
 			</div>
 			<Switch />
 		</div>
 		<div>
 			{#each notifications as notification, idx (idx)}
-				<div
-					class="mb-4 grid grid-cols-[25px_1fr] items-start pb-4 last:mb-0 last:pb-0"
-				>
-					<span
-						class="flex h-2 w-2 translate-y-1 rounded-full bg-sky-500"
-					/>
+				<div class="mb-4 grid grid-cols-[25px_1fr] items-start pb-4 last:mb-0 last:pb-0">
+					<span class="flex h-2 w-2 translate-y-1 rounded-full bg-sky-500" />
 					<div class="space-y-1">
 						<p class="text-sm font-medium leading-none">
 							{notification.title}

--- a/apps/www/src/lib/registry/new-york/example/card-with-form.svelte
+++ b/apps/www/src/lib/registry/new-york/example/card-with-form.svelte
@@ -28,9 +28,7 @@
 <Card.Root class="w-[350px]">
 	<Card.Header>
 		<Card.Title>Create project</Card.Title>
-		<Card.Description
-			>Deploy your new project in one-click.</Card.Description
-		>
+		<Card.Description>Deploy your new project in one-click.</Card.Description>
 	</Card.Header>
 	<Card.Content>
 		<form>
@@ -47,9 +45,7 @@
 						</Select.Trigger>
 						<Select.Content>
 							{#each frameworks as framework}
-								<Select.Item
-									value={framework.value}
-									label={framework.label}
+								<Select.Item value={framework.value} label={framework.label}
 									>{framework.label}</Select.Item
 								>
 							{/each}

--- a/apps/www/src/lib/registry/new-york/example/cards/activity-goal.svelte
+++ b/apps/www/src/lib/registry/new-york/example/cards/activity-goal.svelte
@@ -29,9 +29,7 @@
 			</Button>
 			<div class="flex-1 text-center">
 				<div class="text-5xl font-bold tracking-tighter">{goal}</div>
-				<div class="text-[0.70rem] uppercase text-muted-foreground">
-					Calories/day
-				</div>
+				<div class="text-[0.70rem] uppercase text-muted-foreground">Calories/day</div>
 			</div>
 
 			<Button

--- a/apps/www/src/lib/registry/new-york/example/cards/all.svelte
+++ b/apps/www/src/lib/registry/new-york/example/cards/all.svelte
@@ -15,9 +15,7 @@
 	} from ".";
 </script>
 
-<div
-	class="md:grids-col-2 grid md:gap-4 lg:grid-cols-10 xl:grid-cols-11 xl:gap-4"
->
+<div class="md:grids-col-2 grid md:gap-4 lg:grid-cols-10 xl:grid-cols-11 xl:gap-4">
 	<div class="space-y-4 lg:col-span-4 xl:col-span-6 xl:space-y-4">
 		<CardsStats />
 		<div class="grid gap-1 sm:grid-cols-[260px_1fr] md:hidden">

--- a/apps/www/src/lib/registry/new-york/example/cards/chat.svelte
+++ b/apps/www/src/lib/registry/new-york/example/cards/chat.svelte
@@ -143,13 +143,10 @@
 		<Dialog.Header class="px-4 pb-4 pt-5">
 			<Dialog.Title>New message</Dialog.Title>
 			<Dialog.Description>
-				Invite a user to this thread. This will create a new group
-				message.
+				Invite a user to this thread. This will create a new group message.
 			</Dialog.Description>
 		</Dialog.Header>
-		<Command.Root
-			class="overflow-hidden rounded-t-none border-t bg-transparent"
-		>
+		<Command.Root class="overflow-hidden rounded-t-none border-t bg-transparent">
 			<Command.Input placeholder="Search user..." />
 			<Command.List>
 				<Command.Empty>No users found.</Command.Empty>
@@ -171,8 +168,7 @@
 						>
 							<Avatar.Root>
 								<Avatar.Image src={user.avatar} alt="Image" />
-								<Avatar.Fallback>{user.name[0]}</Avatar.Fallback
-								>
+								<Avatar.Fallback>{user.name[0]}</Avatar.Fallback>
 							</Avatar.Root>
 							<div class="ml-2">
 								<p class="text-sm font-medium leading-none">
@@ -183,38 +179,27 @@
 								</p>
 							</div>
 							{#if selectedUsers.includes(user)}
-								<Check
-									class="ml-auto flex h-5 w-5 text-primary"
-								/>
+								<Check class="ml-auto flex h-5 w-5 text-primary" />
 							{/if}
 						</Command.Item>
 					{/each}
 				</Command.Group>
 			</Command.List>
 		</Command.Root>
-		<Dialog.Footer
-			class="flex items-center border-t p-4 sm:justify-between"
-		>
+		<Dialog.Footer class="flex items-center border-t p-4 sm:justify-between">
 			{#if selectedUsers.length}
 				<div class="flex -space-x-2 overflow-hidden">
 					{#each selectedUsers as user}
-						<Avatar.Root
-							class="inline-block border-2 border-background"
-						>
+						<Avatar.Root class="inline-block border-2 border-background">
 							<Avatar.Image src={user.avatar} />
 							<Avatar.Fallback>{user.name[0]}</Avatar.Fallback>
 						</Avatar.Root>
 					{/each}
 				</div>
 			{:else}
-				<p class="text-sm text-muted-foreground">
-					Select users to add to this thread.
-				</p>
+				<p class="text-sm text-muted-foreground">Select users to add to this thread.</p>
 			{/if}
-			<Button
-				disabled={selectedUsers.length < 2}
-				on:click={() => (open = false)}
-			>
+			<Button disabled={selectedUsers.length < 2} on:click={() => (open = false)}>
 				Continue
 			</Button>
 		</Dialog.Footer>

--- a/apps/www/src/lib/registry/new-york/example/cards/cookie-settings.svelte
+++ b/apps/www/src/lib/registry/new-york/example/cards/cookie-settings.svelte
@@ -14,11 +14,8 @@
 		<div class="flex items-center justify-between space-x-4">
 			<Label for="necessary" class="flex flex-col space-y-1">
 				<span>Strictly Necessary</span>
-				<span
-					class="text-xs font-normal leading-snug text-muted-foreground"
-				>
-					These cookies are essential in order to use the website and
-					use its features.
+				<span class="text-xs font-normal leading-snug text-muted-foreground">
+					These cookies are essential in order to use the website and use its features.
 				</span>
 			</Label>
 			<Switch id="necessary" checked aria-label="Necessary" />
@@ -26,11 +23,8 @@
 		<div class="flex items-center justify-between space-x-4">
 			<Label for="functional" class="flex flex-col space-y-1">
 				<span>Functional Cookies</span>
-				<span
-					class="text-xs font-normal leading-snug text-muted-foreground"
-				>
-					These cookies allow the website to provide personalized
-					functionality.
+				<span class="text-xs font-normal leading-snug text-muted-foreground">
+					These cookies allow the website to provide personalized functionality.
 				</span>
 			</Label>
 			<Switch id="functional" aria-label="Functional" />
@@ -38,11 +32,8 @@
 		<div class="flex items-center justify-between space-x-4">
 			<Label for="performance" class="flex flex-col space-y-1">
 				<span>Performance Cookies</span>
-				<span
-					class="text-xs font-normal leading-snug text-muted-foreground"
-				>
-					These cookies help to improve the performance of the
-					website.
+				<span class="text-xs font-normal leading-snug text-muted-foreground">
+					These cookies help to improve the performance of the website.
 				</span>
 			</Label>
 			<Switch id="performance" aria-label="Performance" />

--- a/apps/www/src/lib/registry/new-york/example/cards/create-account.svelte
+++ b/apps/www/src/lib/registry/new-york/example/cards/create-account.svelte
@@ -9,9 +9,7 @@
 <Card.Root>
 	<Card.Header class="space-y-1">
 		<Card.Title class="text-2xl">Create an account</Card.Title>
-		<Card.Description>
-			Enter your email below to create your account
-		</Card.Description>
+		<Card.Description>Enter your email below to create your account</Card.Description>
 	</Card.Header>
 	<Card.Content class="grid gap-4">
 		<div class="grid grid-cols-2 gap-6">
@@ -29,9 +27,7 @@
 				<span class="w-full border-t" />
 			</div>
 			<div class="relative flex justify-center text-xs uppercase">
-				<span class="bg-card px-2 text-muted-foreground">
-					Or continue with
-				</span>
+				<span class="bg-card px-2 text-muted-foreground"> Or continue with </span>
 			</div>
 		</div>
 		<div class="grid gap-2">

--- a/apps/www/src/lib/registry/new-york/example/cards/data-table.svelte
+++ b/apps/www/src/lib/registry/new-york/example/cards/data-table.svelte
@@ -1,10 +1,5 @@
 <script lang="ts">
-	import {
-		createTable,
-		Subscribe,
-		Render,
-		createRender
-	} from "svelte-headless-table";
+	import { createTable, Subscribe, Render, createRender } from "svelte-headless-table";
 	import {
 		addSortBy,
 		addPagination,
@@ -142,15 +137,8 @@
 		})
 	]);
 
-	const {
-		headerRows,
-		pageRows,
-		tableAttrs,
-		tableBodyAttrs,
-		flatColumns,
-		pluginStates,
-		rows
-	} = table.createViewModel(columns);
+	const { headerRows, pageRows, tableAttrs, tableBodyAttrs, flatColumns, pluginStates, rows } =
+		table.createViewModel(columns);
 
 	const { sortKeys } = pluginStates.sort;
 
@@ -185,20 +173,14 @@
 			/>
 			<DropdownMenu.Root>
 				<DropdownMenu.Trigger asChild let:builder>
-					<Button
-						variant="outline"
-						class="ml-auto"
-						builders={[builder]}
-					>
+					<Button variant="outline" class="ml-auto" builders={[builder]}>
 						Columns <ChevronDown class="ml-2 h-4 w-4" />
 					</Button>
 				</DropdownMenu.Trigger>
 				<DropdownMenu.Content>
 					{#each flatColumns as col}
 						{#if hideableCols.includes(col.id)}
-							<DropdownMenu.CheckboxItem
-								bind:checked={hideForId[col.id]}
-							>
+							<DropdownMenu.CheckboxItem bind:checked={hideForId[col.id]}>
 								{col.header}
 							</DropdownMenu.CheckboxItem>
 						{/if}
@@ -221,17 +203,11 @@
 									>
 										<Table.Head
 											{...attrs}
-											class={cn(
-												"[&:has([role=checkbox])]:pl-3"
-											)}
+											class={cn("[&:has([role=checkbox])]:pl-3")}
 										>
 											{#if cell.id === "amount"}
-												<div
-													class="text-right font-medium"
-												>
-													<Render
-														of={cell.render()}
-													/>
+												<div class="text-right font-medium">
+													<Render of={cell.render()} />
 												</div>
 											{:else if cell.id === "email"}
 												<Button
@@ -239,13 +215,10 @@
 													variant="ghost"
 													on:click={props.sort.toggle}
 												>
-													<Render
-														of={cell.render()}
-													/>
+													<Render of={cell.render()} />
 													<ArrowUpDown
 														class={cn(
-															$sortKeys[0]?.id ===
-																cell.id &&
+															$sortKeys[0]?.id === cell.id &&
 																"text-foreground",
 															"ml-2 h-4 w-4"
 														)}
@@ -266,8 +239,7 @@
 						<Subscribe rowAttrs={row.attrs()} let:rowAttrs>
 							<Table.Row
 								{...rowAttrs}
-								data-state={$selectedDataIds[row.id] &&
-									"selected"}
+								data-state={$selectedDataIds[row.id] && "selected"}
 							>
 								{#each row.cells as cell (cell.id)}
 									<Subscribe attrs={cell.attrs()} let:attrs>
@@ -276,18 +248,12 @@
 											{...attrs}
 										>
 											{#if cell.id === "amount"}
-												<div
-													class="text-right font-medium"
-												>
-													<Render
-														of={cell.render()}
-													/>
+												<div class="text-right font-medium">
+													<Render of={cell.render()} />
 												</div>
 											{:else if cell.id === "status"}
 												<div class="capitalize">
-													<Render
-														of={cell.render()}
-													/>
+													<Render of={cell.render()} />
 												</div>
 											{:else}
 												<Render of={cell.render()} />

--- a/apps/www/src/lib/registry/new-york/example/cards/github.svelte
+++ b/apps/www/src/lib/registry/new-york/example/cards/github.svelte
@@ -15,13 +15,10 @@
 		<div class="space-y-1">
 			<Card.Title>shadcn/ui</Card.Title>
 			<Card.Description>
-				Beautifully designed components built with Radix UI and Tailwind
-				CSS.
+				Beautifully designed components built with Radix UI and Tailwind CSS.
 			</Card.Description>
 		</div>
-		<div
-			class="flex items-center space-x-1 rounded-md bg-secondary text-secondary-foreground"
-		>
+		<div class="flex items-center space-x-1 rounded-md bg-secondary text-secondary-foreground">
 			<Button variant="secondary" class="px-3 shadow-none">
 				<Star class="mr-2 h-4 w-4" />
 				Star
@@ -29,14 +26,8 @@
 			<Separator orientation="vertical" class="h-[20px]" />
 			<DropdownMenu.Root>
 				<DropdownMenu.Trigger asChild let:builder>
-					<Button
-						builders={[builder]}
-						variant="secondary"
-						class="px-2 shadow-none"
-					>
-						<ChevronDown
-							class="h-4 w-4 text-secondary-foreground"
-						/>
+					<Button builders={[builder]} variant="secondary" class="px-2 shadow-none">
+						<ChevronDown class="h-4 w-4 text-secondary-foreground" />
 					</Button>
 				</DropdownMenu.Trigger>
 				<DropdownMenu.Content class="w-[200px]" align="end">

--- a/apps/www/src/lib/registry/new-york/example/cards/notifications.svelte
+++ b/apps/www/src/lib/registry/new-york/example/cards/notifications.svelte
@@ -6,9 +6,7 @@
 <Card.Root>
 	<Card.Header>
 		<Card.Title>Notifications</Card.Title>
-		<Card.Description>
-			Choose what you want to be notified about.
-		</Card.Description>
+		<Card.Description>Choose what you want to be notified about.</Card.Description>
 	</Card.Header>
 	<Card.Content class="grid gap-1 p-1.5">
 		<div
@@ -17,20 +15,14 @@
 			<Bell class="h-5 w-5" />
 			<div class="space-y-1">
 				<p class="text-sm font-medium leading-none">Everything</p>
-				<p class="text-sm text-muted-foreground">
-					Email digest, mentions & all activity.
-				</p>
+				<p class="text-sm text-muted-foreground">Email digest, mentions & all activity.</p>
 			</div>
 		</div>
-		<div
-			class="flex items-center space-x-4 rounded-md bg-accent p-2 text-accent-foreground"
-		>
+		<div class="flex items-center space-x-4 rounded-md bg-accent p-2 text-accent-foreground">
 			<AtSign class="h-5 w-5" />
 			<div class="space-y-1">
 				<p class="text-sm font-medium leading-none">Available</p>
-				<p class="text-sm text-muted-foreground">
-					Only mentions and comments.
-				</p>
+				<p class="text-sm text-muted-foreground">Only mentions and comments.</p>
 			</div>
 		</div>
 		<div
@@ -39,9 +31,7 @@
 			<BellOff class="h-5 w-5" />
 			<div class="space-y-1">
 				<p class="text-sm font-medium leading-none">Ignoring</p>
-				<p class="text-sm text-muted-foreground">
-					Turn off all notifications.
-				</p>
+				<p class="text-sm text-muted-foreground">Turn off all notifications.</p>
 			</div>
 		</div>
 	</Card.Content>

--- a/apps/www/src/lib/registry/new-york/example/cards/payment-method.svelte
+++ b/apps/www/src/lib/registry/new-york/example/cards/payment-method.svelte
@@ -26,9 +26,7 @@
 <Card.Root>
 	<Card.Header>
 		<Card.Title>Payment Method</Card.Title>
-		<Card.Description>
-			Add a new payment method to your account.
-		</Card.Description>
+		<Card.Description>Add a new payment method to your account.</Card.Description>
 	</Card.Header>
 	<Card.Content class="grid gap-6">
 		<RadioGroup.Root value="card" class="grid grid-cols-3 gap-4">
@@ -36,12 +34,7 @@
 				for="card"
 				class="flex flex-col items-center justify-between rounded-md border-2 border-muted bg-transparent p-4 hover:bg-accent hover:text-accent-foreground [&:has([data-state=checked])]:border-primary"
 			>
-				<RadioGroup.Item
-					value="card"
-					id="card"
-					class="sr-only"
-					aria-label="Card"
-				/>
+				<RadioGroup.Item value="card" id="card" class="sr-only" aria-label="Card" />
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
 					viewBox="0 0 24 24"
@@ -61,12 +54,7 @@
 				for="paypal"
 				class="flex flex-col items-center justify-between rounded-md border-2 border-muted bg-transparent p-4 hover:bg-accent hover:text-accent-foreground [&:has([data-state=checked])]:border-primary"
 			>
-				<RadioGroup.Item
-					value="paypal"
-					id="paypal"
-					class="sr-only"
-					aria-label="Paypal"
-				/>
+				<RadioGroup.Item value="paypal" id="paypal" class="sr-only" aria-label="Paypal" />
 				<Icons.paypal class="mb-3 h-6 w-6" />
 				Paypal
 			</Label>
@@ -74,12 +62,7 @@
 				for="apple"
 				class="flex flex-col items-center justify-between rounded-md border-2 border-muted bg-transparent p-4 hover:bg-accent hover:text-accent-foreground [&:has([data-state=checked])]:border-primary"
 			>
-				<RadioGroup.Item
-					value="apple"
-					id="apple"
-					class="sr-only"
-					aria-label="Apple"
-				/>
+				<RadioGroup.Item value="apple" id="apple" class="sr-only" aria-label="Apple" />
 				<Icons.apple class="mb-3 h-6 w-6" />
 				Apple
 			</Label>
@@ -105,9 +88,7 @@
 					</Select.Trigger>
 					<Select.Content>
 						{#each months as month, i}
-							<Select.Item value={i + 1} label={month}
-								>{month}</Select.Item
-							>
+							<Select.Item value={i + 1} label={month}>{month}</Select.Item>
 						{/each}
 					</Select.Content>
 				</Select.Root>

--- a/apps/www/src/lib/registry/new-york/example/cards/report-issue.svelte
+++ b/apps/www/src/lib/registry/new-york/example/cards/report-issue.svelte
@@ -51,9 +51,7 @@
 <Card.Root>
 	<Card.Header>
 		<Card.Title>Report an issue</Card.Title>
-		<Card.Description
-			>What area are you having problems with?</Card.Description
-		>
+		<Card.Description>What area are you having problems with?</Card.Description>
 	</Card.Header>
 	<Card.Content class="grid gap-6">
 		<div class="grid grid-cols-2 gap-4">

--- a/apps/www/src/lib/registry/new-york/example/cards/share.svelte
+++ b/apps/www/src/lib/registry/new-york/example/cards/share.svelte
@@ -42,9 +42,7 @@
 <Card.Root>
 	<Card.Header>
 		<Card.Title>Share this document</Card.Title>
-		<Card.Description>
-			Anyone with the link can view this document.
-		</Card.Description>
+		<Card.Description>Anyone with the link can view this document.</Card.Description>
 	</Card.Header>
 	<Card.Content>
 		<div class="flex space-x-2">
@@ -61,8 +59,7 @@
 							<Avatar.Root>
 								<Avatar.Image src={person.avatar} />
 								{@const splitName = person.name.split(" ")}
-								<Avatar.Fallback
-									>{splitName[0][0]}{splitName[1][0]}</Avatar.Fallback
+								<Avatar.Fallback>{splitName[0][0]}{splitName[1][0]}</Avatar.Fallback
 								>
 							</Avatar.Root>
 							<div>
@@ -80,9 +77,7 @@
 							</Select.Trigger>
 							<Select.Content>
 								{#each permissions as permission}
-									<Select.Item
-										value={permission.value}
-										label={permission.label}
+									<Select.Item value={permission.value} label={permission.label}
 										>{permission.label}</Select.Item
 									>
 								{/each}

--- a/apps/www/src/lib/registry/new-york/example/cards/stats.svelte
+++ b/apps/www/src/lib/registry/new-york/example/cards/stats.svelte
@@ -5,9 +5,7 @@
 
 <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-2">
 	<Card.Root>
-		<Card.Header
-			class="flex flex-row items-center justify-between space-y-0 pb-2"
-		>
+		<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-2">
 			<Card.Title class="text-sm font-normal">Total Revenue</Card.Title>
 		</Card.Header>
 		<Card.Content>
@@ -19,9 +17,7 @@
 		</Card.Content>
 	</Card.Root>
 	<Card.Root>
-		<Card.Header
-			class="flex flex-row items-center justify-between space-y-0 pb-2"
-		>
+		<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-2">
 			<Card.Title class="text-sm font-normal">Subscriptions</Card.Title>
 		</Card.Header>
 		<Card.Content>

--- a/apps/www/src/lib/registry/new-york/example/cards/team-members.svelte
+++ b/apps/www/src/lib/registry/new-york/example/cards/team-members.svelte
@@ -11,9 +11,7 @@
 <Card.Root>
 	<Card.Header>
 		<Card.Title>Team Members</Card.Title>
-		<Card.Description>
-			Invite your team members to collaborate.
-		</Card.Description>
+		<Card.Description>Invite your team members to collaborate.</Card.Description>
 	</Card.Header>
 	<Card.Content class="grid gap-6">
 		<div class="flex items-center justify-between space-x-4">
@@ -31,9 +29,7 @@
 				<Popover.Trigger asChild>
 					<Button variant="outline" size="sm" class="ml-auto">
 						Owner{" "}
-						<ChevronDown
-							class="ml-2 h-4 w-4 text-muted-foreground"
-						/>
+						<ChevronDown class="ml-2 h-4 w-4 text-muted-foreground" />
 					</Button>
 				</Popover.Trigger>
 				<Popover.Content class="p-0" align="end">
@@ -95,9 +91,7 @@
 				<Popover.Trigger asChild>
 					<Button variant="outline" size="sm" class="ml-auto">
 						Member{" "}
-						<ChevronDown
-							class="ml-2 h-4 w-4 text-muted-foreground"
-						/>
+						<ChevronDown class="ml-2 h-4 w-4 text-muted-foreground" />
 					</Button>
 				</Popover.Trigger>
 				<Popover.Content class="p-0" align="end">
@@ -151,9 +145,7 @@
 					<Avatar.Fallback>IN</Avatar.Fallback>
 				</Avatar.Root>
 				<div>
-					<p class="text-sm font-medium leading-none">
-						Isabella Nguyen
-					</p>
+					<p class="text-sm font-medium leading-none">Isabella Nguyen</p>
 					<p class="text-sm text-muted-foreground">i@example.com</p>
 				</div>
 			</div>
@@ -161,9 +153,7 @@
 				<Popover.Trigger asChild>
 					<Button variant="outline" size="sm" class="ml-auto">
 						Member{" "}
-						<ChevronDown
-							class="ml-2 h-4 w-4 text-muted-foreground"
-						/>
+						<ChevronDown class="ml-2 h-4 w-4 text-muted-foreground" />
 					</Button>
 				</Popover.Trigger>
 				<Popover.Content class="p-0" align="end">

--- a/apps/www/src/lib/registry/new-york/example/checkbox-form-single.svelte
+++ b/apps/www/src/lib/registry/new-york/example/checkbox-form-single.svelte
@@ -27,12 +27,10 @@
 		>
 			<Form.Checkbox />
 			<div class="space-y-1 leading-none">
-				<Form.Label
-					>Use different settings for my mobile devices</Form.Label
-				>
+				<Form.Label>Use different settings for my mobile devices</Form.Label>
 				<Form.Description>
-					You can manage your mobile notifications in the <a
-						href="/examples/forms">mobile settings</a
+					You can manage your mobile notifications in the <a href="/examples/forms"
+						>mobile settings</a
 					> page.
 				</Form.Description>
 			</div>

--- a/apps/www/src/lib/registry/new-york/example/collapsible-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/collapsible-demo.svelte
@@ -8,26 +8,15 @@
 	<div class="flex items-center justify-between space-x-4 px-4">
 		<h4 class="text-sm font-semibold">@huntabyte starred 3 repositories</h4>
 		<Collapsible.Trigger asChild let:builder>
-			<Button
-				builders={[builder]}
-				variant="ghost"
-				size="sm"
-				class="w-9 p-0"
-			>
+			<Button builders={[builder]} variant="ghost" size="sm" class="w-9 p-0">
 				<CaretSort class="h-4 w-4" />
 				<span class="sr-only">Toggle</span>
 			</Button>
 		</Collapsible.Trigger>
 	</div>
-	<div class="rounded-md border px-4 py-3 font-mono text-sm">
-		@huntabyte/bits-ui
-	</div>
+	<div class="rounded-md border px-4 py-3 font-mono text-sm">@huntabyte/bits-ui</div>
 	<Collapsible.Content class="space-y-2">
-		<div class="rounded-md border px-4 py-3 font-mono text-sm">
-			@melt-ui/melt-ui
-		</div>
-		<div class="rounded-md border px-4 py-3 font-mono text-sm">
-			@sveltejs/svelte
-		</div>
+		<div class="rounded-md border px-4 py-3 font-mono text-sm">@melt-ui/melt-ui</div>
+		<div class="rounded-md border px-4 py-3 font-mono text-sm">@sveltejs/svelte</div>
 	</Collapsible.Content>
 </Collapsible.Root>

--- a/apps/www/src/lib/registry/new-york/example/combobox-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/combobox-demo.svelte
@@ -32,9 +32,7 @@
 	let open = false;
 	let value = "";
 
-	$: selectedValue =
-		frameworks.find((f) => f.value === value)?.label ??
-		"Select a framework...";
+	$: selectedValue = frameworks.find((f) => f.value === value)?.label ?? "Select a framework...";
 
 	// We want to refocus the trigger button when the user selects
 	// an item from the list so users can continue navigating the

--- a/apps/www/src/lib/registry/new-york/example/combobox-dropdown-menu.svelte
+++ b/apps/www/src/lib/registry/new-york/example/combobox-dropdown-menu.svelte
@@ -33,21 +33,14 @@
 	class="flex w-full flex-col items-start justify-between rounded-md border px-4 py-3 sm:flex-row sm:items-center"
 >
 	<p class="text-sm font-medium leading-none">
-		<span
-			class="mr-2 rounded-lg bg-primary px-2 py-1 text-xs text-primary-foreground"
-		>
+		<span class="mr-2 rounded-lg bg-primary px-2 py-1 text-xs text-primary-foreground">
 			{selectedLabel}
 		</span>
 		<span class="text-muted-foreground">Create a new project</span>
 	</p>
 	<DropdownMenu.Root bind:open let:ids>
 		<DropdownMenu.Trigger asChild let:builder>
-			<Button
-				builders={[builder]}
-				variant="ghost"
-				size="sm"
-				aria-label="Open menu"
-			>
+			<Button builders={[builder]} variant="ghost" size="sm" aria-label="Open menu">
 				<DotsHorizontal />
 			</Button>
 		</DropdownMenu.Trigger>
@@ -58,16 +51,10 @@
 				<DropdownMenu.Item>Set due date...</DropdownMenu.Item>
 				<DropdownMenu.Separator />
 				<DropdownMenu.Sub>
-					<DropdownMenu.SubTrigger>
-						Apply label
-					</DropdownMenu.SubTrigger>
+					<DropdownMenu.SubTrigger>Apply label</DropdownMenu.SubTrigger>
 					<DropdownMenu.SubContent class="p-0">
 						<Command.Root value={selectedLabel}>
-							<Command.Input
-								autofocus
-								placeholder="Filter label..."
-								class="h-9"
-							/>
+							<Command.Input autofocus placeholder="Filter label..." class="h-9" />
 							<Command.List>
 								<Command.Empty>No label found.</Command.Empty>
 								<Command.Group>
@@ -76,9 +63,7 @@
 											value={label}
 											onSelect={(value) => {
 												selectedLabel = value;
-												closeAndFocusTrigger(
-													ids.trigger
-												);
+												closeAndFocusTrigger(ids.trigger);
 											}}
 										>
 											{label}

--- a/apps/www/src/lib/registry/new-york/example/combobox-form.svelte
+++ b/apps/www/src/lib/registry/new-york/example/combobox-form.svelte
@@ -16,12 +16,9 @@
 	type Language = (typeof languages)[number]["value"];
 
 	export const formSchema = z.object({
-		language: z.enum(
-			languages.map((f) => f.value) as [Language, ...Language[]],
-			{
-				errorMap: () => ({ message: "Please select a valid language." })
-			}
-		)
+		language: z.enum(languages.map((f) => f.value) as [Language, ...Language[]], {
+			errorMap: () => ({ message: "Please select a valid language." })
+		})
 	});
 
 	export type FormSchema = typeof formSchema;
@@ -76,21 +73,14 @@
 								!value && "text-muted-foreground"
 							)}
 						>
-							{languages.find((f) => f.value === value)?.label ??
-								"Select language"}
-							<CaretSort
-								class="ml-2 h-4 w-4 shrink-0 opacity-50"
-							/>
+							{languages.find((f) => f.value === value)?.label ?? "Select language"}
+							<CaretSort class="ml-2 h-4 w-4 shrink-0 opacity-50" />
 						</Button>
 					</Form.Control>
 				</Popover.Trigger>
 				<Popover.Content class="w-[200px] p-0">
 					<Command.Root>
-						<Command.Input
-							autofocus
-							placeholder="Search language..."
-							class="h-9"
-						/>
+						<Command.Input autofocus placeholder="Search language..." class="h-9" />
 						<Command.Empty>No language found.</Command.Empty>
 						<Command.Group>
 							{#each languages as language}
@@ -105,8 +95,7 @@
 									<Check
 										class={cn(
 											"ml-auto h-4 w-4",
-											language.value !== value &&
-												"text-transparent"
+											language.value !== value && "text-transparent"
 										)}
 									/>
 								</Command.Item>

--- a/apps/www/src/lib/registry/new-york/example/combobox-popover.svelte
+++ b/apps/www/src/lib/registry/new-york/example/combobox-popover.svelte
@@ -52,11 +52,7 @@
 	<p class="text-sm text-muted-foreground">Status</p>
 	<Popover.Root bind:open let:ids>
 		<Popover.Trigger asChild let:builder>
-			<Button
-				builders={[builder]}
-				variant="outline"
-				class="w-[150px] justify-start"
-			>
+			<Button builders={[builder]} variant="outline" class="w-[150px] justify-start">
 				{selectedStatus ? selectedStatus.label : "+ Set status"}
 			</Button>
 		</Popover.Trigger>

--- a/apps/www/src/lib/registry/new-york/example/command-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/command-demo.svelte
@@ -1,12 +1,5 @@
 <script lang="ts">
-	import {
-		Calendar,
-		EnvelopeClosed,
-		Face,
-		Gear,
-		Person,
-		Rocket
-	} from "radix-icons-svelte";
+	import { Calendar, EnvelopeClosed, Face, Gear, Person, Rocket } from "radix-icons-svelte";
 	import * as Command from "@/registry/new-york/ui/command";
 </script>
 

--- a/apps/www/src/lib/registry/new-york/example/command-dialog.svelte
+++ b/apps/www/src/lib/registry/new-york/example/command-dialog.svelte
@@ -1,12 +1,5 @@
 <script lang="ts">
-	import {
-		Calendar,
-		EnvelopeClosed,
-		Face,
-		Gear,
-		Person,
-		Rocket
-	} from "radix-icons-svelte";
+	import { Calendar, EnvelopeClosed, Face, Gear, Person, Rocket } from "radix-icons-svelte";
 	import * as Command from "@/registry/new-york/ui/command";
 	import { onMount } from "svelte";
 	let open = false;

--- a/apps/www/src/lib/registry/new-york/example/context-menu-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/context-menu-demo.svelte
@@ -51,12 +51,8 @@
 		<ContextMenu.RadioGroup bind:value>
 			<ContextMenu.Label inset>People</ContextMenu.Label>
 			<ContextMenu.Separator />
-			<ContextMenu.RadioItem value="pedro">
-				Pedro Duarte
-			</ContextMenu.RadioItem>
-			<ContextMenu.RadioItem value="colm">
-				Colm Tuite
-			</ContextMenu.RadioItem>
+			<ContextMenu.RadioItem value="pedro">Pedro Duarte</ContextMenu.RadioItem>
+			<ContextMenu.RadioItem value="colm">Colm Tuite</ContextMenu.RadioItem>
 		</ContextMenu.RadioGroup>
 	</ContextMenu.Content>
 </ContextMenu.Root>

--- a/apps/www/src/lib/registry/new-york/example/dark-mode-dropdown-menu.svelte
+++ b/apps/www/src/lib/registry/new-york/example/dark-mode-dropdown-menu.svelte
@@ -19,14 +19,8 @@
 		</Button>
 	</DropdownMenu.Trigger>
 	<DropdownMenu.Content align="end">
-		<DropdownMenu.Item on:click={() => setMode("light")}>
-			Light
-		</DropdownMenu.Item>
-		<DropdownMenu.Item on:click={() => setMode("dark")}>
-			Dark
-		</DropdownMenu.Item>
-		<DropdownMenu.Item on:click={() => resetMode()}>
-			System
-		</DropdownMenu.Item>
+		<DropdownMenu.Item on:click={() => setMode("light")}>Light</DropdownMenu.Item>
+		<DropdownMenu.Item on:click={() => setMode("dark")}>Dark</DropdownMenu.Item>
+		<DropdownMenu.Item on:click={() => resetMode()}>System</DropdownMenu.Item>
 	</DropdownMenu.Content>
 </DropdownMenu.Root>

--- a/apps/www/src/lib/registry/new-york/example/data-table-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/data-table-demo.svelte
@@ -1,10 +1,5 @@
 <script lang="ts">
-	import {
-		createTable,
-		Subscribe,
-		Render,
-		createRender
-	} from "svelte-headless-table";
+	import { createTable, Subscribe, Render, createRender } from "svelte-headless-table";
 	import {
 		addSortBy,
 		addPagination,
@@ -148,15 +143,8 @@
 		})
 	]);
 
-	const {
-		headerRows,
-		pageRows,
-		tableAttrs,
-		tableBodyAttrs,
-		flatColumns,
-		pluginStates,
-		rows
-	} = table.createViewModel(columns);
+	const { headerRows, pageRows, tableAttrs, tableBodyAttrs, flatColumns, pluginStates, rows } =
+		table.createViewModel(columns);
 
 	const { sortKeys } = pluginStates.sort;
 
@@ -193,9 +181,7 @@
 			<DropdownMenu.Content>
 				{#each flatColumns as col}
 					{#if hideableCols.includes(col.id)}
-						<DropdownMenu.CheckboxItem
-							bind:checked={hideForId[col.id]}
-						>
+						<DropdownMenu.CheckboxItem bind:checked={hideForId[col.id]}>
 							{col.header}
 						</DropdownMenu.CheckboxItem>
 					{/if}
@@ -218,24 +204,18 @@
 								>
 									<Table.Head
 										{...attrs}
-										class={cn(
-											"[&:has([role=checkbox])]:pl-3"
-										)}
+										class={cn("[&:has([role=checkbox])]:pl-3")}
 									>
 										{#if cell.id === "amount"}
 											<div class="text-right">
 												<Render of={cell.render()} />
 											</div>
 										{:else if cell.id === "email"}
-											<Button
-												variant="ghost"
-												on:click={props.sort.toggle}
-											>
+											<Button variant="ghost" on:click={props.sort.toggle}>
 												<Render of={cell.render()} />
 												<CaretSort
 													class={cn(
-														$sortKeys[0]?.id ===
-															cell.id &&
+														$sortKeys[0]?.id === cell.id &&
 															"text-foreground",
 														"ml-2 h-4 w-4"
 													)}
@@ -260,10 +240,7 @@
 						>
 							{#each row.cells as cell (cell.id)}
 								<Subscribe attrs={cell.attrs()} let:attrs>
-									<Table.Cell
-										class="[&:has([role=checkbox])]:pl-3"
-										{...attrs}
-									>
+									<Table.Cell class="[&:has([role=checkbox])]:pl-3" {...attrs}>
 										{#if cell.id === "amount"}
 											<div class="text-right font-medium">
 												<Render of={cell.render()} />

--- a/apps/www/src/lib/registry/new-york/example/data-table/data-table-actions.svelte
+++ b/apps/www/src/lib/registry/new-york/example/data-table/data-table-actions.svelte
@@ -8,11 +8,7 @@
 
 <DropdownMenu.Root>
 	<DropdownMenu.Trigger asChild let:builder>
-		<Button
-			variant="ghost"
-			builders={[builder]}
-			class="relative w-8 h-8 p-0"
-		>
+		<Button variant="ghost" builders={[builder]} class="relative w-8 h-8 p-0">
 			<span class="sr-only">Open menu</span>
 			<DotsHorizontal class="w-4 h-4" />
 		</Button>
@@ -20,9 +16,7 @@
 	<DropdownMenu.Content>
 		<DropdownMenu.Group>
 			<DropdownMenu.Label>Actions</DropdownMenu.Label>
-			<DropdownMenu.Item
-				on:click={() => navigator.clipboard.writeText(id)}
-			>
+			<DropdownMenu.Item on:click={() => navigator.clipboard.writeText(id)}>
 				Copy payment ID
 			</DropdownMenu.Item>
 		</DropdownMenu.Group>

--- a/apps/www/src/lib/registry/new-york/example/date-picker-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/date-picker-demo.svelte
@@ -1,10 +1,6 @@
 <script lang="ts">
 	import { Calendar as CalendarIcon } from "radix-icons-svelte";
-	import {
-		type DateValue,
-		DateFormatter,
-		getLocalTimeZone
-	} from "@internationalized/date";
+	import { type DateValue, DateFormatter, getLocalTimeZone } from "@internationalized/date";
 	import { cn } from "$lib/utils";
 	import { Button } from "@/registry/new-york/ui/button";
 	import { Calendar } from "@/registry/new-york/ui/calendar";
@@ -28,9 +24,7 @@
 			builders={[builder]}
 		>
 			<CalendarIcon class="mr-2 h-4 w-4" />
-			{value
-				? df.format(value.toDate(getLocalTimeZone()))
-				: "Pick a date"}
+			{value ? df.format(value.toDate(getLocalTimeZone())) : "Pick a date"}
 		</Button>
 	</Popover.Trigger>
 	<Popover.Content class="w-auto p-0" align="start">

--- a/apps/www/src/lib/registry/new-york/example/date-picker-form.svelte
+++ b/apps/www/src/lib/registry/new-york/example/date-picker-form.svelte
@@ -2,9 +2,7 @@
 	import { z } from "zod";
 
 	export const formSchema = z.object({
-		dob: z
-			.string()
-			.refine((v) => v, { message: "A date of birth is required." })
+		dob: z.string().refine((v) => v, { message: "A date of birth is required." })
 	});
 
 	export type FormSchema = typeof formSchema;
@@ -41,9 +39,7 @@
 		dateStyle: "long"
 	});
 
-	let value: DateValue | undefined = $formStore.dob
-		? parseDate($formStore.dob)
-		: undefined;
+	let value: DateValue | undefined = $formStore.dob ? parseDate($formStore.dob) : undefined;
 
 	let placeholder: DateValue = today(getLocalTimeZone());
 </script>
@@ -70,9 +66,7 @@
 							!value && "text-muted-foreground"
 						)}
 					>
-						{value
-							? df.format(value.toDate(getLocalTimeZone()))
-							: "Pick a date"}
+						{value ? df.format(value.toDate(getLocalTimeZone())) : "Pick a date"}
 						<CalendarIcon class="ml-auto opacity-50 h-4 w-4" />
 					</Popover.Trigger>
 				</Form.Control>
@@ -94,9 +88,7 @@
 					/>
 				</Popover.Content>
 			</Popover.Root>
-			<Form.Description>
-				Your date of birth is used to calculator your age
-			</Form.Description>
+			<Form.Description>Your date of birth is used to calculator your age</Form.Description>
 			<Form.Validation />
 		</Form.Item>
 	</Form.Field>

--- a/apps/www/src/lib/registry/new-york/example/date-picker-with-presets.svelte
+++ b/apps/www/src/lib/registry/new-york/example/date-picker-with-presets.svelte
@@ -37,9 +37,7 @@
 			builders={[builder]}
 		>
 			<CalendarIcon class="mr-2 h-4 w-4" />
-			{value
-				? df.format(value.toDate(getLocalTimeZone()))
-				: "Pick a date"}
+			{value ? df.format(value.toDate(getLocalTimeZone())) : "Pick a date"}
 		</Button>
 	</Popover.Trigger>
 	<Popover.Content class="flex w-auto flex-col space-y-2 p-2">

--- a/apps/www/src/lib/registry/new-york/example/dialog-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/dialog-demo.svelte
@@ -6,9 +6,7 @@
 </script>
 
 <Dialog.Root>
-	<Dialog.Trigger class={buttonVariants({ variant: "outline" })}>
-		Edit Profile
-	</Dialog.Trigger>
+	<Dialog.Trigger class={buttonVariants({ variant: "outline" })}>Edit Profile</Dialog.Trigger>
 	<Dialog.Content class="sm:max-w-[425px]">
 		<Dialog.Header>
 			<Dialog.Title>Edit profile</Dialog.Title>

--- a/apps/www/src/lib/registry/new-york/example/drawer-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/drawer-demo.svelte
@@ -76,9 +76,7 @@
 		<div class="mx-auto w-full max-w-sm">
 			<Drawer.Header>
 				<Drawer.Title>Move Goal</Drawer.Title>
-				<Drawer.Description
-					>Set your daily activity goal.</Drawer.Description
-				>
+				<Drawer.Description>Set your daily activity goal.</Drawer.Description>
 			</Drawer.Header>
 			<div class="p-4 pb-0">
 				<div class="flex items-center justify-center space-x-2">
@@ -96,9 +94,7 @@
 						<div class="text-7xl font-bold tracking-tighter">
 							{goal}
 						</div>
-						<div
-							class="text-[0.70rem] uppercase text-muted-foreground"
-						>
+						<div class="text-[0.70rem] uppercase text-muted-foreground">
 							Calories/day
 						</div>
 					</div>
@@ -114,20 +110,14 @@
 				</div>
 				<div class="mt-3 h-[120px]">
 					<VisXYContainer {data} height={60}>
-						<VisGroupedBar
-							{x}
-							{y}
-							color={"hsl(var(--primary) / 0.2)"}
-						/>
+						<VisGroupedBar {x} {y} color={"hsl(var(--primary) / 0.2)"} />
 					</VisXYContainer>
 				</div>
 			</div>
 			<Drawer.Footer>
 				<Button>Submit</Button>
 				<Drawer.Close asChild let:builder>
-					<Button builders={[builder]} variant="outline"
-						>Cancel</Button
-					>
+					<Button builders={[builder]} variant="outline">Cancel</Button>
 				</Drawer.Close>
 			</Drawer.Footer>
 		</div>

--- a/apps/www/src/lib/registry/new-york/example/drawer-dialog.svelte
+++ b/apps/www/src/lib/registry/new-york/example/drawer-dialog.svelte
@@ -19,8 +19,7 @@
 			<Dialog.Header>
 				<Dialog.Title>Edit profile</Dialog.Title>
 				<Dialog.Description>
-					Make changes to your profile here. Click save when you're
-					done.
+					Make changes to your profile here. Click save when you're done.
 				</Dialog.Description>
 			</Dialog.Header>
 			<form class="grid items-start gap-4">
@@ -45,8 +44,7 @@
 			<Drawer.Header class="text-left">
 				<Drawer.Title>Edit profile</Drawer.Title>
 				<Drawer.Description>
-					Make changes to your profile here. Click save when you're
-					done.
+					Make changes to your profile here. Click save when you're done.
 				</Drawer.Description>
 			</Drawer.Header>
 			<form class="grid items-start gap-4 px-4">
@@ -62,9 +60,7 @@
 			</form>
 			<Drawer.Footer class="pt-2">
 				<Drawer.Close asChild let:builder>
-					<Button variant="outline" builders={[builder]}
-						>Cancel</Button
-					>
+					<Button variant="outline" builders={[builder]}>Cancel</Button>
 				</Drawer.Close>
 			</Drawer.Footer>
 		</Drawer.Content>

--- a/apps/www/src/lib/registry/new-york/example/dropdown-menu-checkboxes.svelte
+++ b/apps/www/src/lib/registry/new-york/example/dropdown-menu-checkboxes.svelte
@@ -20,8 +20,6 @@
 		<DropdownMenu.CheckboxItem bind:checked={showActivityBar} disabled>
 			Activity Bar
 		</DropdownMenu.CheckboxItem>
-		<DropdownMenu.CheckboxItem bind:checked={showPanel}>
-			Panel
-		</DropdownMenu.CheckboxItem>
+		<DropdownMenu.CheckboxItem bind:checked={showPanel}>Panel</DropdownMenu.CheckboxItem>
 	</DropdownMenu.Content>
 </DropdownMenu.Root>

--- a/apps/www/src/lib/registry/new-york/example/dropdown-menu-radio-group.svelte
+++ b/apps/www/src/lib/registry/new-york/example/dropdown-menu-radio-group.svelte
@@ -14,9 +14,7 @@
 		<DropdownMenu.Separator />
 		<DropdownMenu.RadioGroup bind:value={position}>
 			<DropdownMenu.RadioItem value="top">Top</DropdownMenu.RadioItem>
-			<DropdownMenu.RadioItem value="bottom"
-				>Bottom</DropdownMenu.RadioItem
-			>
+			<DropdownMenu.RadioItem value="bottom">Bottom</DropdownMenu.RadioItem>
 			<DropdownMenu.RadioItem value="right">Right</DropdownMenu.RadioItem>
 		</DropdownMenu.RadioGroup>
 	</DropdownMenu.Content>

--- a/apps/www/src/lib/registry/new-york/example/form-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/form-demo.svelte
@@ -26,9 +26,7 @@
 		<Form.Item>
 			<Form.Label>Username</Form.Label>
 			<Form.Input />
-			<Form.Description
-				>This is your public display name.</Form.Description
-			>
+			<Form.Description>This is your public display name.</Form.Description>
 			<Form.Validation />
 		</Form.Item>
 	</Form.Field>

--- a/apps/www/src/lib/registry/new-york/example/hover-card-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/hover-card-demo.svelte
@@ -24,9 +24,7 @@
 				<p class="text-sm">Cybernetically enhanced web apps.</p>
 				<div class="flex items-center pt-2">
 					<Calendar class="mr-2 h-4 w-4 opacity-70" />{" "}
-					<span class="text-xs text-muted-foreground">
-						Joined September 2022
-					</span>
+					<span class="text-xs text-muted-foreground"> Joined September 2022 </span>
 				</div>
 			</div>
 		</div>

--- a/apps/www/src/lib/registry/new-york/example/pagination-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/pagination-demo.svelte
@@ -25,10 +25,7 @@
 				</Pagination.Item>
 			{:else}
 				<Pagination.Item>
-					<Pagination.Link
-						{page}
-						isActive={currentPage == page.value}
-					>
+					<Pagination.Link {page} isActive={currentPage == page.value}>
 						{page.value}
 					</Pagination.Link>
 				</Pagination.Item>

--- a/apps/www/src/lib/registry/new-york/example/popover-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/popover-demo.svelte
@@ -13,9 +13,7 @@
 		<div class="grid gap-4">
 			<div class="space-y-2">
 				<h4 class="font-medium leading-none">Dimensions</h4>
-				<p class="text-sm text-muted-foreground">
-					Set the dimensions for the layer.
-				</p>
+				<p class="text-sm text-muted-foreground">Set the dimensions for the layer.</p>
 			</div>
 			<div class="grid gap-2">
 				<div class="grid grid-cols-3 items-center gap-4">

--- a/apps/www/src/lib/registry/new-york/example/radio-group-form.svelte
+++ b/apps/www/src/lib/registry/new-york/example/radio-group-form.svelte
@@ -33,14 +33,11 @@
 			<Form.RadioGroup class="flex flex-col space-y-1">
 				<Form.Item class="flex items-center space-x-3 space-y-0">
 					<Form.RadioItem value="all" id="all" />
-					<Label for="all" class="font-normal">All new messages</Label
-					>
+					<Label for="all" class="font-normal">All new messages</Label>
 				</Form.Item>
 				<Form.Item class="flex items-center space-x-3 space-y-0">
 					<Form.RadioItem value="mentions" id="mentions" />
-					<Label for="mentions" class="font-normal"
-						>Direct messages and mentions</Label
-					>
+					<Label for="mentions" class="font-normal">Direct messages and mentions</Label>
 				</Form.Item>
 				<Form.Item class="flex items-center space-x-3 space-y-0">
 					<Form.RadioItem value="none" id="none" />

--- a/apps/www/src/lib/registry/new-york/example/select-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/select-demo.svelte
@@ -18,9 +18,7 @@
 		<Select.Group>
 			<Select.Label>Fruits</Select.Label>
 			{#each fruits as fruit}
-				<Select.Item value={fruit.value} label={fruit.label}
-					>{fruit.label}</Select.Item
-				>
+				<Select.Item value={fruit.value} label={fruit.label}>{fruit.label}</Select.Item>
 			{/each}
 		</Select.Group>
 	</Select.Content>

--- a/apps/www/src/lib/registry/new-york/example/select-form.svelte
+++ b/apps/www/src/lib/registry/new-york/example/select-form.svelte
@@ -2,9 +2,7 @@
 	import { z } from "zod";
 
 	export const formSchema = z.object({
-		email: z
-			.string({ required_error: "Please select an email to display" })
-			.email()
+		email: z.string({ required_error: "Please select an email to display" }).email()
 	});
 
 	export type FormSchema = typeof formSchema;
@@ -29,25 +27,15 @@
 		<Form.Item>
 			<Form.Label>Email</Form.Label>
 			<Form.Select>
-				<Form.SelectTrigger
-					placeholder="Select a verified email to display"
-				/>
+				<Form.SelectTrigger placeholder="Select a verified email to display" />
 				<Form.SelectContent>
-					<Form.SelectItem value="m@example.com"
-						>m@example.com</Form.SelectItem
-					>
-					<Form.SelectItem value="m@google.com"
-						>m@google.com</Form.SelectItem
-					>
-					<Form.SelectItem value="m@support.com"
-						>m@support.com</Form.SelectItem
-					>
+					<Form.SelectItem value="m@example.com">m@example.com</Form.SelectItem>
+					<Form.SelectItem value="m@google.com">m@google.com</Form.SelectItem>
+					<Form.SelectItem value="m@support.com">m@support.com</Form.SelectItem>
 				</Form.SelectContent>
 			</Form.Select>
 			<Form.Description>
-				You can manage email address in your <a href="/examples/forms"
-					>email settings</a
-				>.
+				You can manage email address in your <a href="/examples/forms">email settings</a>.
 			</Form.Description>
 			<Form.Validation />
 		</Form.Item>

--- a/apps/www/src/lib/registry/new-york/example/separator-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/separator-demo.svelte
@@ -5,9 +5,7 @@
 <div>
 	<div class="space-y-1">
 		<h4 class="text-sm font-medium leading-none">Radix Primitives</h4>
-		<p class="text-sm text-muted-foreground">
-			An open-source UI component library.
-		</p>
+		<p class="text-sm text-muted-foreground">An open-source UI component library.</p>
 	</div>
 	<Separator class="my-4" />
 	<div class="flex h-5 items-center space-x-4 text-sm">

--- a/apps/www/src/lib/registry/new-york/example/sheet-side.svelte
+++ b/apps/www/src/lib/registry/new-york/example/sheet-side.svelte
@@ -17,34 +17,22 @@
 				<Sheet.Header>
 					<Sheet.Title>Edit profile</Sheet.Title>
 					<Sheet.Description>
-						Make changes to your profile here. Click save when
-						you're done.
+						Make changes to your profile here. Click save when you're done.
 					</Sheet.Description>
 				</Sheet.Header>
 				<div class="grid gap-4 py-4">
 					<div class="grid grid-cols-4 items-center gap-4">
 						<Label for="name" class="text-right">Name</Label>
-						<Input
-							id="name"
-							value="Pedro Duarte"
-							class="col-span-3"
-						/>
+						<Input id="name" value="Pedro Duarte" class="col-span-3" />
 					</div>
 					<div class="grid grid-cols-4 items-center gap-4">
-						<Label for="username" class="text-right">Username</Label
-						>
-						<Input
-							id="username"
-							value="@peduarte"
-							class="col-span-3"
-						/>
+						<Label for="username" class="text-right">Username</Label>
+						<Input id="username" value="@peduarte" class="col-span-3" />
 					</div>
 				</div>
 				<Sheet.Footer>
 					<Sheet.Close asChild let:builder>
-						<Button builders={[builder]} type="submit"
-							>Save changes</Button
-						>
+						<Button builders={[builder]} type="submit">Save changes</Button>
 					</Sheet.Close>
 				</Sheet.Footer>
 			</Sheet.Content>

--- a/apps/www/src/lib/registry/new-york/example/switch-form.svelte
+++ b/apps/www/src/lib/registry/new-york/example/switch-form.svelte
@@ -26,23 +26,18 @@
 		<legend class="mb-4 text-lg font-medium"> Email Notifications </legend>
 		<div class="space-y-4">
 			<Form.Field {config} name="marketing_emails">
-				<Form.Item
-					class="flex flex-row items-center justify-between rounded-lg border p-4"
-				>
+				<Form.Item class="flex flex-row items-center justify-between rounded-lg border p-4">
 					<div class="space-y-0.5">
 						<Form.Label>Marketing emails</Form.Label>
 						<Form.Description>
-							Receive emails about new products, features, and
-							more.
+							Receive emails about new products, features, and more.
 						</Form.Description>
 					</div>
 					<Form.Switch />
 				</Form.Item>
 			</Form.Field>
 			<Form.Field {config} name="security_emails">
-				<Form.Item
-					class="flex flex-row items-center justify-between rounded-lg border p-4"
-				>
+				<Form.Item class="flex flex-row items-center justify-between rounded-lg border p-4">
 					<div class="space-y-0.5">
 						<Form.Label>Security emails</Form.Label>
 						<Form.Description>

--- a/apps/www/src/lib/registry/new-york/example/table-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/table-demo.svelte
@@ -63,8 +63,7 @@
 				<Table.Cell class="font-medium">{invoice.invoice}</Table.Cell>
 				<Table.Cell>{invoice.paymentStatus}</Table.Cell>
 				<Table.Cell>{invoice.paymentMethod}</Table.Cell>
-				<Table.Cell class="text-right">{invoice.totalAmount}</Table.Cell
-				>
+				<Table.Cell class="text-right">{invoice.totalAmount}</Table.Cell>
 			</Table.Row>
 		{/each}
 	</Table.Body>

--- a/apps/www/src/lib/registry/new-york/example/tabs-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/tabs-demo.svelte
@@ -16,8 +16,7 @@
 			<Card.Header>
 				<Card.Title>Account</Card.Title>
 				<Card.Description>
-					Make changes to your account here. Click save when you're
-					done.
+					Make changes to your account here. Click save when you're done.
 				</Card.Description>
 			</Card.Header>
 			<Card.Content class="space-y-2">
@@ -40,8 +39,7 @@
 			<Card.Header>
 				<Card.Title>Password</Card.Title>
 				<Card.Description>
-					Change your password here. After saving, you'll be logged
-					out.
+					Change your password here. After saving, you'll be logged out.
 				</Card.Description>
 			</Card.Header>
 			<Card.Content class="space-y-2">

--- a/apps/www/src/lib/registry/new-york/example/textarea-form.svelte
+++ b/apps/www/src/lib/registry/new-york/example/textarea-form.svelte
@@ -27,10 +27,7 @@
 	<Form.Field {config} name="bio">
 		<Form.Item>
 			<Form.Label>Bio</Form.Label>
-			<Form.Textarea
-				placeholder="Tell us a little bit about yourself"
-				class="resize-none"
-			/>
+			<Form.Textarea placeholder="Tell us a little bit about yourself" class="resize-none" />
 			<Form.Description>
 				You can <span>@mention</span> other users and organizations.
 			</Form.Description>

--- a/apps/www/src/lib/registry/new-york/example/textarea-with-text.svelte
+++ b/apps/www/src/lib/registry/new-york/example/textarea-with-text.svelte
@@ -6,7 +6,5 @@
 <div class="grid w-full gap-1.5">
 	<Label for="message-2">Your Message</Label>
 	<Textarea placeholder="Type your message here." id="message-2" />
-	<p class="text-sm text-muted-foreground">
-		Your message will be copied to the support team.
-	</p>
+	<p class="text-sm text-muted-foreground">Your message will be copied to the support team.</p>
 </div>

--- a/apps/www/src/lib/registry/new-york/example/typography-blockquote.svelte
+++ b/apps/www/src/lib/registry/new-york/example/typography-blockquote.svelte
@@ -1,4 +1,4 @@
 <blockquote class="mt-6 border-l-2 pl-6 italic">
-	"After all," he said, "everyone enjoys a good joke, so it's only fair that
-	they should pay for the privilege."
+	"After all," he said, "everyone enjoys a good joke, so it's only fair that they should pay for
+	the privilege."
 </blockquote>

--- a/apps/www/src/lib/registry/new-york/example/typography-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/typography-demo.svelte
@@ -3,9 +3,9 @@
 		The Joke Tax Chronicles
 	</h1>
 	<p class="leading-7 [&:not(:first-child)]:mt-6">
-		Once upon a time, in a far-off land, there was a very lazy king who
-		spent all day lounging on his throne. One day, his advisors came to him
-		with a problem: the kingdom was running out of money.
+		Once upon a time, in a far-off land, there was a very lazy king who spent all day lounging
+		on his throne. One day, his advisors came to him with a problem: the kingdom was running out
+		of money.
 	</p>
 	<h2
 		class="mt-10 scroll-m-20 border-b pb-2 text-3xl font-semibold tracking-tight transition-colors first:mt-0"
@@ -15,24 +15,18 @@
 	<p class="leading-7 [&:not(:first-child)]:mt-6">
 		The king thought long and hard, and finally came up with{" "}
 		<!-- svelte-ignore a11y-invalid-attribute -->
-		<a
-			href="#"
-			class="font-medium text-primary underline underline-offset-4"
-		>
+		<a href="#" class="font-medium text-primary underline underline-offset-4">
 			a brilliant plan
 		</a>
 		: he would tax the jokes in the kingdom.
 	</p>
 	<blockquote class="mt-6 border-l-2 pl-6 italic">
-		"After all," he said, "everyone enjoys a good joke, so it's only fair
-		that they should pay for the privilege."
+		"After all," he said, "everyone enjoys a good joke, so it's only fair that they should pay
+		for the privilege."
 	</blockquote>
-	<h3 class="mt-8 scroll-m-20 text-2xl font-semibold tracking-tight">
-		The Joke Tax
-	</h3>
+	<h3 class="mt-8 scroll-m-20 text-2xl font-semibold tracking-tight">The Joke Tax</h3>
 	<p class="leading-7 [&:not(:first-child)]:mt-6">
-		The king's subjects were not amused. They grumbled and complained, but
-		the king was firm:
+		The king's subjects were not amused. They grumbled and complained, but the king was firm:
 	</p>
 	<ul class="my-6 ml-6 list-disc [&>li]:mt-2">
 		<li>1st level of puns: 5 gold coins</li>
@@ -40,31 +34,25 @@
 		<li>3rd level of one-liners : 20 gold coins</li>
 	</ul>
 	<p class="leading-7 [&:not(:first-child)]:mt-6">
-		As a result, people stopped telling jokes, and the kingdom fell into a
-		gloom. But there was one person who refused to let the king's
-		foolishness get him down: a court jester named Jokester.
+		As a result, people stopped telling jokes, and the kingdom fell into a gloom. But there was
+		one person who refused to let the king's foolishness get him down: a court jester named
+		Jokester.
 	</p>
-	<h3 class="mt-8 scroll-m-20 text-2xl font-semibold tracking-tight">
-		Jokester's Revolt
-	</h3>
+	<h3 class="mt-8 scroll-m-20 text-2xl font-semibold tracking-tight">Jokester's Revolt</h3>
 	<p class="leading-7 [&:not(:first-child)]:mt-6">
-		Jokester began sneaking into the castle in the middle of the night and
-		leaving jokes all over the place: under the king's pillow, in his soup,
-		even in the royal toilet. The king was furious, but he couldn't seem to
-		stop Jokester.
+		Jokester began sneaking into the castle in the middle of the night and leaving jokes all
+		over the place: under the king's pillow, in his soup, even in the royal toilet. The king was
+		furious, but he couldn't seem to stop Jokester.
 	</p>
 	<p class="leading-7 [&:not(:first-child)]:mt-6">
-		And then, one day, the people of the kingdom discovered that the jokes
-		left by Jokester were so funny that they couldn't help but laugh. And
-		once they started laughing, they couldn't stop.
+		And then, one day, the people of the kingdom discovered that the jokes left by Jokester were
+		so funny that they couldn't help but laugh. And once they started laughing, they couldn't
+		stop.
 	</p>
-	<h3 class="mt-8 scroll-m-20 text-2xl font-semibold tracking-tight">
-		The People's Rebellion
-	</h3>
+	<h3 class="mt-8 scroll-m-20 text-2xl font-semibold tracking-tight">The People's Rebellion</h3>
 	<p class="leading-7 [&:not(:first-child)]:mt-6">
-		The people of the kingdom, feeling uplifted by the laughter, started to
-		tell jokes and puns again, and soon the entire kingdom was in on the
-		joke.
+		The people of the kingdom, feeling uplifted by the laughter, started to tell jokes and puns
+		again, and soon the entire kingdom was in on the joke.
 	</p>
 	<div class="my-6 w-full overflow-y-auto">
 		<table class="w-full">
@@ -123,12 +111,12 @@
 		</table>
 	</div>
 	<p class="leading-7 [&:not(:first-child)]:mt-6">
-		The king, seeing how much happier his subjects were, realized the error
-		of his ways and repealed the joke tax. Jokester was declared a hero, and
-		the kingdom lived happily ever after.
+		The king, seeing how much happier his subjects were, realized the error of his ways and
+		repealed the joke tax. Jokester was declared a hero, and the kingdom lived happily ever
+		after.
 	</p>
 	<p class="leading-7 [&:not(:first-child)]:mt-6">
-		The moral of the story is: never underestimate the power of a good laugh
-		and always be careful of bad ideas.
+		The moral of the story is: never underestimate the power of a good laugh and always be
+		careful of bad ideas.
 	</p>
 </div>

--- a/apps/www/src/lib/registry/new-york/example/typography-h4.svelte
+++ b/apps/www/src/lib/registry/new-york/example/typography-h4.svelte
@@ -1,3 +1,1 @@
-<h4 class="scroll-m-20 text-xl font-semibold tracking-tight">
-	People stopped telling jokes
-</h4>
+<h4 class="scroll-m-20 text-xl font-semibold tracking-tight">People stopped telling jokes</h4>

--- a/apps/www/src/lib/registry/new-york/example/typography-inline-code.svelte
+++ b/apps/www/src/lib/registry/new-york/example/typography-inline-code.svelte
@@ -1,5 +1,3 @@
-<code
-	class="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold"
->
+<code class="relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm font-semibold">
 	radix-svelte
 </code>

--- a/apps/www/src/lib/registry/new-york/example/typography-lead.svelte
+++ b/apps/www/src/lib/registry/new-york/example/typography-lead.svelte
@@ -1,4 +1,3 @@
 <p class="text-xl text-muted-foreground">
-	A modal dialog that interrupts the user with important content and expects a
-	response.
+	A modal dialog that interrupts the user with important content and expects a response.
 </p>

--- a/apps/www/src/lib/registry/new-york/example/typography-p.svelte
+++ b/apps/www/src/lib/registry/new-york/example/typography-p.svelte
@@ -1,4 +1,4 @@
 <p class="leading-7 [&:not(:first-child)]:mt-6">
-	The king, seeing how much happier his subjects were, realized the error of
-	his ways and repealed the joke tax.
+	The king, seeing how much happier his subjects were, realized the error of his ways and repealed
+	the joke tax.
 </p>

--- a/apps/www/src/lib/registry/new-york/ui/accordion/accordion-item.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/accordion/accordion-item.svelte
@@ -9,10 +9,6 @@
 	export let value: $$Props["value"];
 </script>
 
-<AccordionPrimitive.Item
-	{value}
-	class={cn("border-b", className)}
-	{...$$restProps}
->
+<AccordionPrimitive.Item {value} class={cn("border-b", className)} {...$$restProps}>
 	<slot />
 </AccordionPrimitive.Item>

--- a/apps/www/src/lib/registry/new-york/ui/alert-dialog/alert-dialog-cancel.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/alert-dialog/alert-dialog-cancel.svelte
@@ -11,11 +11,7 @@
 </script>
 
 <AlertDialogPrimitive.Cancel
-	class={cn(
-		buttonVariants({ variant: "outline" }),
-		"mt-2 sm:mt-0",
-		className
-	)}
+	class={cn(buttonVariants({ variant: "outline" }), "mt-2 sm:mt-0", className)}
 	{...$$restProps}
 	on:click
 	on:keydown

--- a/apps/www/src/lib/registry/new-york/ui/alert-dialog/alert-dialog-footer.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/alert-dialog/alert-dialog-footer.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <div
-	class={cn(
-		"flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-		className
-	)}
+	class={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/new-york/ui/alert-dialog/alert-dialog-header.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/alert-dialog/alert-dialog-header.svelte
@@ -8,9 +8,6 @@
 	export { className as class };
 </script>
 
-<div
-	class={cn("flex flex-col space-y-2 text-center sm:text-left", className)}
-	{...$$restProps}
->
+<div class={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...$$restProps}>
 	<slot />
 </div>

--- a/apps/www/src/lib/registry/new-york/ui/alert-dialog/alert-dialog-overlay.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/alert-dialog/alert-dialog-overlay.svelte
@@ -16,9 +16,6 @@
 <AlertDialogPrimitive.Overlay
 	{transition}
 	{transitionConfig}
-	class={cn(
-		"fixed inset-0 z-50 bg-background/80 backdrop-blur-sm",
-		className
-	)}
+	class={cn("fixed inset-0 z-50 bg-background/80 backdrop-blur-sm", className)}
 	{...$$restProps}
 />

--- a/apps/www/src/lib/registry/new-york/ui/alert-dialog/alert-dialog-title.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/alert-dialog/alert-dialog-title.svelte
@@ -9,10 +9,6 @@
 	export { className as class };
 </script>
 
-<AlertDialogPrimitive.Title
-	class={cn("text-lg font-semibold", className)}
-	{level}
-	{...$$restProps}
->
+<AlertDialogPrimitive.Title class={cn("text-lg font-semibold", className)} {level} {...$$restProps}>
 	<slot />
 </AlertDialogPrimitive.Title>

--- a/apps/www/src/lib/registry/new-york/ui/alert/alert.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/alert/alert.svelte
@@ -12,10 +12,6 @@
 	export { className as class };
 </script>
 
-<div
-	class={cn(alertVariants({ variant }), className)}
-	{...$$restProps}
-	role="alert"
->
+<div class={cn(alertVariants({ variant }), className)} {...$$restProps} role="alert">
 	<slot />
 </div>

--- a/apps/www/src/lib/registry/new-york/ui/avatar/avatar-fallback.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/avatar/avatar-fallback.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <AvatarPrimitive.Fallback
-	class={cn(
-		"flex h-full w-full items-center justify-center rounded-full bg-muted",
-		className
-	)}
+	class={cn("flex h-full w-full items-center justify-center rounded-full bg-muted", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/new-york/ui/avatar/avatar.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/avatar/avatar.svelte
@@ -11,10 +11,7 @@
 
 <AvatarPrimitive.Root
 	{delayMs}
-	class={cn(
-		"relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
-		className
-	)}
+	class={cn("relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/new-york/ui/button/index.ts
+++ b/apps/www/src/lib/registry/new-york/ui/button/index.ts
@@ -6,14 +6,12 @@ const buttonVariants = tv({
 	base: "inline-flex items-center justify-center rounded-md text-sm font-medium whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
 	variants: {
 		variant: {
-			default:
-				"bg-primary text-primary-foreground shadow hover:bg-primary/90",
+			default: "bg-primary text-primary-foreground shadow hover:bg-primary/90",
 			destructive:
 				"bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
 			outline:
 				"border border-input bg-transparent shadow-sm hover:bg-accent hover:text-accent-foreground",
-			secondary:
-				"bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+			secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
 			ghost: "hover:bg-accent hover:text-accent-foreground",
 			link: "text-primary underline-offset-4 hover:underline"
 		},

--- a/apps/www/src/lib/registry/new-york/ui/calendar/calendar-grid.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/calendar/calendar-grid.svelte
@@ -8,9 +8,6 @@
 	export { className as class };
 </script>
 
-<CalendarPrimitive.Grid
-	class={cn("w-full border-collapse space-y-1", className)}
-	{...$$restProps}
->
+<CalendarPrimitive.Grid class={cn("w-full border-collapse space-y-1", className)} {...$$restProps}>
 	<slot />
 </CalendarPrimitive.Grid>

--- a/apps/www/src/lib/registry/new-york/ui/calendar/calendar-head-cell.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/calendar/calendar-head-cell.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <CalendarPrimitive.HeadCell
-	class={cn(
-		"text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]",
-		className
-	)}
+	class={cn("text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/new-york/ui/calendar/calendar-header.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/calendar/calendar-header.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <CalendarPrimitive.Header
-	class={cn(
-		"flex justify-between pt-1 relative items-center w-full",
-		className
-	)}
+	class={cn("flex justify-between pt-1 relative items-center w-full", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/new-york/ui/calendar/calendar-months.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/calendar/calendar-months.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <div
-	class={cn(
-		"flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0 mt-4",
-		className
-	)}
+	class={cn("flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0 mt-4", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/new-york/ui/card/card.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/card/card.svelte
@@ -10,10 +10,7 @@
 
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div
-	class={cn(
-		"rounded-xl border bg-card text-card-foreground shadow",
-		className
-	)}
+	class={cn("rounded-xl border bg-card text-card-foreground shadow", className)}
 	{...$$restProps}
 	on:click
 	on:focusin

--- a/apps/www/src/lib/registry/new-york/ui/checkbox/checkbox.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/checkbox/checkbox.svelte
@@ -28,9 +28,7 @@
 		{#if isIndeterminate}
 			<Minus class="h-3.5 w-3.5" />
 		{:else}
-			<Check
-				class={cn("h-3.5 w-3.5", !isChecked && "text-transparent")}
-			/>
+			<Check class={cn("h-3.5 w-3.5", !isChecked && "text-transparent")} />
 		{/if}
 	</CheckboxPrimitive.Indicator>
 </CheckboxPrimitive.Root>

--- a/apps/www/src/lib/registry/new-york/ui/command/command-empty.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/command/command-empty.svelte
@@ -7,9 +7,6 @@
 	export { className as class };
 </script>
 
-<CommandPrimitive.Empty
-	class={cn("py-6 text-center text-sm", className)}
-	{...$$restProps}
->
+<CommandPrimitive.Empty class={cn("py-6 text-center text-sm", className)} {...$$restProps}>
 	<slot />
 </CommandPrimitive.Empty>

--- a/apps/www/src/lib/registry/new-york/ui/command/command-separator.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/command/command-separator.svelte
@@ -7,7 +7,4 @@
 	export { className as class };
 </script>
 
-<CommandPrimitive.Separator
-	class={cn("-mx-1 h-px bg-border", className)}
-	{...$$restProps}
-/>
+<CommandPrimitive.Separator class={cn("-mx-1 h-px bg-border", className)} {...$$restProps} />

--- a/apps/www/src/lib/registry/new-york/ui/command/command-shortcut.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/command/command-shortcut.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <span
-	class={cn(
-		"ml-auto text-xs tracking-widest text-muted-foreground",
-		className
-	)}
+	class={cn("ml-auto text-xs tracking-widest text-muted-foreground", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/new-york/ui/context-menu/context-menu-label.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/context-menu/context-menu-label.svelte
@@ -12,11 +12,7 @@
 </script>
 
 <ContextMenuPrimitive.Label
-	class={cn(
-		"px-2 py-1.5 text-sm font-semibold text-foreground",
-		inset && "pl-8",
-		className
-	)}
+	class={cn("px-2 py-1.5 text-sm font-semibold text-foreground", inset && "pl-8", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/new-york/ui/context-menu/context-menu-shortcut.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/context-menu/context-menu-shortcut.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <span
-	class={cn(
-		"ml-auto text-xs tracking-widest text-muted-foreground",
-		className
-	)}
+	class={cn("ml-auto text-xs tracking-widest text-muted-foreground", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/new-york/ui/dialog/dialog-footer.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/dialog/dialog-footer.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <div
-	class={cn(
-		"flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-		className
-	)}
+	class={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/new-york/ui/dialog/dialog-header.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/dialog/dialog-header.svelte
@@ -8,9 +8,6 @@
 	export { className as class };
 </script>
 
-<div
-	class={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)}
-	{...$$restProps}
->
+<div class={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...$$restProps}>
 	<slot />
 </div>

--- a/apps/www/src/lib/registry/new-york/ui/dialog/dialog-overlay.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/dialog/dialog-overlay.svelte
@@ -16,9 +16,6 @@
 <DialogPrimitive.Overlay
 	{transition}
 	{transitionConfig}
-	class={cn(
-		"fixed inset-0 z-50 bg-background/80 backdrop-blur-sm ",
-		className
-	)}
+	class={cn("fixed inset-0 z-50 bg-background/80 backdrop-blur-sm ", className)}
 	{...$$restProps}
 />

--- a/apps/www/src/lib/registry/new-york/ui/drawer/drawer-footer.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/drawer/drawer-footer.svelte
@@ -11,10 +11,6 @@
 	export { className as class };
 </script>
 
-<div
-	bind:this={el}
-	class={cn("mt-auto flex flex-col gap-2 p-4", className)}
-	{...$$restProps}
->
+<div bind:this={el} class={cn("mt-auto flex flex-col gap-2 p-4", className)} {...$$restProps}>
 	<slot />
 </div>

--- a/apps/www/src/lib/registry/new-york/ui/drawer/drawer.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/drawer/drawer.svelte
@@ -7,11 +7,6 @@
 	export let activeSnapPoint: $$Props["activeSnapPoint"] = undefined;
 </script>
 
-<DrawerPrimitive.Root
-	{shouldScaleBackground}
-	bind:open
-	bind:activeSnapPoint
-	{...$$restProps}
->
+<DrawerPrimitive.Root {shouldScaleBackground} bind:open bind:activeSnapPoint {...$$restProps}>
 	<slot />
 </DrawerPrimitive.Root>

--- a/apps/www/src/lib/registry/new-york/ui/dropdown-menu/dropdown-menu-shortcut.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/dropdown-menu/dropdown-menu-shortcut.svelte
@@ -8,9 +8,6 @@
 	export { className as class };
 </script>
 
-<span
-	class={cn("ml-auto text-xs tracking-widest opacity-60", className)}
-	{...$$restProps}
->
+<span class={cn("ml-auto text-xs tracking-widest opacity-60", className)} {...$$restProps}>
 	<slot />
 </span>

--- a/apps/www/src/lib/registry/new-york/ui/form/form-label.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/form/form-label.svelte
@@ -12,10 +12,6 @@
 	const { errors, ids } = getFormField();
 </script>
 
-<Label
-	for={$ids.input}
-	class={cn($errors && "text-destructive", className)}
-	{...$$restProps}
->
+<Label for={$ids.input} class={cn($errors && "text-destructive", className)} {...$$restProps}>
 	<slot />
 </Label>

--- a/apps/www/src/lib/registry/new-york/ui/form/form-select-trigger.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/form/form-select-trigger.svelte
@@ -7,11 +7,12 @@
 		placeholder?: string;
 	};
 	type $$Events = SelectPrimitive.TriggerEvents;
-	const { attrStore } = getFormField();
+	const { attrStore, value } = getFormField();
 	export let placeholder = "";
 </script>
 
 <Select.Trigger {...$$restProps} {...$attrStore} on:click on:keydown>
-	<Select.Value {placeholder} />
-	<slot />
+	<slot value={$value}>
+		<Select.Value {placeholder} />
+	</slot>
 </Select.Trigger>

--- a/apps/www/src/lib/registry/new-york/ui/form/form-textarea.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/form/form-textarea.svelte
@@ -2,10 +2,7 @@
 	import { getFormField } from "formsnap";
 	import type { HTMLTextareaAttributes } from "svelte/elements";
 	import type { TextareaGetFormField } from ".";
-	import {
-		Textarea,
-		type TextareaEvents
-	} from "@/registry/new-york/ui/textarea";
+	import { Textarea, type TextareaEvents } from "@/registry/new-york/ui/textarea";
 
 	type $$Props = HTMLTextareaAttributes;
 	type $$Events = TextareaEvents;

--- a/apps/www/src/lib/registry/new-york/ui/form/index.ts
+++ b/apps/www/src/lib/registry/new-york/ui/form/index.ts
@@ -27,10 +27,7 @@ const SelectGroup = SelectComp.Group;
 const SelectItem = SelectComp.Item;
 const SelectSeparator = SelectComp.Separator;
 
-export type TextareaGetFormField = Omit<
-	ReturnType<typeof getFormField>,
-	"value"
-> & {
+export type TextareaGetFormField = Omit<ReturnType<typeof getFormField>, "value"> & {
 	value: Writable<string>;
 };
 

--- a/apps/www/src/lib/registry/new-york/ui/menubar/menubar-separator.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/menubar/menubar-separator.svelte
@@ -7,7 +7,4 @@
 	export { className as class };
 </script>
 
-<MenubarPrimitive.Separator
-	class={cn("-mx-1 my-1 h-px bg-muted", className)}
-	{...$$restProps}
-/>
+<MenubarPrimitive.Separator class={cn("-mx-1 my-1 h-px bg-muted", className)} {...$$restProps} />

--- a/apps/www/src/lib/registry/new-york/ui/menubar/menubar-shortcut.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/menubar/menubar-shortcut.svelte
@@ -8,10 +8,7 @@
 </script>
 
 <span
-	class={cn(
-		"ml-auto text-xs tracking-widest text-muted-foreground",
-		className
-	)}
+	class={cn("ml-auto text-xs tracking-widest text-muted-foreground", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/new-york/ui/pagination/pagination.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/pagination/pagination.svelte
@@ -27,10 +27,7 @@
 	asChild
 	{...$$restProps}
 >
-	<nav
-		{...builder}
-		class={cn("mx-auto flex flex-col w-full items-center", className)}
-	>
+	<nav {...builder} class={cn("mx-auto flex flex-col w-full items-center", className)}>
 		<slot {pages} {range} {currentPage} />
 	</nav>
 </PaginationPrimitive.Root>

--- a/apps/www/src/lib/registry/new-york/ui/progress/progress.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/progress/progress.svelte
@@ -11,16 +11,11 @@
 </script>
 
 <ProgressPrimitive.Root
-	class={cn(
-		"relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
-		className
-	)}
+	class={cn("relative h-2 w-full overflow-hidden rounded-full bg-primary/20", className)}
 	{...$$restProps}
 >
 	<div
 		class="h-full w-full flex-1 bg-primary transition-all"
-		style={`transform: translateX(-${
-			100 - (100 * (value ?? 0)) / (max ?? 1)
-		}%)`}
+		style={`transform: translateX(-${100 - (100 * (value ?? 0)) / (max ?? 1)}%)`}
 	/>
 </ProgressPrimitive.Root>

--- a/apps/www/src/lib/registry/new-york/ui/radio-group/radio-group.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/radio-group/radio-group.svelte
@@ -9,10 +9,6 @@
 	export { className as class };
 </script>
 
-<RadioGroupPrimitive.Root
-	bind:value
-	class={cn("grid gap-2", className)}
-	{...$$restProps}
->
+<RadioGroupPrimitive.Root bind:value class={cn("grid gap-2", className)} {...$$restProps}>
 	<slot />
 </RadioGroupPrimitive.Root>

--- a/apps/www/src/lib/registry/new-york/ui/range-calendar/range-calendar-head-cell.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/range-calendar/range-calendar-head-cell.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <RangeCalendarPrimitive.HeadCell
-	class={cn(
-		"text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]",
-		className
-	)}
+	class={cn("text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/new-york/ui/range-calendar/range-calendar-header.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/range-calendar/range-calendar-header.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <RangeCalendarPrimitive.Header
-	class={cn(
-		"flex justify-between pt-1 relative items-center w-full",
-		className
-	)}
+	class={cn("flex justify-between pt-1 relative items-center w-full", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/new-york/ui/range-calendar/range-calendar-months.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/range-calendar/range-calendar-months.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <div
-	class={cn(
-		"flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0 mt-4",
-		className
-	)}
+	class={cn("flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0 mt-4", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/new-york/ui/range-calendar/range-calendar.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/range-calendar/range-calendar.svelte
@@ -48,10 +48,7 @@
 						<RangeCalendar.GridRow class="w-full mt-2">
 							{#each weekDates as date}
 								<RangeCalendar.Cell {date}>
-									<RangeCalendar.Day
-										{date}
-										month={month.value}
-									/>
+									<RangeCalendar.Day {date} month={month.value} />
 								</RangeCalendar.Cell>
 							{/each}
 						</RangeCalendar.GridRow>

--- a/apps/www/src/lib/registry/new-york/ui/select/select-label.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/select/select-label.svelte
@@ -8,9 +8,6 @@
 	export { className as class };
 </script>
 
-<SelectPrimitive.Label
-	class={cn("px-2 py-1.5 text-sm font-semibold", className)}
-	{...$$restProps}
->
+<SelectPrimitive.Label class={cn("px-2 py-1.5 text-sm font-semibold", className)} {...$$restProps}>
 	<slot />
 </SelectPrimitive.Label>

--- a/apps/www/src/lib/registry/new-york/ui/select/select-separator.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/select/select-separator.svelte
@@ -8,7 +8,4 @@
 	export { className as class };
 </script>
 
-<SelectPrimitive.Separator
-	class={cn("-mx-1 my-1 h-px bg-muted", className)}
-	{...$$restProps}
-/>
+<SelectPrimitive.Separator class={cn("-mx-1 my-1 h-px bg-muted", className)} {...$$restProps} />

--- a/apps/www/src/lib/registry/new-york/ui/sheet/sheet-content.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/sheet/sheet-content.svelte
@@ -1,12 +1,6 @@
 <script lang="ts">
 	import { Dialog as SheetPrimitive } from "bits-ui";
-	import {
-		SheetOverlay,
-		SheetPortal,
-		sheetVariants,
-		sheetTransitions,
-		type Side
-	} from ".";
+	import { SheetOverlay, SheetPortal, sheetVariants, sheetTransitions, type Side } from ".";
 	import { Cross2 } from "radix-icons-svelte";
 	import { cn } from "$lib/utils";
 	import { fly } from "svelte/transition";

--- a/apps/www/src/lib/registry/new-york/ui/sheet/sheet-description.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/sheet/sheet-description.svelte
@@ -8,9 +8,6 @@
 	export { className as class };
 </script>
 
-<SheetPrimitive.Description
-	class={cn("text-sm text-muted-foreground", className)}
-	{...$$restProps}
->
+<SheetPrimitive.Description class={cn("text-sm text-muted-foreground", className)} {...$$restProps}>
 	<slot />
 </SheetPrimitive.Description>

--- a/apps/www/src/lib/registry/new-york/ui/sheet/sheet-footer.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/sheet/sheet-footer.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <div
-	class={cn(
-		"flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-		className
-	)}
+	class={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
 	{...$$restProps}
 >
 	<slot />

--- a/apps/www/src/lib/registry/new-york/ui/sheet/sheet-header.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/sheet/sheet-header.svelte
@@ -8,9 +8,6 @@
 	export { className as class };
 </script>
 
-<div
-	class={cn("flex flex-col space-y-2 text-center sm:text-left", className)}
-	{...$$restProps}
->
+<div class={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...$$restProps}>
 	<slot />
 </div>

--- a/apps/www/src/lib/registry/new-york/ui/sheet/sheet-overlay.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/sheet/sheet-overlay.svelte
@@ -16,9 +16,6 @@
 <SheetPrimitive.Overlay
 	{transition}
 	{transitionConfig}
-	class={cn(
-		"fixed inset-0 z-50 bg-background/80 backdrop-blur-sm",
-		className
-	)}
+	class={cn("fixed inset-0 z-50 bg-background/80 backdrop-blur-sm", className)}
 	{...$$restProps}
 />

--- a/apps/www/src/lib/registry/new-york/ui/skeleton/skeleton.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/skeleton/skeleton.svelte
@@ -8,7 +8,4 @@
 	export { className as class };
 </script>
 
-<div
-	class={cn("animate-pulse rounded-md bg-primary/10", className)}
-	{...$$restProps}
-/>
+<div class={cn("animate-pulse rounded-md bg-primary/10", className)} {...$$restProps} />

--- a/apps/www/src/lib/registry/new-york/ui/slider/slider.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/slider/slider.svelte
@@ -11,15 +11,10 @@
 
 <SliderPrimitive.Root
 	bind:value
-	class={cn(
-		"relative flex w-full touch-none select-none items-center",
-		className
-	)}
+	class={cn("relative flex w-full touch-none select-none items-center", className)}
 	{...$$restProps}
 >
-	<span
-		class="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20"
-	>
+	<span class="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
 		<SliderPrimitive.Range class="absolute h-full bg-primary" />
 	</span>
 	<SliderPrimitive.Thumb

--- a/apps/www/src/lib/registry/new-york/ui/sonner/sonner.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/sonner/sonner.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-	import {
-		Toaster as Sonner,
-		type ToasterProps as SonnerProps
-	} from "svelte-sonner";
+	import { Toaster as Sonner, type ToasterProps as SonnerProps } from "svelte-sonner";
 	import { mode } from "mode-watcher";
 
 	type $$Props = SonnerProps;
@@ -15,10 +12,8 @@
 		classes: {
 			toast: "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
 			description: "group-[.toast]:text-muted-foreground",
-			actionButton:
-				"group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
-			cancelButton:
-				"group-[.toast]:bg-muted group-[.toast]:text-muted-foreground"
+			actionButton: "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+			cancelButton: "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground"
 		}
 	}}
 	{...$$restProps}

--- a/apps/www/src/lib/registry/new-york/ui/super-form/form-field.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/super-form/form-field.svelte
@@ -27,10 +27,7 @@
 		},
 		handleInput: (
 			e: Event & {
-				currentTarget:
-					| HTMLInputElement
-					| HTMLTextAreaElement
-					| HTMLSelectElement;
+				currentTarget: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
 			}
 		) => {
 			field.updateValue(e.currentTarget.value);

--- a/apps/www/src/lib/registry/new-york/ui/super-form/form-message.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/super-form/form-message.svelte
@@ -9,10 +9,7 @@
 </script>
 
 {#if $errors}
-	<p
-		class={cn("text-[0.8rem] font-medium text-destructive", className)}
-		id={formMessageId}
-	>
+	<p class={cn("text-[0.8rem] font-medium text-destructive", className)} id={formMessageId}>
 		{$errors}
 	</p>
 {/if}

--- a/apps/www/src/lib/registry/new-york/ui/super-form/index.ts
+++ b/apps/www/src/lib/registry/new-york/ui/super-form/index.ts
@@ -9,11 +9,7 @@ import type { FieldAttrs, Form, FormFieldContext, FormStores } from "./types";
 import { formFieldProxy } from "sveltekit-superforms/client";
 import type { AnyZodObject, z } from "zod";
 
-import type {
-	FormPathLeaves,
-	UnwrapEffects,
-	ZodValidation
-} from "sveltekit-superforms";
+import type { FormPathLeaves, UnwrapEffects, ZodValidation } from "sveltekit-superforms";
 
 export const FORM_CONTROL_CONTEXT = "FormFieldControl";
 export const FORM_FIELD_CONTEXT = "FormField";

--- a/apps/www/src/lib/registry/new-york/ui/super-form/types.ts
+++ b/apps/www/src/lib/registry/new-york/ui/super-form/types.ts
@@ -1,9 +1,5 @@
 import type { Writable } from "svelte/store";
-import type {
-	FormPathLeaves,
-	UnwrapEffects,
-	ZodValidation
-} from "sveltekit-superforms";
+import type { FormPathLeaves, UnwrapEffects, ZodValidation } from "sveltekit-superforms";
 import type { SuperForm, formFieldProxy } from "sveltekit-superforms/client";
 import type { AnyZodObject, z } from "zod";
 
@@ -25,8 +21,7 @@ export type Form<T extends ZodValidation<AnyZodObject>> = {
 };
 
 export type FormValidation = ZodValidation<AnyZodObject>;
-export type FormFieldName<T extends ZodValidation<AnyZodObject>> =
-	FormPathLeaves<z.infer<T>>;
+export type FormFieldName<T extends ZodValidation<AnyZodObject>> = FormPathLeaves<z.infer<T>>;
 
 export type FormFieldContext = {
 	name: string;

--- a/apps/www/src/lib/registry/new-york/ui/table/table-caption.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/table/table-caption.svelte
@@ -8,9 +8,6 @@
 	export { className as class };
 </script>
 
-<caption
-	class={cn("mt-4 text-sm text-muted-foreground", className)}
-	{...$$restProps}
->
+<caption class={cn("mt-4 text-sm text-muted-foreground", className)} {...$$restProps}>
 	<slot />
 </caption>

--- a/apps/www/src/lib/registry/new-york/ui/table/table-footer.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/table/table-footer.svelte
@@ -8,9 +8,6 @@
 	export { className as class };
 </script>
 
-<tfoot
-	class={cn("bg-primary font-medium text-primary-foreground", className)}
-	{...$$restProps}
->
+<tfoot class={cn("bg-primary font-medium text-primary-foreground", className)} {...$$restProps}>
 	<slot />
 </tfoot>

--- a/apps/www/src/lib/registry/new-york/ui/table/table-header.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/table/table-header.svelte
@@ -9,11 +9,6 @@
 </script>
 
 <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
-<thead
-	class={cn("[&_tr]:border-b", className)}
-	{...$$restProps}
-	on:click
-	on:keydown
->
+<thead class={cn("[&_tr]:border-b", className)} {...$$restProps} on:click on:keydown>
 	<slot />
 </thead>

--- a/apps/www/src/lib/registry/new-york/ui/table/table.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/table/table.svelte
@@ -9,10 +9,7 @@
 </script>
 
 <div class="w-full overflow-auto">
-	<table
-		class={cn("w-full caption-bottom text-sm", className)}
-		{...$$restProps}
-	>
+	<table class={cn("w-full caption-bottom text-sm", className)} {...$$restProps}>
 		<slot />
 	</table>
 </div>

--- a/apps/www/src/lib/registry/new-york/ui/toggle-group/toggle-group.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/toggle-group/toggle-group.svelte
@@ -6,8 +6,7 @@
 	import { cn } from "$lib/utils";
 
 	type T = $$Generic<"single" | "multiple">;
-	type $$Props = ToggleGroupPrimitive.Props<T> &
-		VariantProps<typeof toggleVariants>;
+	type $$Props = ToggleGroupPrimitive.Props<T> & VariantProps<typeof toggleVariants>;
 
 	let className: string | undefined | null = undefined;
 	export { className as class };

--- a/apps/www/src/lib/registry/schema.ts
+++ b/apps/www/src/lib/registry/schema.ts
@@ -6,11 +6,7 @@ export const registrySchema = z.array(
 		dependencies: z.array(z.string()),
 		registryDependencies: z.array(z.string()),
 		files: z.array(z.string()),
-		type: z.enum([
-			"components:ui",
-			"components:component",
-			"components:example"
-		])
+		type: z.enum(["components:ui", "components:component", "components:example"])
 	})
 );
 

--- a/apps/www/src/lib/utils.ts
+++ b/apps/www/src/lib/utils.ts
@@ -147,9 +147,7 @@ export const flyAndScale = (
 		return valueB;
 	};
 
-	const styleToString = (
-		style: Record<string, number | string | undefined>
-	): string => {
+	const styleToString = (style: Record<string, number | string | undefined>): string => {
 		return Object.keys(style).reduce((str, key) => {
 			if (style[key] === undefined) return str;
 			return str + `${key}:${style[key]};`;

--- a/apps/www/src/routes/+layout.svelte
+++ b/apps/www/src/routes/+layout.svelte
@@ -1,12 +1,7 @@
 <script lang="ts">
 	import { page } from "$app/stores";
 	import { dev, browser } from "$app/environment";
-	import {
-		Metadata,
-		SiteFooter,
-		SiteHeader,
-		TailwindIndicator
-	} from "$components/docs";
+	import { Metadata, SiteFooter, SiteHeader, TailwindIndicator } from "$components/docs";
 	import { updateTheme } from "@/utils";
 	import "../styles/globals.css";
 	import { config } from "@/stores";

--- a/apps/www/src/routes/+page.svelte
+++ b/apps/www/src/routes/+page.svelte
@@ -1,9 +1,5 @@
 <script lang="ts">
-	import {
-		DashboardPage,
-		ExamplesNav,
-		Announcement
-	} from "@/components/docs";
+	import { DashboardPage, ExamplesNav, Announcement } from "@/components/docs";
 	import * as PageHeader from "@/components/docs/page-header";
 	import { Icons } from "@/components/docs/icons";
 	import { buttonVariants } from "@/registry/new-york/ui/button";
@@ -16,8 +12,8 @@
 		<Announcement />
 		<PageHeader.Heading>Build your component library</PageHeader.Heading>
 		<PageHeader.Description>
-			Beautifully designed components that you can copy and paste into
-			your apps. Accessible. Customizable. Open Source.
+			Beautifully designed components that you can copy and paste into your apps. Accessible.
+			Customizable. Open Source.
 		</PageHeader.Description>
 		<p class="text-sm text-center text-orange-700 dark:text-orange-400">
 			This is an unofficial port of <a
@@ -34,9 +30,7 @@
 				class="font-medium underline underline-offset-4">@shadcn</a
 			>.
 		</p>
-		<div
-			class="flex w-full items-center justify-center space-x-4 py-4 md:pb-10"
-		>
+		<div class="flex w-full items-center justify-center space-x-4 py-4 md:pb-10">
 			<a href="/docs" class={cn(buttonVariants())}> Get Started </a>
 			<a
 				target="_blank"

--- a/apps/www/src/routes/docs/+page.svelte
+++ b/apps/www/src/routes/docs/+page.svelte
@@ -16,12 +16,8 @@
 
 <main class="relative py-6 lg:gap-10 lg:py-8 xl:grid xl:grid-cols-[1fr_300px]">
 	<div class="mx-auto w-full min-w-0">
-		<div
-			class="mb-4 flex items-center space-x-1 text-sm text-muted-foreground"
-		>
-			<div class="overflow-hidden text-ellipsis whitespace-nowrap">
-				Docs
-			</div>
+		<div class="mb-4 flex items-center space-x-1 text-sm text-muted-foreground">
+			<div class="overflow-hidden text-ellipsis whitespace-nowrap">Docs</div>
 			<ChevronRight class="h-4 w-4" />
 			<div class="font-medium text-foreground">{doc.title}</div>
 		</div>
@@ -45,9 +41,7 @@
 		<DocsPager />
 	</div>
 	<div class="hidden text-sm xl:block">
-		<div
-			class="sticky top-16 -mt-10 h-[calc(100vh-3.5rem)] overflow-hidden pt-6"
-		>
+		<div class="sticky top-16 -mt-10 h-[calc(100vh-3.5rem)] overflow-hidden pt-6">
 			{#key $page.url.pathname}
 				<TableOfContents />
 			{/key}

--- a/apps/www/src/routes/docs/[...slug]/+page.svelte
+++ b/apps/www/src/routes/docs/[...slug]/+page.svelte
@@ -14,20 +14,13 @@
 	type Component = $$Generic<typeof SvelteComponent<any, any, any>>;
 	$: component = data.component as unknown as Component;
 	$: doc = data.metadata;
-	$: componentSource = data.metadata.source?.replace(
-		"default",
-		$config.style ?? "default"
-	);
+	$: componentSource = data.metadata.source?.replace("default", $config.style ?? "default");
 </script>
 
 <main class="relative py-6 lg:gap-10 lg:py-8 xl:grid xl:grid-cols-[1fr_300px]">
 	<div class="mx-auto w-full min-w-0">
-		<div
-			class="mb-4 flex items-center space-x-1 text-sm text-muted-foreground"
-		>
-			<div class="overflow-hidden text-ellipsis whitespace-nowrap">
-				Docs
-			</div>
+		<div class="mb-4 flex items-center space-x-1 text-sm text-muted-foreground">
+			<div class="overflow-hidden text-ellipsis whitespace-nowrap">Docs</div>
 			<ChevronRight class="h-4 w-4" />
 			<div class="font-medium text-foreground">{doc.title}</div>
 		</div>
@@ -50,10 +43,7 @@
 						href={componentSource}
 						target="_blank"
 						rel="noreferrer"
-						class={cn(
-							badgeVariants({ variant: "secondary" }),
-							"gap-1"
-						)}
+						class={cn(badgeVariants({ variant: "secondary" }), "gap-1")}
 					>
 						Component Source
 						<Code class="h-3.5 w-3.5" />
@@ -64,10 +54,7 @@
 						href={doc.bits}
 						target="_blank"
 						rel="noreferrer"
-						class={cn(
-							badgeVariants({ variant: "secondary" }),
-							"gap-1"
-						)}
+						class={cn(badgeVariants({ variant: "secondary" }), "gap-1")}
 					>
 						Primitive API Reference
 						<ExternalLink class="h-3 w-3" />
@@ -81,9 +68,7 @@
 		<DocsPager />
 	</div>
 	<div class="hidden text-sm xl:block">
-		<div
-			class="sticky top-16 -mt-10 h-[calc(100vh-3.5rem)] overflow-hidden pt-4"
-		>
+		<div class="sticky top-16 -mt-10 h-[calc(100vh-3.5rem)] overflow-hidden pt-4">
 			{#key $page.url.pathname}
 				<TableOfContents />
 			{/key}

--- a/apps/www/src/routes/examples/+layout.svelte
+++ b/apps/www/src/routes/examples/+layout.svelte
@@ -7,28 +7,20 @@
 <div class="container relative pb-10">
 	<PageHeader.Root>
 		<Announcement />
-		<PageHeader.Heading class="hidden md:block">
-			Check out some examples
-		</PageHeader.Heading>
+		<PageHeader.Heading class="hidden md:block">Check out some examples</PageHeader.Heading>
 		<PageHeader.Heading class="md:hidden">Examples</PageHeader.Heading>
 		<PageHeader.Description>
-			Dashboard, cards, authentication. Some examples built using the
-			components. Use this as a guide to build your own.
+			Dashboard, cards, authentication. Some examples built using the components. Use this as
+			a guide to build your own.
 		</PageHeader.Description>
-		<section
-			class="flex w-full items-center justify-center space-x-4 py-4 md:pb-10"
-		>
+		<section class="flex w-full items-center justify-center space-x-4 py-4 md:pb-10">
 			<Button href="/docs" class="rounded-[6px]">Get Started</Button>
-			<Button href="/components" variant="outline" class="rounded-[6px]"
-				>Components</Button
-			>
+			<Button href="/components" variant="outline" class="rounded-[6px]">Components</Button>
 		</section>
 	</PageHeader.Root>
 	<section>
 		<ExamplesNav />
-		<div
-			class="overflow-hidden rounded-[0.5rem] border bg-background shadow-xl"
-		>
+		<div class="overflow-hidden rounded-[0.5rem] border bg-background shadow-xl">
 			<slot />
 		</div>
 	</section>

--- a/apps/www/src/routes/examples/authentication/(components)/user-auth-form.svelte
+++ b/apps/www/src/routes/examples/authentication/(components)/user-auth-form.svelte
@@ -46,9 +46,7 @@
 			<span class="w-full border-t" />
 		</div>
 		<div class="relative flex justify-center text-xs uppercase">
-			<span class="bg-background px-2 text-muted-foreground">
-				Or continue with
-			</span>
+			<span class="bg-background px-2 text-muted-foreground"> Or continue with </span>
 		</div>
 	</div>
 	<Button variant="outline" type="button" disabled={isLoading}>

--- a/apps/www/src/routes/examples/authentication/+page.svelte
+++ b/apps/www/src/routes/examples/authentication/+page.svelte
@@ -29,9 +29,7 @@
 	>
 		Login
 	</Button>
-	<div
-		class="relative hidden h-full flex-col bg-muted p-10 text-white dark:border-r lg:flex"
-	>
+	<div class="relative hidden h-full flex-col bg-muted p-10 text-white dark:border-r lg:flex">
 		<div
 			class="absolute inset-0 bg-cover"
 			style="
@@ -45,22 +43,18 @@
 		<div class="relative z-20 mt-auto">
 			<blockquote class="space-y-2">
 				<p class="text-lg">
-					&ldquo;This library has saved me countless hours of work and
-					helped me deliver stunning designs to my clients faster than
-					ever before. Highly recommended!&rdquo;
+					&ldquo;This library has saved me countless hours of work and helped me deliver
+					stunning designs to my clients faster than ever before. Highly
+					recommended!&rdquo;
 				</p>
 				<footer class="text-sm">Sofia Davis</footer>
 			</blockquote>
 		</div>
 	</div>
 	<div class="lg:p-8">
-		<div
-			class="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[350px]"
-		>
+		<div class="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[350px]">
 			<div class="flex flex-col space-y-2 text-center">
-				<h1 class="text-2xl font-semibold tracking-tight">
-					Create an account
-				</h1>
+				<h1 class="text-2xl font-semibold tracking-tight">Create an account</h1>
 				<p class="text-sm text-muted-foreground">
 					Enter your email below to create your account
 				</p>
@@ -68,17 +62,11 @@
 			<UserAuthForm />
 			<p class="px-8 text-center text-sm text-muted-foreground">
 				By clicking continue, you agree to our{" "}
-				<a
-					href="/terms"
-					class="underline underline-offset-4 hover:text-primary"
-				>
+				<a href="/terms" class="underline underline-offset-4 hover:text-primary">
 					Terms of Service
 				</a>{" "}
 				and{" "}
-				<a
-					href="/privacy"
-					class="underline underline-offset-4 hover:text-primary"
-				>
+				<a href="/privacy" class="underline underline-offset-4 hover:text-primary">
 					Privacy Policy
 				</a>
 				.

--- a/apps/www/src/routes/examples/cards/(components)/cookie-settings.svelte
+++ b/apps/www/src/routes/examples/cards/(components)/cookie-settings.svelte
@@ -14,11 +14,8 @@
 		<div class="flex items-center justify-between space-x-2">
 			<Label for="necessary" class="flex flex-col space-y-1">
 				<span>Strictly Necessary</span>
-				<span
-					class="text-xs font-normal leading-snug text-muted-foreground"
-				>
-					These cookies are essential in order to use the website and
-					use its features.
+				<span class="text-xs font-normal leading-snug text-muted-foreground">
+					These cookies are essential in order to use the website and use its features.
 				</span>
 			</Label>
 			<Switch id="necessary" checked aria-label="Necessary" />
@@ -26,11 +23,8 @@
 		<div class="flex items-center justify-between space-x-2">
 			<Label for="functional" class="flex flex-col space-y-1">
 				<span>Functional Cookies</span>
-				<span
-					class="text-xs font-normal leading-snug text-muted-foreground"
-				>
-					These cookies allow the website to provide personalized
-					functionality.
+				<span class="text-xs font-normal leading-snug text-muted-foreground">
+					These cookies allow the website to provide personalized functionality.
 				</span>
 			</Label>
 			<Switch id="functional" aria-label="Functional" />
@@ -38,11 +32,8 @@
 		<div class="flex items-center justify-between space-x-2">
 			<Label for="performance" class="flex flex-col space-y-1">
 				<span>Performance Cookies</span>
-				<span
-					class="text-xs font-normal leading-snug text-muted-foreground"
-				>
-					These cookies help to improve the performance of the
-					website.
+				<span class="text-xs font-normal leading-snug text-muted-foreground">
+					These cookies help to improve the performance of the website.
 				</span>
 			</Label>
 			<Switch id="performance" aria-label="Performance" />

--- a/apps/www/src/routes/examples/cards/(components)/create-account.svelte
+++ b/apps/www/src/routes/examples/cards/(components)/create-account.svelte
@@ -9,9 +9,7 @@
 <Card.Root>
 	<Card.Header class="space-y-1">
 		<Card.Title class="text-2xl">Create an account</Card.Title>
-		<Card.Description>
-			Enter your email below to create your account
-		</Card.Description>
+		<Card.Description>Enter your email below to create your account</Card.Description>
 	</Card.Header>
 	<Card.Content class="grid gap-4">
 		<div class="grid grid-cols-2 gap-6">
@@ -29,9 +27,7 @@
 				<span class="w-full border-t" />
 			</div>
 			<div class="relative flex justify-center text-xs uppercase">
-				<span class="bg-card px-2 text-muted-foreground">
-					Or continue with
-				</span>
+				<span class="bg-card px-2 text-muted-foreground"> Or continue with </span>
 			</div>
 		</div>
 		<div class="grid gap-2">

--- a/apps/www/src/routes/examples/cards/(components)/demo-container.svelte
+++ b/apps/www/src/routes/examples/cards/(components)/demo-container.svelte
@@ -5,9 +5,6 @@
 	export { className as class };
 </script>
 
-<div
-	class={cn("flex items-center justify-center [&>div]:w-full", className)}
-	{...$$restProps}
->
+<div class={cn("flex items-center justify-center [&>div]:w-full", className)} {...$$restProps}>
 	<slot />
 </div>

--- a/apps/www/src/routes/examples/cards/(components)/github.svelte
+++ b/apps/www/src/routes/examples/cards/(components)/github.svelte
@@ -11,13 +11,10 @@
 		<div class="space-y-1">
 			<Card.Title>shadcn/ui</Card.Title>
 			<Card.Description>
-				Beautifully designed components built with Radix UI and Tailwind
-				CSS.
+				Beautifully designed components built with Radix UI and Tailwind CSS.
 			</Card.Description>
 		</div>
-		<div
-			class="flex items-center space-x-1 rounded-md bg-secondary text-secondary-foreground"
-		>
+		<div class="flex items-center space-x-1 rounded-md bg-secondary text-secondary-foreground">
 			<Button variant="secondary" class="px-3 shadow-none">
 				<Star class="mr-2 h-4 w-4" />
 				Star
@@ -25,28 +22,16 @@
 			<Separator orientation="vertical" class="h-[20px]" />
 			<DropdownMenu.Root>
 				<DropdownMenu.Trigger asChild let:builder>
-					<Button
-						builders={[builder]}
-						variant="secondary"
-						class="px-2 shadow-none"
-					>
-						<ChevronDown
-							class="h-4 w-4 text-secondary-foreground"
-						/>
+					<Button builders={[builder]} variant="secondary" class="px-2 shadow-none">
+						<ChevronDown class="h-4 w-4 text-secondary-foreground" />
 					</Button>
 				</DropdownMenu.Trigger>
 				<DropdownMenu.Content class="w-[200px]" align="end">
 					<DropdownMenu.Label>Suggested Lists</DropdownMenu.Label>
 					<DropdownMenu.Separator />
-					<DropdownMenu.CheckboxItem checked>
-						Future Ideas
-					</DropdownMenu.CheckboxItem>
-					<DropdownMenu.CheckboxItem
-						>My Stack</DropdownMenu.CheckboxItem
-					>
-					<DropdownMenu.CheckboxItem
-						>Inspiration</DropdownMenu.CheckboxItem
-					>
+					<DropdownMenu.CheckboxItem checked>Future Ideas</DropdownMenu.CheckboxItem>
+					<DropdownMenu.CheckboxItem>My Stack</DropdownMenu.CheckboxItem>
+					<DropdownMenu.CheckboxItem>Inspiration</DropdownMenu.CheckboxItem>
 					<DropdownMenu.Separator />
 					<DropdownMenu.Item>
 						<Plus class="mr-2 h-4 w-4" /> Create List

--- a/apps/www/src/routes/examples/cards/(components)/notifications.svelte
+++ b/apps/www/src/routes/examples/cards/(components)/notifications.svelte
@@ -6,9 +6,7 @@
 <Card.Root>
 	<Card.Header class="pb-3">
 		<Card.Title>Notifications</Card.Title>
-		<Card.Description>
-			Choose what you want to be notified about.
-		</Card.Description>
+		<Card.Description>Choose what you want to be notified about.</Card.Description>
 	</Card.Header>
 	<Card.Content class="grid gap-1">
 		<div
@@ -17,9 +15,7 @@
 			<Bell class="mt-px h-5 w-5" />
 			<div class="space-y-1">
 				<p class="text-sm font-medium leading-none">Everything</p>
-				<p class="text-sm text-muted-foreground">
-					Email digest, mentions & all activity.
-				</p>
+				<p class="text-sm text-muted-foreground">Email digest, mentions & all activity.</p>
 			</div>
 		</div>
 		<div
@@ -28,9 +24,7 @@
 			<Person class="mt-px h-5 w-5" />
 			<div class="space-y-1">
 				<p class="text-sm font-medium leading-none">Available</p>
-				<p class="text-sm text-muted-foreground">
-					Only mentions and comments.
-				</p>
+				<p class="text-sm text-muted-foreground">Only mentions and comments.</p>
 			</div>
 		</div>
 		<div
@@ -39,9 +33,7 @@
 			<EyeNone class="mt-px h-5 w-5" />
 			<div class="space-y-1">
 				<p class="text-sm font-medium leading-none">Ignoring</p>
-				<p class="text-sm text-muted-foreground">
-					Turn off all notifications.
-				</p>
+				<p class="text-sm text-muted-foreground">Turn off all notifications.</p>
 			</div>
 		</div>
 	</Card.Content>

--- a/apps/www/src/routes/examples/cards/(components)/payment-method.svelte
+++ b/apps/www/src/routes/examples/cards/(components)/payment-method.svelte
@@ -26,9 +26,7 @@
 <Card.Root>
 	<Card.Header>
 		<Card.Title>Payment Method</Card.Title>
-		<Card.Description>
-			Add a new payment method to your account.
-		</Card.Description>
+		<Card.Description>Add a new payment method to your account.</Card.Description>
 	</Card.Header>
 	<Card.Content class="grid gap-6">
 		<RadioGroup.Root value="card" class="grid grid-cols-3 gap-4">
@@ -36,12 +34,7 @@
 				for="card"
 				class="flex flex-col items-center justify-between rounded-md border-2 border-muted bg-popover p-4 hover:bg-accent hover:text-accent-foreground [&:has([data-state=checked])]:border-primary"
 			>
-				<RadioGroup.Item
-					value="card"
-					id="card"
-					class="sr-only"
-					aria-label="Card"
-				/>
+				<RadioGroup.Item value="card" id="card" class="sr-only" aria-label="Card" />
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
 					viewBox="0 0 24 24"
@@ -61,12 +54,7 @@
 				for="paypal"
 				class="flex flex-col items-center justify-between rounded-md border-2 border-muted bg-popover p-4 hover:bg-accent hover:text-accent-foreground [&:has([data-state=checked])]:border-primary"
 			>
-				<RadioGroup.Item
-					value="paypal"
-					id="paypal"
-					class="sr-only"
-					aria-label="Paypal"
-				/>
+				<RadioGroup.Item value="paypal" id="paypal" class="sr-only" aria-label="Paypal" />
 				<Icons.paypal class="mb-3 h-6 w-6" />
 				Paypal
 			</Label>
@@ -74,12 +62,7 @@
 				for="apple"
 				class="flex flex-col items-center justify-between rounded-md border-2 border-muted bg-popover p-4 hover:bg-accent hover:text-accent-foreground [&:has([data-state=checked])]:border-primary"
 			>
-				<RadioGroup.Item
-					value="apple"
-					id="apple"
-					class="sr-only"
-					aria-label="Apple"
-				/>
+				<RadioGroup.Item value="apple" id="apple" class="sr-only" aria-label="Apple" />
 				<Icons.apple class="mb-3 h-6 w-6" />
 				Apple
 			</Label>
@@ -101,9 +84,7 @@
 					</Select.Trigger>
 					<Select.Content>
 						{#each months as month, i}
-							<Select.Item value={i + 1} label={month}
-								>{month}</Select.Item
-							>
+							<Select.Item value={i + 1} label={month}>{month}</Select.Item>
 						{/each}
 					</Select.Content>
 				</Select.Root>

--- a/apps/www/src/routes/examples/cards/(components)/report-issue.svelte
+++ b/apps/www/src/routes/examples/cards/(components)/report-issue.svelte
@@ -52,9 +52,7 @@
 <Card.Root>
 	<Card.Header>
 		<Card.Title>Report an issue</Card.Title>
-		<Card.Description
-			>What area are you having problems with?</Card.Description
-		>
+		<Card.Description>What area are you having problems with?</Card.Description>
 	</Card.Header>
 	<Card.Content class="grid gap-6">
 		<div class="grid grid-cols-2 gap-4">
@@ -76,10 +74,7 @@
 			<div class="grid gap-2">
 				<Label for="security-level">Security Level</Label>
 				<Select.Root selected={securityLevels[1]}>
-					<Select.Trigger
-						id="security-level"
-						class="line-clamp-1 w-[160px] truncate"
-					>
+					<Select.Trigger id="security-level" class="line-clamp-1 w-[160px] truncate">
 						<Select.Value placeholder="Select level" />
 					</Select.Trigger>
 					<Select.Content>

--- a/apps/www/src/routes/examples/cards/(components)/share.svelte
+++ b/apps/www/src/routes/examples/cards/(components)/share.svelte
@@ -42,9 +42,7 @@
 <Card.Root>
 	<Card.Header>
 		<Card.Title>Share this document</Card.Title>
-		<Card.Description>
-			Anyone with the link can view this document.
-		</Card.Description>
+		<Card.Description>Anyone with the link can view this document.</Card.Description>
 	</Card.Header>
 	<Card.Content>
 		<div class="flex space-x-2">
@@ -61,9 +59,7 @@
 						<div class="flex items-center space-x-4">
 							<Avatar.Root>
 								<Avatar.Image src={person.avatar} />
-								<Avatar.Fallback
-									>{name[0][0] + name[1][0]}</Avatar.Fallback
-								>
+								<Avatar.Fallback>{name[0][0] + name[1][0]}</Avatar.Fallback>
 							</Avatar.Root>
 							<div>
 								<p class="text-sm font-medium leading-none">
@@ -80,9 +76,7 @@
 							</Select.Trigger>
 							<Select.Content>
 								{#each permissions as permission}
-									<Select.Item
-										value={permission.value}
-										label={permission.label}
+									<Select.Item value={permission.value} label={permission.label}
 										>{permission.label}</Select.Item
 									>
 								{/each}

--- a/apps/www/src/routes/examples/cards/(components)/team-members.svelte
+++ b/apps/www/src/routes/examples/cards/(components)/team-members.svelte
@@ -10,9 +10,7 @@
 <Card.Root>
 	<Card.Header>
 		<Card.Title>Team Members</Card.Title>
-		<Card.Description
-			>Invite your team members to collaborate</Card.Description
-		>
+		<Card.Description>Invite your team members to collaborate</Card.Description>
 	</Card.Header>
 	<Card.Content class="grid gap-6">
 		<div class="flex items-center justify-between space-x-4">
@@ -28,15 +26,9 @@
 			</div>
 			<Popover.Root>
 				<Popover.Trigger asChild let:builder>
-					<Button
-						builders={[builder]}
-						variant="outline"
-						class="ml-auto"
-					>
+					<Button builders={[builder]} variant="outline" class="ml-auto">
 						Owner
-						<ChevronDown
-							class="ml-2 h-4 w-4 text-muted-foreground"
-						/>
+						<ChevronDown class="ml-2 h-4 w-4 text-muted-foreground" />
 					</Button>
 				</Popover.Trigger>
 				<Popover.Content class="p-0" align="end">
@@ -45,33 +37,25 @@
 						<Command.List>
 							<Command.Empty>No roles found.</Command.Empty>
 							<Command.Group>
-								<Command.Item
-									class="space-y-1 flex flex-col items-start px-4 py-2"
-								>
+								<Command.Item class="space-y-1 flex flex-col items-start px-4 py-2">
 									<p>Viewer</p>
 									<p class="text-sm text-muted-foreground">
 										Can view and comment.
 									</p>
 								</Command.Item>
-								<Command.Item
-									class="space-y-1 flex flex-col items-start px-4 py-2"
-								>
+								<Command.Item class="space-y-1 flex flex-col items-start px-4 py-2">
 									<p>Developer</p>
 									<p class="text-sm text-muted-foreground">
 										Can view, comment, and edit.
 									</p>
 								</Command.Item>
-								<Command.Item
-									class="space-y-1 flex flex-col items-start px-4 py-2"
-								>
+								<Command.Item class="space-y-1 flex flex-col items-start px-4 py-2">
 									<p>Billing</p>
 									<p class="text-sm text-muted-foreground">
 										Can view, comment and manage billing.
 									</p>
 								</Command.Item>
-								<Command.Item
-									class="space-y-1 flex flex-col items-start px-4 py-2"
-								>
+								<Command.Item class="space-y-1 flex flex-col items-start px-4 py-2">
 									<p>Owner</p>
 									<p class="text-sm text-muted-foreground">
 										Admin-level access to all resources.
@@ -96,15 +80,9 @@
 			</div>
 			<Popover.Root>
 				<Popover.Trigger asChild let:builder>
-					<Button
-						builders={[builder]}
-						variant="outline"
-						class="ml-auto"
-					>
+					<Button builders={[builder]} variant="outline" class="ml-auto">
 						Member
-						<ChevronDown
-							class="ml-2 h-4 w-4 text-muted-foreground"
-						/>
+						<ChevronDown class="ml-2 h-4 w-4 text-muted-foreground" />
 					</Button>
 				</Popover.Trigger>
 				<Popover.Content class="p-0" align="end">
@@ -113,33 +91,25 @@
 						<Command.List>
 							<Command.Empty>No roles found.</Command.Empty>
 							<Command.Group>
-								<Command.Item
-									class="space-y-1 flex flex-col items-start px-4 py-2"
-								>
+								<Command.Item class="space-y-1 flex flex-col items-start px-4 py-2">
 									<p>Viewer</p>
 									<p class="text-sm text-muted-foreground">
 										Can view and comment.
 									</p>
 								</Command.Item>
-								<Command.Item
-									class="space-y-1 flex flex-col items-start px-4 py-2"
-								>
+								<Command.Item class="space-y-1 flex flex-col items-start px-4 py-2">
 									<p>Developer</p>
 									<p class="text-sm text-muted-foreground">
 										Can view, comment, and edit.
 									</p>
 								</Command.Item>
-								<Command.Item
-									class="space-y-1 flex flex-col items-start px-4 py-2"
-								>
+								<Command.Item class="space-y-1 flex flex-col items-start px-4 py-2">
 									<p>Billing</p>
 									<p class="text-sm text-muted-foreground">
 										Can view, comment and manage billing.
 									</p>
 								</Command.Item>
-								<Command.Item
-									class="space-y-1 flex flex-col items-start px-4 py-2"
-								>
+								<Command.Item class="space-y-1 flex flex-col items-start px-4 py-2">
 									<p>Owner</p>
 									<p class="text-sm text-muted-foreground">
 										Admin-level access to all resources.

--- a/apps/www/src/routes/examples/data-table/data-table-actions.svelte
+++ b/apps/www/src/routes/examples/data-table/data-table-actions.svelte
@@ -8,11 +8,7 @@
 
 <DropdownMenu.Root>
 	<DropdownMenu.Trigger asChild let:builder>
-		<Button
-			variant="ghost"
-			builders={[builder]}
-			class="w-8 h-8 p- relative"
-		>
+		<Button variant="ghost" builders={[builder]} class="w-8 h-8 p- relative">
 			<span class="sr-only">Open menu</span>
 			<DotsHorizontal class="w-4 h-4" />
 		</Button>
@@ -20,9 +16,7 @@
 	<DropdownMenu.Content>
 		<DropdownMenu.Group>
 			<DropdownMenu.Label>Actions</DropdownMenu.Label>
-			<DropdownMenu.Item
-				on:click={() => navigator.clipboard.writeText(id)}
-			>
+			<DropdownMenu.Item on:click={() => navigator.clipboard.writeText(id)}>
 				Copy payment ID
 			</DropdownMenu.Item>
 		</DropdownMenu.Group>

--- a/apps/www/src/routes/examples/data-table/data-table.svelte
+++ b/apps/www/src/routes/examples/data-table/data-table.svelte
@@ -1,10 +1,5 @@
 <script lang="ts">
-	import {
-		createTable,
-		Subscribe,
-		Render,
-		createRender
-	} from "svelte-headless-table";
+	import { createTable, Subscribe, Render, createRender } from "svelte-headless-table";
 	import {
 		addSortBy,
 		addPagination,
@@ -137,15 +132,8 @@
 		})
 	]);
 
-	const {
-		headerRows,
-		pageRows,
-		tableAttrs,
-		tableBodyAttrs,
-		flatColumns,
-		pluginStates,
-		rows
-	} = table.createViewModel(columns);
+	const { headerRows, pageRows, tableAttrs, tableBodyAttrs, flatColumns, pluginStates, rows } =
+		table.createViewModel(columns);
 
 	const { sortKeys } = pluginStates.sort;
 
@@ -182,9 +170,7 @@
 			<DropdownMenu.Content>
 				{#each flatColumns as col}
 					{#if hideableCols.includes(col.id)}
-						<DropdownMenu.CheckboxItem
-							bind:checked={hideForId[col.id]}
-						>
+						<DropdownMenu.CheckboxItem bind:checked={hideForId[col.id]}>
 							{col.header}
 						</DropdownMenu.CheckboxItem>
 					{/if}
@@ -207,22 +193,16 @@
 								>
 									<Table.Head
 										{...attrs}
-										class={cn(
-											"[&:has([role=checkbox])]:pl-3"
-										)}
+										class={cn("[&:has([role=checkbox])]:pl-3")}
 									>
 										{#if props.sort.disabled}
 											<Render of={cell.render()} />
 										{:else}
-											<Button
-												variant="ghost"
-												on:click={props.sort.toggle}
-											>
+											<Button variant="ghost" on:click={props.sort.toggle}>
 												<Render of={cell.render()} />
 												<CaretSort
 													class={cn(
-														$sortKeys[0]?.id ===
-															cell.id &&
+														$sortKeys[0]?.id === cell.id &&
 															"text-foreground",
 														"ml-2 h-4 w-4"
 													)}
@@ -245,10 +225,7 @@
 						>
 							{#each row.cells as cell (cell.id)}
 								<Subscribe attrs={cell.attrs()} let:attrs>
-									<Table.Cell
-										class="[&:has([role=checkbox])]:pl-3"
-										{...attrs}
-									>
+									<Table.Cell class="[&:has([role=checkbox])]:pl-3" {...attrs}>
 										<Render of={cell.render()} />
 									</Table.Cell>
 								</Subscribe>

--- a/apps/www/src/routes/examples/forms/(components)/sidebar-nav.svelte
+++ b/apps/www/src/routes/examples/forms/(components)/sidebar-nav.svelte
@@ -7,12 +7,7 @@
 	export { className as class };
 </script>
 
-<nav
-	class={cn(
-		"flex space-x-2 lg:flex-col lg:space-x-0 lg:space-y-1",
-		className
-	)}
->
+<nav class={cn("flex space-x-2 lg:flex-col lg:space-x-0 lg:space-y-1", className)}>
 	{#each items as item}
 		<Button
 			href={item.href}

--- a/apps/www/src/routes/examples/forms/+page.svelte
+++ b/apps/www/src/routes/examples/forms/+page.svelte
@@ -8,9 +8,7 @@
 <div class="space-y-6">
 	<div>
 		<h3 class="text-lg font-medium">Profile</h3>
-		<p class="text-sm text-muted-foreground">
-			This is how others will see you on the site.
-		</p>
+		<p class="text-sm text-muted-foreground">This is how others will see you on the site.</p>
 	</div>
 	<Separator />
 	<ProfileForm data={data.form} />

--- a/apps/www/src/routes/examples/forms/account/+page.svelte
+++ b/apps/www/src/routes/examples/forms/account/+page.svelte
@@ -10,8 +10,7 @@
 	<div>
 		<h3 class="text-lg font-medium">Account</h3>
 		<p class="text-sm text-muted-foreground">
-			Update your account settings. Set your preferred language and
-			timezone.
+			Update your account settings. Set your preferred language and timezone.
 		</p>
 	</div>
 	<Separator />

--- a/apps/www/src/routes/examples/forms/account/account-form.svelte
+++ b/apps/www/src/routes/examples/forms/account/account-form.svelte
@@ -50,8 +50,7 @@
 			<Form.Label>Name</Form.Label>
 			<Form.Input placeholder="Your name" />
 			<Form.Description>
-				This is the name that will be displayed on your profile and in
-				emails.
+				This is the name that will be displayed on your profile and in emails.
 			</Form.Description>
 			<Form.Validation />
 		</Form.Field>

--- a/apps/www/src/routes/examples/forms/appearance/+page.svelte
+++ b/apps/www/src/routes/examples/forms/appearance/+page.svelte
@@ -10,8 +10,7 @@
 	<div>
 		<h3 class="text-lg font-medium">Appearance</h3>
 		<p class="text-sm text-muted-foreground">
-			Customize the appearance of the app. Automatically switch between
-			day and night themes.
+			Customize the appearance of the app. Automatically switch between day and night themes.
 		</p>
 	</div>
 	<Separator />

--- a/apps/www/src/routes/examples/forms/appearance/appearance-form.svelte
+++ b/apps/www/src/routes/examples/forms/appearance/appearance-form.svelte
@@ -39,112 +39,67 @@
 					<option value="system">System</option>
 				</Form.NativeSelect>
 			</div>
-			<Form.Description>
-				Set the font you want to use in the dashboard.
-			</Form.Description>
+			<Form.Description>Set the font you want to use in the dashboard.</Form.Description>
 			<Form.Validation />
 		</Form.Field>
 	</Form.Item>
 	<Form.Item>
 		<Form.Field {config} name="theme">
 			<Form.Label>Theme</Form.Label>
-			<Form.Description
-				>Select the theme for the dashboard.</Form.Description
-			>
+			<Form.Description>Select the theme for the dashboard.</Form.Description>
 			<Form.Validation />
-			<Form.RadioGroup
-				class="grid max-w-md grid-cols-2 gap-8 pt-2"
-				orientation="horizontal"
-			>
-				<Label
-					for="light"
-					class="[&:has([data-state=checked])>div]:border-primary"
-				>
+			<Form.RadioGroup class="grid max-w-md grid-cols-2 gap-8 pt-2" orientation="horizontal">
+				<Label for="light" class="[&:has([data-state=checked])>div]:border-primary">
 					<Form.RadioItem id="light" value="light" class="sr-only" />
 					<div
 						class="items-center rounded-md border-2 border-muted p-1 hover:border-accent"
 					>
 						<div class="space-y-2 rounded-sm bg-[#ecedef] p-2">
-							<div
-								class="space-y-2 rounded-md bg-white p-2 shadow-sm"
-							>
-								<div
-									class="h-2 w-[80px] rounded-lg bg-[#ecedef]"
-								/>
-								<div
-									class="h-2 w-[100px] rounded-lg bg-[#ecedef]"
-								/>
+							<div class="space-y-2 rounded-md bg-white p-2 shadow-sm">
+								<div class="h-2 w-[80px] rounded-lg bg-[#ecedef]" />
+								<div class="h-2 w-[100px] rounded-lg bg-[#ecedef]" />
 							</div>
 							<div
 								class="flex items-center space-x-2 rounded-md bg-white p-2 shadow-sm"
 							>
-								<div
-									class="h-4 w-4 rounded-full bg-[#ecedef]"
-								/>
-								<div
-									class="h-2 w-[100px] rounded-lg bg-[#ecedef]"
-								/>
+								<div class="h-4 w-4 rounded-full bg-[#ecedef]" />
+								<div class="h-2 w-[100px] rounded-lg bg-[#ecedef]" />
 							</div>
 							<div
 								class="flex items-center space-x-2 rounded-md bg-white p-2 shadow-sm"
 							>
-								<div
-									class="h-4 w-4 rounded-full bg-[#ecedef]"
-								/>
-								<div
-									class="h-2 w-[100px] rounded-lg bg-[#ecedef]"
-								/>
+								<div class="h-4 w-4 rounded-full bg-[#ecedef]" />
+								<div class="h-2 w-[100px] rounded-lg bg-[#ecedef]" />
 							</div>
 						</div>
 					</div>
-					<span class="block w-full p-2 text-center font-normal">
-						Light
-					</span>
+					<span class="block w-full p-2 text-center font-normal"> Light </span>
 				</Label>
-				<Label
-					for="dark"
-					class="[&:has([data-state=checked])>div]:border-primary"
-				>
+				<Label for="dark" class="[&:has([data-state=checked])>div]:border-primary">
 					<Form.RadioItem id="dark" value="dark" class="sr-only" />
 					<div
 						class="items-center rounded-md border-2 border-muted bg-popover p-1 hover:bg-accent hover:text-accent-foreground"
 					>
 						<div class="space-y-2 rounded-sm bg-slate-950 p-2">
-							<div
-								class="space-y-2 rounded-md bg-slate-800 p-2 shadow-sm"
-							>
-								<div
-									class="h-2 w-[80px] rounded-lg bg-slate-400"
-								/>
-								<div
-									class="h-2 w-[100px] rounded-lg bg-slate-400"
-								/>
+							<div class="space-y-2 rounded-md bg-slate-800 p-2 shadow-sm">
+								<div class="h-2 w-[80px] rounded-lg bg-slate-400" />
+								<div class="h-2 w-[100px] rounded-lg bg-slate-400" />
 							</div>
 							<div
 								class="flex items-center space-x-2 rounded-md bg-slate-800 p-2 shadow-sm"
 							>
-								<div
-									class="h-4 w-4 rounded-full bg-slate-400"
-								/>
-								<div
-									class="h-2 w-[100px] rounded-lg bg-slate-400"
-								/>
+								<div class="h-4 w-4 rounded-full bg-slate-400" />
+								<div class="h-2 w-[100px] rounded-lg bg-slate-400" />
 							</div>
 							<div
 								class="flex items-center space-x-2 rounded-md bg-slate-800 p-2 shadow-sm"
 							>
-								<div
-									class="h-4 w-4 rounded-full bg-slate-400"
-								/>
-								<div
-									class="h-2 w-[100px] rounded-lg bg-slate-400"
-								/>
+								<div class="h-4 w-4 rounded-full bg-slate-400" />
+								<div class="h-2 w-[100px] rounded-lg bg-slate-400" />
 							</div>
 						</div>
 					</div>
-					<span class="block w-full p-2 text-center font-normal">
-						Dark
-					</span>
+					<span class="block w-full p-2 text-center font-normal"> Dark </span>
 				</Label>
 			</Form.RadioGroup>
 		</Form.Field>

--- a/apps/www/src/routes/examples/forms/notifications/+page.svelte
+++ b/apps/www/src/routes/examples/forms/notifications/+page.svelte
@@ -9,9 +9,7 @@
 <div class="space-y-6">
 	<div>
 		<h3 class="text-lg font-medium">Notifications</h3>
-		<p class="text-sm text-muted-foreground">
-			Configure how you receive notifications.
-		</p>
+		<p class="text-sm text-muted-foreground">Configure how you receive notifications.</p>
 	</div>
 	<Separator />
 	<NotificationsForm data={data.form} />

--- a/apps/www/src/routes/examples/forms/notifications/notifications-form.svelte
+++ b/apps/www/src/routes/examples/forms/notifications/notifications-form.svelte
@@ -34,14 +34,11 @@
 			<Form.RadioGroup class="flex flex-col space-y-1">
 				<div class="flex items-center space-x-3">
 					<Form.RadioItem value="all" id="all" />
-					<Label for="all" class="font-normal">All new messages</Label
-					>
+					<Label for="all" class="font-normal">All new messages</Label>
 				</div>
 				<div class="flex items-center space-x-3">
 					<Form.RadioItem value="mentions" id="mentions" />
-					<Label for="mentions" class="font-normal"
-						>Direct messages and mentions</Label
-					>
+					<Label for="mentions" class="font-normal">Direct messages and mentions</Label>
 				</div>
 				<div class="flex items-center space-x-3">
 					<Form.RadioItem value="none" id="none" />
@@ -54,13 +51,9 @@
 		<h3 class="mb-4 text-lg font-medium">Email Notifications</h3>
 		<div class="space-y-4">
 			<Form.Field {config} name="communication_emails">
-				<Form.Item
-					class="flex flex-row items-center justify-between rounded-lg border p-4"
-				>
+				<Form.Item class="flex flex-row items-center justify-between rounded-lg border p-4">
 					<div class="space-y-0.5">
-						<Form.Label class="text-base"
-							>Communication emails</Form.Label
-						>
+						<Form.Label class="text-base">Communication emails</Form.Label>
 						<Form.Description>
 							Receive emails about your account activity.
 						</Form.Description>
@@ -69,46 +62,33 @@
 				</Form.Item>
 			</Form.Field>
 			<Form.Field {config} name="marketing_emails">
-				<Form.Item
-					class="flex flex-row items-center justify-between rounded-lg border p-4"
-				>
+				<Form.Item class="flex flex-row items-center justify-between rounded-lg border p-4">
 					<div class="space-y-0.5">
-						<Form.Label class="text-base"
-							>Marketing emails</Form.Label
-						>
+						<Form.Label class="text-base">Marketing emails</Form.Label>
 						<Form.Description>
-							Receive emails about new products, features, and
-							more.
+							Receive emails about new products, features, and more.
 						</Form.Description>
 					</div>
 					<Form.Switch />
 				</Form.Item>
 			</Form.Field>
 			<Form.Field {config} name="social_emails">
-				<Form.Item
-					class="flex flex-row items-center justify-between rounded-lg border p-4"
-				>
+				<Form.Item class="flex flex-row items-center justify-between rounded-lg border p-4">
 					<div class="space-y-0.5">
 						<Form.Label class="text-base">Social emails</Form.Label>
 						<Form.Description>
-							Receive emails for friend requests, follows, and
-							more.
+							Receive emails for friend requests, follows, and more.
 						</Form.Description>
 					</div>
 					<Form.Switch />
 				</Form.Item>
 			</Form.Field>
 			<Form.Field {config} name="security_emails">
-				<Form.Item
-					class="flex flex-row items-center justify-between rounded-lg border p-4"
-				>
+				<Form.Item class="flex flex-row items-center justify-between rounded-lg border p-4">
 					<div class="space-y-0.5">
-						<Form.Label class="text-base"
-							>Security emails</Form.Label
-						>
+						<Form.Label class="text-base">Security emails</Form.Label>
 						<Form.Description>
-							Receive emails about your account activity and
-							security.
+							Receive emails about your account activity and security.
 						</Form.Description>
 					</div>
 					<Form.Switch />
@@ -120,12 +100,10 @@
 		<Form.Item class="flex flex-row items-start space-x-3 space-y-0">
 			<Form.Checkbox />
 			<div class="space-y-1 leading-none">
-				<Form.Label
-					>Use different settings for my mobile devices</Form.Label
-				>
+				<Form.Label>Use different settings for my mobile devices</Form.Label>
 				<Form.Description>
-					You can manage your mobile notifications in the{" "}<a
-						href="/examples/forms">mobile settings</a
+					You can manage your mobile notifications in the{" "}<a href="/examples/forms"
+						>mobile settings</a
 					> page.
 				</Form.Description>
 			</div>

--- a/apps/www/src/routes/examples/forms/profile-form.svelte
+++ b/apps/www/src/routes/examples/forms/profile-form.svelte
@@ -5,9 +5,7 @@
 			.string()
 			.min(2, "Username must be at least 2 characters.")
 			.max(30, "Username must not be longer than 30 characters"),
-		email: z
-			.string({ required_error: "Please select an email to display" })
-			.email(),
+		email: z.string({ required_error: "Please select an email to display" }).email(),
 		bio: z.string().min(4).max(160).default("I own a computer."),
 		website: z
 			.string()
@@ -37,8 +35,8 @@
 			<Form.Label>Username</Form.Label>
 			<Form.Input placeholder="@shadcn" />
 			<Form.Description>
-				This is your public display name. It can be your real name or a
-				pseudonym. You can only change this once every 30 days.
+				This is your public display name. It can be your real name or a pseudonym. You can
+				only change this once every 30 days.
 			</Form.Description>
 			<Form.Validation />
 		</Form.Field>
@@ -47,9 +45,7 @@
 		<Form.Field {config} name="email">
 			<Form.Label>Email</Form.Label>
 			<Form.Select>
-				<Form.SelectTrigger
-					placeholder="Select a verified email to display"
-				/>
+				<Form.SelectTrigger placeholder="Select a verified email to display" />
 				<Form.SelectContent>
 					<Form.SelectItem value="m@example.com" label="m@example.com"
 						>m@example.com
@@ -63,8 +59,8 @@
 				</Form.SelectContent>
 			</Form.Select>
 			<Form.Description>
-				You can manage verified email addresses in your <a
-					href="/examples/forms">email settings</a
+				You can manage verified email addresses in your <a href="/examples/forms"
+					>email settings</a
 				>.
 			</Form.Description>
 			<Form.Validation />
@@ -73,13 +69,9 @@
 	<Form.Item>
 		<Form.Field {config} name="bio">
 			<Form.Label>Bio</Form.Label>
-			<Form.Textarea
-				placeholder="Tell us a little bit about yourself"
-				class="resize-none"
-			/>
+			<Form.Textarea placeholder="Tell us a little bit about yourself" class="resize-none" />
 			<Form.Description>
-				You can <span>@mention</span> other users and organizations to link
-				to them.
+				You can <span>@mention</span> other users and organizations to link to them.
 			</Form.Description>
 			<Form.Validation />
 		</Form.Field>
@@ -88,9 +80,7 @@
 		<Form.Field {config} name="website">
 			<Form.Label>Website</Form.Label>
 			<Form.Input />
-			<Form.Description>
-				Your personal website, blog, or portfolio.
-			</Form.Description>
+			<Form.Description>Your personal website, blog, or portfolio.</Form.Description>
 			<Form.Validation />
 		</Form.Field>
 	</Form.Item>

--- a/apps/www/src/routes/examples/music/(components)/album-artwork.svelte
+++ b/apps/www/src/routes/examples/music/(components)/album-artwork.svelte
@@ -20,9 +20,7 @@
 				<img
 					class={cn(
 						"h-auto w-auto object-cover transition-all hover:scale-105",
-						aspectRatio === "portrait"
-							? "aspect-[3/4]"
-							: "aspect-square"
+						aspectRatio === "portrait" ? "aspect-[3/4]" : "aspect-square"
 					)}
 					src={album.cover}
 					alt={album.name}

--- a/apps/www/src/routes/examples/music/(components)/menu.svelte
+++ b/apps/www/src/routes/examples/music/(components)/menu.svelte
@@ -34,14 +34,10 @@
 						Playlist <Menubar.Shortcut>⌘N</Menubar.Shortcut>
 					</Menubar.Item>
 					<Menubar.Item disabled>
-						Playlist from Selection <Menubar.Shortcut
-							>⇧⌘N</Menubar.Shortcut
-						>
+						Playlist from Selection <Menubar.Shortcut>⇧⌘N</Menubar.Shortcut>
 					</Menubar.Item>
 					<Menubar.Item>
-						Smart Playlist... <Menubar.Shortcut
-							>⌥⌘N</Menubar.Shortcut
-						>
+						Smart Playlist... <Menubar.Shortcut>⌥⌘N</Menubar.Shortcut>
 					</Menubar.Item>
 					<Menubar.Item>Playlist Folder</Menubar.Item>
 					<Menubar.Item disabled>Genius Playlist</Menubar.Item>
@@ -127,9 +123,7 @@
 						class="h-4 w-4"
 						viewBox="0 0 24 24"
 					>
-						<path
-							d="m12 8-9.04 9.06a2.82 2.82 0 1 0 3.98 3.98L16 12"
-						/>
+						<path d="m12 8-9.04 9.06a2.82 2.82 0 1 0 3.98 3.98L16 12" />
 						<circle cx="17" cy="7" r="5" />
 					</svg>
 				</Menubar.Shortcut>

--- a/apps/www/src/routes/examples/music/(components)/podcast-empty-placeholder.svelte
+++ b/apps/www/src/routes/examples/music/(components)/podcast-empty-placeholder.svelte
@@ -5,12 +5,8 @@
 	import { Label } from "@/registry/new-york/ui/label";
 </script>
 
-<div
-	class="flex h-[450px] shrink-0 items-center justify-center rounded-md border border-dashed"
->
-	<div
-		class="mx-auto flex max-w-[420px] flex-col items-center justify-center text-center"
-	>
+<div class="flex h-[450px] shrink-0 items-center justify-center rounded-md border border-dashed">
+	<div class="mx-auto flex max-w-[420px] flex-col items-center justify-center text-center">
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
 			fill="none"
@@ -34,9 +30,7 @@
 		</p>
 		<Dialog.Root>
 			<Dialog.Trigger asChild let:builder>
-				<Button size="sm" builders={[builder]} class="relative">
-					Add Podcast
-				</Button>
+				<Button size="sm" builders={[builder]} class="relative">Add Podcast</Button>
 			</Dialog.Trigger>
 			<Dialog.Content>
 				<Dialog.Header>
@@ -48,10 +42,7 @@
 				<div class="grid gap-4 py-4">
 					<div class="grid gap-2">
 						<Label for="url">Podcast URL</Label>
-						<Input
-							id="url"
-							placeholder="https://example.com/feed.xml"
-						/>
+						<Input id="url" placeholder="https://example.com/feed.xml" />
 					</div>
 				</div>
 				<Dialog.Footer>

--- a/apps/www/src/routes/examples/music/(components)/sidebar.svelte
+++ b/apps/www/src/routes/examples/music/(components)/sidebar.svelte
@@ -11,9 +11,7 @@
 <div class={cn("pb-12", className)}>
 	<div class="space-y-4 py-4">
 		<div class="px-3 py-2">
-			<h2 class="mb-2 px-4 text-lg font-semibold tracking-tight">
-				Discover
-			</h2>
+			<h2 class="mb-2 px-4 text-lg font-semibold tracking-tight">Discover</h2>
 			<div class="space-y-1">
 				<Button variant="secondary" class="w-full justify-start">
 					<svg
@@ -71,9 +69,7 @@
 			</div>
 		</div>
 		<div class="px-3 py-2">
-			<h2 class="mb-2 px-4 text-lg font-semibold tracking-tight">
-				Library
-			</h2>
+			<h2 class="mb-2 px-4 text-lg font-semibold tracking-tight">Library</h2>
 			<div class="space-y-1">
 				<Button variant="ghost" class="w-full justify-start">
 					<svg
@@ -87,9 +83,7 @@
 						class="mr-2 h-4 w-4"
 					>
 						<path d="M21 15V6" />
-						<path
-							d="M18.5 18a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z"
-						/>
+						<path d="M18.5 18a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z" />
 						<path d="M12 12H3" />
 						<path d="M16 6H3" />
 						<path d="M12 18H3" />
@@ -139,9 +133,7 @@
 						stroke-linejoin="round"
 						class="mr-2 h-4 w-4"
 					>
-						<path
-							d="m12 8-9.04 9.06a2.82 2.82 0 1 0 3.98 3.98L16 12"
-						/>
+						<path d="m12 8-9.04 9.06a2.82 2.82 0 1 0 3.98 3.98L16 12" />
 						<circle cx="17" cy="7" r="5" />
 					</svg>
 					Artists
@@ -167,16 +159,11 @@
 			</div>
 		</div>
 		<div class="py-2">
-			<h2 class="relative px-7 text-lg font-semibold tracking-tight">
-				Playlists
-			</h2>
+			<h2 class="relative px-7 text-lg font-semibold tracking-tight">Playlists</h2>
 			<div class="h-[300px] overflow-y-auto px-1">
 				<div class="space-y-1 p-2">
 					{#each playlists as playlist}
-						<Button
-							variant="ghost"
-							class="w-full justify-start font-normal"
-						>
+						<Button variant="ghost" class="w-full justify-start font-normal">
 							<svg
 								xmlns="http://www.w3.org/2000/svg"
 								viewBox="0 0 24 24"
@@ -188,9 +175,7 @@
 								class="mr-2 h-4 w-4"
 							>
 								<path d="M21 15V6" />
-								<path
-									d="M18.5 18a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z"
-								/>
+								<path d="M18.5 18a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z" />
 								<path d="M12 12H3" />
 								<path d="M16 6H3" />
 								<path d="M12 18H3" />

--- a/apps/www/src/routes/examples/music/+page.svelte
+++ b/apps/www/src/routes/examples/music/+page.svelte
@@ -3,12 +3,7 @@
 	import { Button } from "@/registry/new-york/ui/button";
 	import { Separator } from "@/registry/new-york/ui/separator";
 	import * as Tabs from "@/registry/new-york/ui/tabs";
-	import {
-		AlbumArtwork,
-		Sidebar,
-		Menu,
-		PodcastEmptyPlaceholder
-	} from "./(components)";
+	import { AlbumArtwork, Sidebar, Menu, PodcastEmptyPlaceholder } from "./(components)";
 	import { playlists } from "./(data)/playlists";
 	import { listenNowAlbums, madeForYouAlbums } from "./(data)/albums";
 </script>
@@ -40,18 +35,11 @@
 						<Tabs.Root value="music" class="h-full space-y-6">
 							<div class="space-between flex items-center">
 								<Tabs.List>
-									<Tabs.Trigger
-										value="music"
-										class="relative"
-									>
+									<Tabs.Trigger value="music" class="relative">
 										Music
 									</Tabs.Trigger>
-									<Tabs.Trigger value="podcasts"
-										>Podcasts</Tabs.Trigger
-									>
-									<Tabs.Trigger value="live" disabled
-										>Live</Tabs.Trigger
-									>
+									<Tabs.Trigger value="podcasts">Podcasts</Tabs.Trigger>
+									<Tabs.Trigger value="live" disabled>Live</Tabs.Trigger>
 								</Tabs.List>
 								<div class="ml-auto mr-4">
 									<Button>
@@ -60,20 +48,13 @@
 									</Button>
 								</div>
 							</div>
-							<Tabs.Content
-								value="music"
-								class="border-none p-0 outline-none"
-							>
+							<Tabs.Content value="music" class="border-none p-0 outline-none">
 								<div class="flex items-center justify-between">
 									<div class="space-y-1">
-										<h2
-											class="text-2xl font-semibold tracking-tight"
-										>
+										<h2 class="text-2xl font-semibold tracking-tight">
 											Listen Now
 										</h2>
-										<p
-											class="text-sm text-muted-foreground"
-										>
+										<p class="text-sm text-muted-foreground">
 											Top picks for you. Updated daily.
 										</p>
 									</div>
@@ -95,9 +76,7 @@
 									</div>
 								</div>
 								<div class="mt-6 space-y-1">
-									<h2
-										class="text-2xl font-semibold tracking-tight"
-									>
+									<h2 class="text-2xl font-semibold tracking-tight">
 										Made for You
 									</h2>
 									<p class="text-sm text-muted-foreground">
@@ -127,16 +106,11 @@
 							>
 								<div class="flex items-center justify-between">
 									<div class="space-y-1">
-										<h2
-											class="text-2xl font-semibold tracking-tight"
-										>
+										<h2 class="text-2xl font-semibold tracking-tight">
 											New Episodes
 										</h2>
-										<p
-											class="text-sm text-muted-foreground"
-										>
-											Your favorite podcasts. Updated
-											daily.
+										<p class="text-sm text-muted-foreground">
+											Your favorite podcasts. Updated daily.
 										</p>
 									</div>
 								</div>

--- a/apps/www/src/routes/examples/playground/(components)/code-viewer.svelte
+++ b/apps/www/src/routes/examples/playground/(components)/code-viewer.svelte
@@ -11,60 +11,35 @@
 		<Dialog.Header>
 			<Dialog.Title>View code</Dialog.Title>
 			<Dialog.Description>
-				You can use the following code to start integrating your current
-				prompt and settings into your application.
+				You can use the following code to start integrating your current prompt and settings
+				into your application.
 			</Dialog.Description>
 		</Dialog.Header>
 		<div class="grid gap-4">
 			<div class="rounded-md bg-black p-6">
-				<pre><code
-						class="grid gap-1 text-sm text-muted-foreground [&_span]:h-4"
-						><span><span class="text-sky-300">import</span> os</span
-						><span
-							><span class="text-sky-300">import</span
-							> openai</span
+				<pre><code class="grid gap-1 text-sm text-muted-foreground [&_span]:h-4"
+						><span><span class="text-sky-300">import</span> os</span><span
+							><span class="text-sky-300">import</span> openai</span
 						><span /><span
-							>openai.api_key = os.getenv(<span
-								class="text-green-300"
+							>openai.api_key = os.getenv(<span class="text-green-300"
 								>&quot;OPENAI_API_KEY&quot;</span
 							>)</span
-						><span /><span
-							>response = openai.Completion.create(</span
-						><span
-							>{" "}model=<span class="text-green-300"
-								>&quot;davinci&quot;</span
+						><span /><span>response = openai.Completion.create(</span><span
+							>{" "}model=<span class="text-green-300">&quot;davinci&quot;</span
 							>,</span
-						><span
-							>{" "}prompt=<span class="text-amber-300"
-								>&quot;&quot;</span
-							>,</span
-						><span
-							>{" "}temperature=<span class="text-amber-300"
-								>0.9</span
-							>,</span
-						><span
-							>{" "}max_tokens=<span class="text-amber-300"
-								>5</span
-							>,</span
-						><span
-							>{" "}top_p=<span class="text-amber-300">1</span
-							>,</span
-						><span
-							>{" "}frequency_penalty=<span class="text-amber-300"
-								>0</span
-							>,</span
-						><span
-							>{" "}presence_penalty=<span class="text-green-300"
-								>0</span
-							>,</span
+						><span>{" "}prompt=<span class="text-amber-300">&quot;&quot;</span>,</span
+						><span>{" "}temperature=<span class="text-amber-300">0.9</span>,</span><span
+							>{" "}max_tokens=<span class="text-amber-300">5</span>,</span
+						><span>{" "}top_p=<span class="text-amber-300">1</span>,</span><span
+							>{" "}frequency_penalty=<span class="text-amber-300">0</span>,</span
+						><span>{" "}presence_penalty=<span class="text-green-300">0</span>,</span
 						><span>)</span></code
 					></pre>
 			</div>
 			<div>
 				<p class="text-sm text-muted-foreground">
-					Your API Key can be found here. You should use environment
-					variables or a secret management tool to expose your key to
-					your applications.
+					Your API Key can be found here. You should use environment variables or a secret
+					management tool to expose your key to your applications.
 				</p>
 			</div>
 		</div>

--- a/apps/www/src/routes/examples/playground/(components)/max-length-selector.svelte
+++ b/apps/www/src/routes/examples/playground/(components)/max-length-selector.svelte
@@ -30,9 +30,8 @@
 			</div>
 		</HoverCard.Trigger>
 		<HoverCard.Content class="w-[260px] text-sm" side="left" align="start">
-			The maximum number of tokens to generate. Requests can use up to
-			2,048 or 4,000 tokens, shared between prompt and completion. The
-			exact limit varies by model.
+			The maximum number of tokens to generate. Requests can use up to 2,048 or 4,000 tokens,
+			shared between prompt and completion. The exact limit varies by model.
 		</HoverCard.Content>
 	</HoverCard.Root>
 </div>

--- a/apps/www/src/routes/examples/playground/(components)/model-selector.svelte
+++ b/apps/www/src/routes/examples/playground/(components)/model-selector.svelte
@@ -23,8 +23,7 @@
 
 	let value = "";
 
-	$: selectedValue =
-		models.find((f) => f.id === value)?.name ?? "Select a model...";
+	$: selectedValue = models.find((f) => f.id === value)?.name ?? "Select a model...";
 
 	// We want to refocus the trigger button when the user selects
 	// an item from the list so users can continue navigating the
@@ -45,9 +44,8 @@
 			</div>
 		</HoverCard.Trigger>
 		<HoverCard.Content class="w-[260px] text-sm" align="start" side="left">
-			The model which will generate the completion. Some models are
-			suitable for natural language tasks, others specialize in code.
-			Learn more.
+			The model which will generate the completion. Some models are suitable for natural
+			language tasks, others specialize in code. Learn more.
 		</HoverCard.Content>
 	</HoverCard.Root>
 
@@ -70,11 +68,7 @@
 				open={peekedModel.id !== selectedModel.id}
 				openDelay={0}
 			>
-				<HoverCard.Content
-					class="min-h-[280px] -ml-2"
-					side="left"
-					align="start"
-				>
+				<HoverCard.Content class="min-h-[280px] -ml-2" side="left" align="start">
 					<div class="grid gap-2">
 						<h4 class="font-medium leading-none">
 							{peekedModel.name}
@@ -84,9 +78,7 @@
 						</div>
 						{#if peekedModel.strengths}
 							<div class="mt-4 grid gap-2">
-								<h5 class="text-sm font-medium leading-none">
-									Strengths
-								</h5>
+								<h5 class="text-sm font-medium leading-none">Strengths</h5>
 								<ul class="text-sm text-muted-foreground">
 									{peekedModel.strengths}
 								</ul>
@@ -96,9 +88,7 @@
 				</HoverCard.Content>
 				<Command.Root loop>
 					<Command.Input placeholder="Search Models...." />
-					<Command.List
-						class="h-[var(--cmdk-list-height)] max-h-[400px]"
-					>
+					<Command.List class="h-[var(--cmdk-list-height)] max-h-[400px]">
 						<Command.Empty>No models found.</Command.Empty>
 						{#each types as type}
 							<Command.Group heading={type}>
@@ -120,9 +110,7 @@
 												class="aria-selected:bg-primary aria-selected:text-primary-foreground"
 												onSelect={(currentValue) => {
 													value = currentValue;
-													closeAndFocusTrigger(
-														ids.trigger
-													);
+													closeAndFocusTrigger(ids.trigger);
 												}}
 											>
 												{model.name}

--- a/apps/www/src/routes/examples/playground/(components)/preset-actions.svelte
+++ b/apps/www/src/routes/examples/playground/(components)/preset-actions.svelte
@@ -23,10 +23,7 @@
 			Content filter preferences
 		</DropdownMenu.Item>
 		<DropdownMenu.Separator />
-		<DropdownMenu.Item
-			on:click={() => (showDeleteDialog = true)}
-			class="text-red-600"
-		>
+		<DropdownMenu.Item on:click={() => (showDeleteDialog = true)} class="text-red-600">
 			Delete preset
 		</DropdownMenu.Item>
 	</DropdownMenu.Content>
@@ -36,9 +33,9 @@
 		<Dialog.Header>
 			<Dialog.Title>Content filter preferences</Dialog.Title>
 			<Dialog.Description>
-				The content filter flags text that may violate our content
-				policy. It&apos;s powered by our moderation endpoint which is
-				free to use to moderate your OpenAI API traffic. Learn more.
+				The content filter flags text that may violate our content policy. It&apos;s powered
+				by our moderation endpoint which is free to use to moderate your OpenAI API traffic.
+				Learn more.
 			</Dialog.Description>
 		</Dialog.Header>
 		<div class="py-6">
@@ -46,20 +43,16 @@
 			<div class="flex items-start justify-between space-x-4 pt-3">
 				<Switch name="show" id="show" checked />
 				<Label class="grid gap-1 font-normal" for="show">
-					<span class="font-semibold">
-						Show a warning when content is flagged
-					</span>
+					<span class="font-semibold"> Show a warning when content is flagged </span>
 					<span class="text-sm text-muted-foreground">
-						A warning will be shown when sexual, hateful, violent or
-						self-harm content is detected.
+						A warning will be shown when sexual, hateful, violent or self-harm content
+						is detected.
 					</span>
 				</Label>
 			</div>
 		</div>
 		<Dialog.Footer>
-			<Button variant="secondary" on:click={() => (open = false)}
-				>Close</Button
-			>
+			<Button variant="secondary" on:click={() => (open = false)}>Close</Button>
 		</Dialog.Footer>
 	</Dialog.Content>
 </Dialog.Root>
@@ -68,8 +61,8 @@
 		<AlertDialog.Header>
 			<AlertDialog.Title>Are you sure absolutely sure?</AlertDialog.Title>
 			<AlertDialog.Description>
-				This action cannot be undone. This preset will no longer be
-				accessible by you or others you&apos;ve shared it with.
+				This action cannot be undone. This preset will no longer be accessible by you or
+				others you&apos;ve shared it with.
 			</AlertDialog.Description>
 		</AlertDialog.Header>
 		<AlertDialog.Footer>

--- a/apps/www/src/routes/examples/playground/(components)/preset-save.svelte
+++ b/apps/www/src/routes/examples/playground/(components)/preset-save.svelte
@@ -13,8 +13,8 @@
 		<Dialog.Header>
 			<Dialog.Title>Save preset</Dialog.Title>
 			<Dialog.Description>
-				This will save the current playground state as a preset which
-				you can access later or share with others.
+				This will save the current playground state as a preset which you can access later
+				or share with others.
 			</Dialog.Description>
 		</Dialog.Header>
 		<div class="grid gap-4 py-4">

--- a/apps/www/src/routes/examples/playground/(components)/preset-selector.svelte
+++ b/apps/www/src/routes/examples/playground/(components)/preset-selector.svelte
@@ -12,8 +12,7 @@
 
 	let value = "";
 
-	$: selectedValue =
-		presets.find((f) => f.name === value)?.name ?? "Load a preset...";
+	$: selectedValue = presets.find((f) => f.name === value)?.name ?? "Load a preset...";
 
 	// We want to refocus the trigger button when the user selects
 	// an item from the list so users can continue navigating the
@@ -58,9 +57,7 @@
 							<Check
 								class={cn(
 									"ml-auto h-4 w-4",
-									value === preset.name
-										? "opacity-100"
-										: "opacity-0"
+									value === preset.name ? "opacity-100" : "opacity-0"
 								)}
 							/>
 						</Command.Item>

--- a/apps/www/src/routes/examples/playground/(components)/preset-share.svelte
+++ b/apps/www/src/routes/examples/playground/(components)/preset-share.svelte
@@ -14,8 +14,7 @@
 		<div class="flex flex-col space-y-2 text-center sm:text-left">
 			<h3 class="text-lg font-semibold">Share preset</h3>
 			<p class="text-sm text-muted-foreground">
-				Anyone who has this link and an OpenAI account will be able to
-				view this.
+				Anyone who has this link and an OpenAI account will be able to view this.
 			</p>
 		</div>
 		<div class="flex items-center space-x-2 pt-4">

--- a/apps/www/src/routes/examples/playground/(components)/temperature-selector.svelte
+++ b/apps/www/src/routes/examples/playground/(components)/temperature-selector.svelte
@@ -30,9 +30,8 @@
 			</div>
 		</HoverCard.Trigger>
 		<HoverCard.Content class="w-[260px] text-sm" align="start" side="left">
-			Controls randomness: lowering results in less random completions. As
-			the temperature approaches zero, the model will become deterministic
-			and repetitive.
+			Controls randomness: lowering results in less random completions. As the temperature
+			approaches zero, the model will become deterministic and repetitive.
 		</HoverCard.Content>
 	</HoverCard.Root>
 </div>

--- a/apps/www/src/routes/examples/playground/(components)/top-p-selector.svelte
+++ b/apps/www/src/routes/examples/playground/(components)/top-p-selector.svelte
@@ -30,8 +30,8 @@
 			</div>
 		</HoverCard.Trigger>
 		<HoverCard.Content class="w-[260px] text-sm" side="left" align="start">
-			Control diversity via nucleus sampling: 0.5 means half of all
-			likelihood-weighted options are considered.
+			Control diversity via nucleus sampling: 0.5 means half of all likelihood-weighted
+			options are considered.
 		</HoverCard.Content>
 	</HoverCard.Root>
 </div>

--- a/apps/www/src/routes/examples/playground/(data)/models.ts
+++ b/apps/www/src/routes/examples/playground/(data)/models.ts
@@ -25,14 +25,12 @@ export const models: Model<ModelType>[] = [
 		name: "text-curie-001",
 		description: "Very capable, but faster and lower cost than Davinci.",
 		type: "GPT-3",
-		strengths:
-			"Language translation, complex classification, sentiment, summarization"
+		strengths: "Language translation, complex classification, sentiment, summarization"
 	},
 	{
 		id: "ac0797b0-7e31-43b6-a494-da7e2ab43445",
 		name: "text-babbage-001",
-		description:
-			"Capable of straightforward tasks, very fast, and lower cost.",
+		description: "Capable of straightforward tasks, very fast, and lower cost.",
 		type: "GPT-3",
 		strengths: "Moderate classification, semantic search"
 	},
@@ -42,8 +40,7 @@ export const models: Model<ModelType>[] = [
 		description:
 			"Capable of very simple tasks, usually the fastest model in the GPT-3 series, and lowest cost.",
 		type: "GPT-3",
-		strengths:
-			"Parsing text, simple classification, address correction, keywords"
+		strengths: "Parsing text, simple classification, address correction, keywords"
 	},
 	{
 		id: "b43c0ea9-5ad4-456a-ae29-26cd77b6d0fb",

--- a/apps/www/src/routes/examples/playground/+page.svelte
+++ b/apps/www/src/routes/examples/playground/+page.svelte
@@ -55,9 +55,7 @@
 	<Separator />
 	<Tabs.Root value="complete" class="flex-1">
 		<div class="container h-full py-6">
-			<div
-				class="grid h-full items-stretch gap-6 md:grid-cols-[1fr_200px]"
-			>
+			<div class="grid h-full items-stretch gap-6 md:grid-cols-[1fr_200px]">
 				<div class="hidden flex-col space-y-4 sm:flex md:order-2">
 					<div class="grid gap-2">
 						<HoverCard.Root openDelay={200}>
@@ -70,15 +68,10 @@
 									Mode
 								</span>
 							</HoverCard.Trigger>
-							<HoverCard.Content
-								class="w-[320px] text-sm"
-								side="left"
-							>
-								Choose the interface that best suits your task.
-								You can provide: a simple prompt to complete,
-								starting and ending text to insert a completion
-								within, or some text with instructions to edit
-								it.
+							<HoverCard.Content class="w-[320px] text-sm" side="left">
+								Choose the interface that best suits your task. You can provide: a
+								simple prompt to complete, starting and ending text to insert a
+								completion within, or some text with instructions to edit it.
 							</HoverCard.Content>
 						</HoverCard.Root>
 						<Tabs.List class="grid grid-cols-3">
@@ -298,9 +291,7 @@
 										/>
 									</div>
 									<div class="flex flex-col space-y-2">
-										<Label for="instructions"
-											>Instructions</Label
-										>
+										<Label for="instructions">Instructions</Label>
 										<Textarea
 											id="instructions"
 											placeholder="Fix the grammar."

--- a/apps/www/src/routes/examples/tasks/(components)/data-table-column-header.svelte
+++ b/apps/www/src/routes/examples/tasks/(components)/data-table-column-header.svelte
@@ -52,12 +52,8 @@
 				</Button>
 			</DropdownMenu.Trigger>
 			<DropdownMenu.Content align="start">
-				<DropdownMenu.Item on:click={handleAscSort}
-					>Asc</DropdownMenu.Item
-				>
-				<DropdownMenu.Item on:click={handleDescSort}
-					>Desc</DropdownMenu.Item
-				>
+				<DropdownMenu.Item on:click={handleAscSort}>Asc</DropdownMenu.Item>
+				<DropdownMenu.Item on:click={handleDescSort}>Desc</DropdownMenu.Item>
 			</DropdownMenu.Content>
 		</DropdownMenu.Root>
 	</div>

--- a/apps/www/src/routes/examples/tasks/(components)/data-table-faceted-filter.svelte
+++ b/apps/www/src/routes/examples/tasks/(components)/data-table-faceted-filter.svelte
@@ -15,53 +15,33 @@
 	let open = false;
 
 	const handleSelect = (currentValue: string) => {
-		if (
-			Array.isArray(filterValues) &&
-			filterValues.includes(currentValue)
-		) {
+		if (Array.isArray(filterValues) && filterValues.includes(currentValue)) {
 			filterValues = filterValues.filter((v) => v !== currentValue);
 		} else {
-			filterValues = [
-				...(Array.isArray(filterValues) ? filterValues : []),
-				currentValue
-			];
+			filterValues = [...(Array.isArray(filterValues) ? filterValues : []), currentValue];
 		}
 	};
 </script>
 
 <Popover.Root bind:open>
 	<Popover.Trigger asChild let:builder>
-		<Button
-			builders={[builder]}
-			variant="outline"
-			size="sm"
-			class="h-8 border-dashed"
-		>
+		<Button builders={[builder]} variant="outline" size="sm" class="h-8 border-dashed">
 			<PlusCircled class="mr-2 h-4 w-4" />
 			{title}
 
 			{#if filterValues.length > 0}
 				<Separator orientation="vertical" class="mx-2 h-4" />
-				<Badge
-					variant="secondary"
-					class="rounded-sm px-1 font-normal lg:hidden"
-				>
+				<Badge variant="secondary" class="rounded-sm px-1 font-normal lg:hidden">
 					{filterValues.length}
 				</Badge>
 				<div class="hidden space-x-1 lg:flex">
 					{#if filterValues.length > 2}
-						<Badge
-							variant="secondary"
-							class="rounded-sm px-1 font-normal"
-						>
+						<Badge variant="secondary" class="rounded-sm px-1 font-normal">
 							{filterValues.length} Selected
 						</Badge>
 					{:else}
 						{#each filterValues as option}
-							<Badge
-								variant="secondary"
-								class="rounded-sm px-1 font-normal"
-							>
+							<Badge variant="secondary" class="rounded-sm px-1 font-normal">
 								{option}
 							</Badge>
 						{/each}

--- a/apps/www/src/routes/examples/tasks/(components)/data-table-pagination.svelte
+++ b/apps/www/src/routes/examples/tasks/(components)/data-table-pagination.svelte
@@ -15,8 +15,7 @@
 
 	const { pageRows, pluginStates, rows } = tableModel;
 
-	const { hasNextPage, hasPreviousPage, pageIndex, pageCount, pageSize } =
-		pluginStates.page;
+	const { hasNextPage, hasPreviousPage, pageIndex, pageCount, pageSize } = pluginStates.page;
 
 	const { selectedDataIds } = pluginStates.select;
 </script>
@@ -30,8 +29,7 @@
 		<div class="flex items-center space-x-2">
 			<p class="text-sm font-medium">Rows per page</p>
 			<Select.Root
-				onSelectedChange={(selected) =>
-					pageSize.set(Number(selected?.value))}
+				onSelectedChange={(selected) => pageSize.set(Number(selected?.value))}
 				selected={{ value: 10, label: "10" }}
 			>
 				<Select.Trigger class="w-[180px]">
@@ -46,9 +44,7 @@
 				</Select.Content>
 			</Select.Root>
 		</div>
-		<div
-			class="flex w-[100px] items-center justify-center text-sm font-medium"
-		>
+		<div class="flex w-[100px] items-center justify-center text-sm font-medium">
 			Page {$pageIndex + 1} of {$pageCount}
 		</div>
 		<div class="flex items-center space-x-2">
@@ -83,9 +79,7 @@
 				variant="outline"
 				class="hidden h-8 w-8 p-0 lg:flex"
 				disabled={!$hasNextPage}
-				on:click={() =>
-					($pageIndex =
-						Math.ceil($rows.length / $pageRows.length) - 1)}
+				on:click={() => ($pageIndex = Math.ceil($rows.length / $pageRows.length) - 1)}
 			>
 				<span class="sr-only">Go to last page</span>
 				<DoubleArrowRight size={15} />

--- a/apps/www/src/routes/examples/tasks/(components)/data-table-toolbar.svelte
+++ b/apps/www/src/routes/examples/tasks/(components)/data-table-toolbar.svelte
@@ -27,9 +27,7 @@
 		}>;
 	} = pluginStates.colFilter;
 
-	$: showReset = Object.values({ ...$filterValues, $filterValue }).some(
-		(v) => v.length > 0
-	);
+	$: showReset = Object.values({ ...$filterValues, $filterValue }).some((v) => v.length > 0);
 </script>
 
 <div class="flex items-center justify-between">

--- a/apps/www/src/routes/examples/tasks/(components)/data-table-view-options.svelte
+++ b/apps/www/src/routes/examples/tasks/(components)/data-table-view-options.svelte
@@ -23,12 +23,7 @@
 
 <DropdownMenu.Root>
 	<DropdownMenu.Trigger asChild let:builder>
-		<Button
-			variant="outline"
-			size="sm"
-			class="ml-auto hidden h-8 lg:flex"
-			builders={[builder]}
-		>
+		<Button variant="outline" size="sm" class="ml-auto hidden h-8 lg:flex" builders={[builder]}>
 			<MixerHorizontal class="mr-2 h-4 w-4" />
 			View
 		</Button>

--- a/apps/www/src/routes/examples/tasks/(components)/data-table.svelte
+++ b/apps/www/src/routes/examples/tasks/(components)/data-table.svelte
@@ -1,11 +1,6 @@
 <script lang="ts">
 	import { get, readable } from "svelte/store";
-	import {
-		Render,
-		Subscribe,
-		createRender,
-		createTable
-	} from "svelte-headless-table";
+	import { Render, Subscribe, createRender, createTable } from "svelte-headless-table";
 	import * as Table from "@/registry/new-york/ui/table";
 	import {
 		addColumnFilters,
@@ -109,11 +104,7 @@
 				colFilter: {
 					fn: ({ filterValue, value }) => {
 						if (filterValue.length === 0) return true;
-						if (
-							!Array.isArray(filterValue) ||
-							typeof value !== "string"
-						)
-							return true;
+						if (!Array.isArray(filterValue) || typeof value !== "string") return true;
 						return filterValue.some((filter) => {
 							return value.includes(filter);
 						});
@@ -138,11 +129,7 @@
 				colFilter: {
 					fn: ({ filterValue, value }) => {
 						if (filterValue.length === 0) return true;
-						if (
-							!Array.isArray(filterValue) ||
-							typeof value !== "string"
-						)
-							return true;
+						if (!Array.isArray(filterValue) || typeof value !== "string") return true;
 
 						return filterValue.some((filter) => {
 							return value.includes(filter);

--- a/apps/www/src/routes/examples/tasks/(components)/user-nav.svelte
+++ b/apps/www/src/routes/examples/tasks/(components)/user-nav.svelte
@@ -6,11 +6,7 @@
 
 <DropdownMenu.Root>
 	<DropdownMenu.Trigger asChild let:builder>
-		<Button
-			variant="ghost"
-			builders={[builder]}
-			class="relative h-8 w-8 rounded-full"
-		>
+		<Button variant="ghost" builders={[builder]} class="relative h-8 w-8 rounded-full">
 			<Avatar.Root class="h-9 w-9">
 				<Avatar.Image src="/avatars/03.png" alt="@shadcn" />
 				<Avatar.Fallback>SC</Avatar.Fallback>
@@ -21,9 +17,7 @@
 		<DropdownMenu.Label class="font-normal">
 			<div class="flex flex-col space-y-1">
 				<p class="text-sm font-medium leading-none">shadcn</p>
-				<p class="text-xs leading-none text-muted-foreground">
-					m@example.com
-				</p>
+				<p class="text-xs leading-none text-muted-foreground">m@example.com</p>
 			</div>
 		</DropdownMenu.Label>
 		<DropdownMenu.Separator />

--- a/apps/www/src/routes/examples/tasks/+page.svelte
+++ b/apps/www/src/routes/examples/tasks/+page.svelte
@@ -5,20 +5,14 @@
 </script>
 
 <div class="md:hidden">
-	<img
-		src="/examples/tasks-light.png"
-		alt="Tasks"
-		class="block dark:hidden"
-	/>
+	<img src="/examples/tasks-light.png" alt="Tasks" class="block dark:hidden" />
 	<img src="/examples/tasks-dark.png" alt="Tasks" class="hidden dark:block" />
 </div>
 <div class="hidden h-full flex-1 flex-col space-y-8 p-8 md:flex">
 	<div class="flex items-center justify-between space-y-2">
 		<div>
 			<h2 class="text-2xl font-bold tracking-tight">Welcome back!</h2>
-			<p class="text-muted-foreground">
-				Here's a list of your tasks for this month!
-			</p>
+			<p class="text-muted-foreground">Here's a list of your tasks for this month!</p>
 		</div>
 		<div class="flex items-center space-x-2">
 			<UserNav />

--- a/apps/www/src/routes/repro/+page.ts
+++ b/apps/www/src/routes/repro/+page.ts
@@ -2,8 +2,5 @@ import { redirect } from "@sveltejs/kit";
 import type { PageLoad } from "./$types";
 
 export const load: PageLoad = async () => {
-	throw redirect(
-		302,
-		"https://stackblitz.com/github/huntabyte/shadcn-repro-template"
-	);
+	throw redirect(302, "https://stackblitz.com/github/huntabyte/shadcn-repro-template");
 };

--- a/apps/www/src/routes/themes/+page.svelte
+++ b/apps/www/src/routes/themes/+page.svelte
@@ -1,9 +1,5 @@
 <script lang="ts">
-	import {
-		ThemeCustomizer,
-		ThemeWrapper,
-		Announcement
-	} from "@/components/docs";
+	import { ThemeCustomizer, ThemeWrapper, Announcement } from "@/components/docs";
 	import * as PageHeader from "@/components/docs/page-header";
 	import { CardsNewYork } from "@/registry/new-york/example/cards";
 	import { CardsDefault } from "@/registry/default/example/cards";
@@ -33,15 +29,11 @@
 			<PageHeader.Heading class="hidden md:block">
 				Add colors. Make it yours.
 			</PageHeader.Heading>
-			<PageHeader.Heading class="md:hidden">
-				Make it yours.
-			</PageHeader.Heading>
+			<PageHeader.Heading class="md:hidden">Make it yours.</PageHeader.Heading>
 			<PageHeader.Description balanced={false}>
 				Hand-picked themes that you can copy and paste into your apps.
 			</PageHeader.Description>
-			<div
-				class="flex w-full items-center justify-center space-x-4 py-4 md:pb-10"
-			>
+			<div class="flex w-full items-center justify-center space-x-4 py-4 md:pb-10">
 				<ThemeCustomizer />
 			</div>
 		</PageHeader.Root>

--- a/apps/www/src/styles/globals.css
+++ b/apps/www/src/styles/globals.css
@@ -4,9 +4,8 @@
 
 @layer base {
 	:root {
-		--font-geist-sans: "geist-sans", -apple-system, BlinkMacSystemFont,
-			"Segoe UI", Roboto, Helvetica, Arial, sans-serif,
-			"Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+		--font-geist-sans: "geist-sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+			Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 		--background: 0 0% 100%;
 		--foreground: 240 10% 3.9%;
 

--- a/apps/www/tailwind.config.js
+++ b/apps/www/tailwind.config.js
@@ -26,13 +26,11 @@ const config = {
 				},
 				secondary: {
 					DEFAULT: "hsl(var(--secondary) / <alpha-value>)",
-					foreground:
-						"hsl(var(--secondary-foreground) / <alpha-value>)"
+					foreground: "hsl(var(--secondary-foreground) / <alpha-value>)"
 				},
 				destructive: {
 					DEFAULT: "hsl(var(--destructive) / <alpha-value>)",
-					foreground:
-						"hsl(var(--destructive-foreground) / <alpha-value>)"
+					foreground: "hsl(var(--destructive-foreground) / <alpha-value>)"
 				},
 				muted: {
 					DEFAULT: "hsl(var(--muted) / <alpha-value>)",

--- a/apps/www/tests/test.ts
+++ b/apps/www/tests/test.ts
@@ -2,7 +2,5 @@ import { expect, test } from "@playwright/test";
 
 test("index page has expected h1", async ({ page }) => {
 	await page.goto("/");
-	await expect(
-		page.getByRole("heading", { name: "Welcome to SvelteKit" })
-	).toBeVisible();
+	await expect(page.getByRole("heading", { name: "Welcome to SvelteKit" })).toBeVisible();
 });


### PR DESCRIPTION
Closes: #601 

This PR makes the `Form.Value` the slot fallback within the `Form.SelectTrigger`, meaning if children are passed to it, the `Form.Value` will no longer render. You can access the `value` of the field via the `value` slot prop.

This means if you choose to use the child slot of the `SelectTrigger`, you'll need to manually handle displaying the placeholder if the value isn't present. In this example, the field contains a string value, so the default would be an empty string.
```svelte
 <Form.SelectTrigger let:value>
	{value !== "" ? value : "Placeholder here"}
</Form.SelectTrigger>
```

### Before submitting the PR, please make sure you do the following

- [x] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Follows the [contribution guidelines](https://github.com/huntabyte/shadcn-svelte/blob/main/CONTRIBUTING.md).
- [x] Format & lint the code with `pnpm format` and `pnpm lint`
