### PR TITLE
fix: menu `SubContent` with min width

### DIFF
--- a/apps/www/src/lib/registry/default/ui/menubar/menubar-sub-content.svelte
+++ b/apps/www/src/lib/registry/default/ui/menubar/menubar-sub-content.svelte
@@ -15,7 +15,7 @@
 	{transition}
 	{transitionConfig}
 	class={cn(
-		"z-50 min-w-[9rem] rounded-md border bg-popover p-1 text-popover-foreground focus:outline-none",
+		"z-50 min-w-max rounded-md border bg-popover p-1 text-popover-foreground focus:outline-none",
 		className
 	)}
 	{...$$restProps}

--- a/apps/www/src/lib/registry/new-york/ui/menubar/menubar-sub-content.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/menubar/menubar-sub-content.svelte
@@ -16,7 +16,7 @@
 	{transition}
 	{transitionConfig}
 	class={cn(
-		"z-50 min-w-[8rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-lg focus:outline-none",
+		"z-50 min-w-max rounded-md border bg-popover p-1 text-popover-foreground shadow-lg focus:outline-none",
 		className
 	)}
 	{...$$restProps}


### PR DESCRIPTION
This should fix #700. When I was looking at [shadcn-ui](https://ui.shadcn.com/docs/components/menubar) I noticed that they are wrapping the subcontent with 2 divs instead of one as we do here. But I do not see why it's necessary. 

This pr fixes the issue without making any bigger adjustments. Let me know if you disagree @huntabyte 
