### PR TITLE
fix: line wrapping in Select component

### DIFF
--- a/apps/www/src/lib/registry/default/ui/select/select-trigger.svelte
+++ b/apps/www/src/lib/registry/default/ui/select/select-trigger.svelte
@@ -12,7 +12,7 @@
 
 <SelectPrimitive.Trigger
 	class={cn(
-		"flex h-10 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+		"flex h-10 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 line-clamp-1 truncate",
 		className
 	)}
 	{...$$restProps}

--- a/apps/www/src/lib/registry/new-york/ui/select/select-trigger.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/select/select-trigger.svelte
@@ -12,7 +12,7 @@
 
 <SelectPrimitive.Trigger
 	class={cn(
-		"flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+		"flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 line-clamp-1 truncate",
 		className
 	)}
 	{...$$restProps}


### PR DESCRIPTION
Closes #689 

Makes Select components more consistent with the original ShadCn repo, by disabling line wrapping in select trigger.

Before:
<img width="145" alt="Screenshot" src="https://github.com/huntabyte/shadcn-svelte/assets/11229056/9843b055-22e9-4641-ba90-7e5075d795e9">

After:
<img width="141" alt="Screenshot" src="https://github.com/huntabyte/shadcn-svelte/assets/11229056/c233eb69-0060-4b59-b106-4788c1ca2a96">

Compare https://www.shadcn-svelte.com/themes (width set to 1280px)