### PR TITLE
fix: calendar max-width on Themes

### DIFF
--- a/apps/www/src/lib/registry/default/example/cards/calendar.svelte
+++ b/apps/www/src/lib/registry/default/example/cards/calendar.svelte
@@ -11,7 +11,7 @@
 	};
 </script>
 
-<Card.Root class="max-w-[260px] ">
+<Card.Root class="max-w-[280px] ">
 	<Card.Content class="p-0">
 		<RangeCalendar bind:value />
 	</Card.Content>

--- a/apps/www/src/lib/registry/new-york/example/cards/calendar.svelte
+++ b/apps/www/src/lib/registry/new-york/example/cards/calendar.svelte
@@ -11,7 +11,7 @@
 	};
 </script>
 
-<Card.Root class="max-w-[260px]">
+<Card.Root class="max-w-[280px]">
 	<Card.Content class="p-1">
 		<RangeCalendar bind:value />
 	</Card.Content>


### PR DESCRIPTION
Closes: #660

The card with the Calendar (with ``max-w-[260px]``) caused the buttons inside the component to overflow (more noticeable with the Default theme). Changing to ``max-w-[280px]`` fixes it (and syncs with the original shadcn/ui)

### Before submitting the PR, please make sure you do the following

- [X] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [X] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [X] This message body should clearly illustrate what problems it solves.
- [X] Follows the [contribution guidelines](https://github.com/huntabyte/shadcn-svelte/blob/main/CONTRIBUTING.md).
- [x] Format & lint the code with `pnpm format` and `pnpm lint`
