### PR TITLE
docs(forms): :memo: add options to forms

### DIFF
--- a/apps/www/src/content/components/form.md
+++ b/apps/www/src/content/components/form.md
@@ -4,7 +4,7 @@ description: Building forms with Formsnap, Superforms, & Zod.
 ---
 
 <script>
-	import { Steps, ComponentPreview, FormPreview } from '@/components/docs';
+ import { Steps, ComponentPreview, FormPreview } from '@/components/docs';
 </script>
 
 Forms are tricky. They are one of the most common things you'll build in a web application, but also one of the most complex.
@@ -178,6 +178,13 @@ That's it. You now have a fully accessible form that is type-safe and has client
 <FormPreview />
 
 </Steps>
+
+## Options
+
+You can handle the form submission in a few different ways using the `options` from `formsnap`.
+See [the documentation](https://formsnap.dev/docs/options) for more information.
+
+Click the above Submit button to see the different options in action.
 
 ## Examples
 

--- a/apps/www/src/lib/registry/default/example/form-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/form-demo.svelte
@@ -10,13 +10,26 @@
 <script lang="ts">
 	import * as Form from "@/registry/default/ui/form";
 	import type { SuperValidated } from "sveltekit-superforms";
+	import type { FormOptions } from "formsnap";
+	import { toast } from "svelte-sonner";
 
 	export let form: SuperValidated<FormSchema>;
+	const options: FormOptions<FormSchema> = {
+		onSubmit() {
+			toast.info("Submitting...");
+		},
+		onResult({ result }) {
+			console.log(result);
+			if (result.status === 200) toast.success("Success!");
+			if (result.status === 400) toast.error("Error!");
+		}
+	};
 </script>
 
 <Form.Root
 	schema={formSchema}
 	{form}
+	{options}
 	let:config
 	method="POST"
 	action="?/username"

--- a/apps/www/src/lib/registry/new-york/example/form-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/form-demo.svelte
@@ -10,13 +10,26 @@
 <script lang="ts">
 	import * as Form from "@/registry/new-york/ui/form";
 	import type { SuperValidated } from "sveltekit-superforms";
+	import type { FormOptions } from "formsnap";
+	import { toast } from "svelte-sonner";
 
 	export let form: SuperValidated<FormSchema>;
+	const options: FormOptions<FormSchema> = {
+		onSubmit() {
+			toast.info("Submitting...");
+		},
+		onResult({ result }) {
+			console.log(result);
+			if (result.status === 200) toast.success("Success!");
+			if (result.status === 400) toast.error("Error!");
+		}
+	};
 </script>
 
 <Form.Root
 	schema={formSchema}
 	{form}
+	{options}
 	let:config
 	method="POST"
 	action="?/username"

--- a/apps/www/src/routes/docs/[...slug]/+page.server.ts
+++ b/apps/www/src/routes/docs/[...slug]/+page.server.ts
@@ -14,14 +14,14 @@ import type { AnyZodObject } from "zod";
 
 export const load: PageServerLoad = async () => {
 	return {
-		form: superValidate(formSchema),
-		checkboxSingle: superValidate(checkboxSingleSchema),
-		radioGroup: superValidate(radioGroupSchema),
-		select: superValidate(selectSchema),
-		switch: superValidate(switchSchema),
-		textarea: superValidate(textareaSchema),
-		combobox: superValidate(comboboxFormSchema),
-		datePicker: superValidate(datePickerFormSchema)
+		form: await superValidate(formSchema),
+		checkboxSingle: await superValidate(checkboxSingleSchema),
+		radioGroup: await superValidate(radioGroupSchema),
+		select: await superValidate(selectSchema),
+		switch: await superValidate(switchSchema),
+		textarea: await superValidate(textareaSchema),
+		combobox: await superValidate(comboboxFormSchema),
+		datePicker: await superValidate(datePickerFormSchema)
 	};
 };
 

--- a/apps/www/src/routes/examples/forms/+page.server.ts
+++ b/apps/www/src/routes/examples/forms/+page.server.ts
@@ -5,7 +5,7 @@ import { fail, type Actions } from "@sveltejs/kit";
 
 export const load: PageServerLoad = async () => {
 	return {
-		form: superValidate(profileFormSchema)
+		form: await superValidate(profileFormSchema)
 	};
 };
 

--- a/apps/www/src/routes/examples/forms/account/+page.server.ts
+++ b/apps/www/src/routes/examples/forms/account/+page.server.ts
@@ -5,7 +5,7 @@ import { fail, type Actions } from "@sveltejs/kit";
 
 export const load: PageServerLoad = async () => {
 	return {
-		form: superValidate(accountFormSchema)
+		form: await superValidate(accountFormSchema)
 	};
 };
 

--- a/apps/www/src/routes/examples/forms/appearance/+page.server.ts
+++ b/apps/www/src/routes/examples/forms/appearance/+page.server.ts
@@ -5,7 +5,7 @@ import { fail, type Actions } from "@sveltejs/kit";
 
 export const load: PageServerLoad = async () => {
 	return {
-		form: superValidate(appearanceFormSchema)
+		form: await superValidate(appearanceFormSchema)
 	};
 };
 

--- a/apps/www/src/routes/examples/forms/notifications/+page.server.ts
+++ b/apps/www/src/routes/examples/forms/notifications/+page.server.ts
@@ -5,7 +5,7 @@ import { fail, type Actions } from "@sveltejs/kit";
 
 export const load: PageServerLoad = async () => {
 	return {
-		form: superValidate(notificationsFormSchema)
+		form: await superValidate(notificationsFormSchema)
 	};
 };
 


### PR DESCRIPTION
This is a small PR for updating the forms documentation. It also fixes the form's data loading by awaiting all `superValidate` functions in `+page.server.ts` files.

Finally, the examples' forms now display sonner's toasts to show how to handle the form's results in the UI.
It will render different toasts depending on the form's result.

Enjoy ! 🎉 