### PR TITLE
docs: Add "data-vaul-drawer-wrapper" data attribute to the root layout

### DIFF
--- a/apps/www/src/routes/+layout.svelte
+++ b/apps/www/src/routes/+layout.svelte
@@ -22,7 +22,7 @@
 	<DefaultSonner />
 {/if}
 
-<div class="relative flex min-h-screen flex-col bg-background" id="page">
+<div class="relative flex min-h-screen flex-col bg-background" id="page" data-vaul-drawer-wrapper>
 	<SiteHeader />
 	<div class="flex-1">
 		<slot />


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Follows the [contribution guidelines](https://github.com/huntabyte/shadcn-svelte/blob/main/CONTRIBUTING.md).
- [x] Format & lint the code with `pnpm format` and `pnpm lint`


First-time contributor, feel free to shout at me 😆 
I treated this as a small fix which is why I didn't file an issue.

This PR adds "data-vaul-drawer-wrapper" to the root docs "layout.svelte" which allows the vaul-svelte drawer to properly scale the background.

## Before
https://github.com/huntabyte/shadcn-svelte/assets/102172929/a52482e0-c971-4745-96b4-f1cedc1a3baa

## After
https://github.com/huntabyte/shadcn-svelte/assets/102172929/ff8eaf6a-a18f-45d6-ad6f-440e3d571e59

## shadcn-ui docs for reference
https://github.com/huntabyte/shadcn-svelte/assets/102172929/853c70e0-97b6-4fa5-b1be-4066b65ae7a8


As I said, first-time contributor so sorry if I did anything wrong, I'm here to learn 😄 



