### PR TITLE
docs: add button sizes example

### DIFF
--- a/apps/www/src/content/components/button.md
+++ b/apps/www/src/content/components/button.md
@@ -133,6 +133,17 @@ Alternatively, you can use the `buttonVariants` helper to create a link that loo
 
 ---
 
+### Sizes
+
+
+<ComponentPreview name="button-sizes">
+
+<div />
+
+</ComponentPreview>
+
+---
+
 ### With Icon
 
 <ComponentPreview name="button-with-icon">

--- a/apps/www/src/lib/registry/default/example/button-sizes.svelte
+++ b/apps/www/src/lib/registry/default/example/button-sizes.svelte
@@ -1,0 +1,7 @@
+<Button size="sm">
+	Small button
+</Button>
+
+<Button size="lg">
+	Large button
+</Button>

--- a/apps/www/src/lib/registry/new-york/example/button-sizes.svelte
+++ b/apps/www/src/lib/registry/new-york/example/button-sizes.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Button } from "@/registry/default/ui/button";
+	import { Button } from "@/registry/new-york/ui/button";
 </script>
 
 <Button size="sm">


### PR DESCRIPTION
I've added an example of the button size variants to make it clear that such an option exists