### PR TITLE
fix: grey out Menubar.Sub when disabled

### DIFF
--- a/apps/www/src/lib/registry/default/ui/menubar/menubar-sub-trigger.svelte
+++ b/apps/www/src/lib/registry/default/ui/menubar/menubar-sub-trigger.svelte
@@ -15,7 +15,7 @@
 
 <MenubarPrimitive.SubTrigger
 	class={cn(
-		"flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+		"flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground data-[disabled]:text-muted-foreground data-[disabled]:pointer-events-none",
 		inset && "pl-8",
 		className
 	)}

--- a/apps/www/src/lib/registry/default/ui/menubar/menubar-sub-trigger.svelte
+++ b/apps/www/src/lib/registry/default/ui/menubar/menubar-sub-trigger.svelte
@@ -15,7 +15,7 @@
 
 <MenubarPrimitive.SubTrigger
 	class={cn(
-		"flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground data-[disabled]:text-muted-foreground data-[disabled]:pointer-events-none",
+		"flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground data-[disabled]:opacity-50 data-[disabled]:pointer-events-none",
 		inset && "pl-8",
 		className
 	)}

--- a/apps/www/src/lib/registry/new-york/ui/menubar/menubar-sub-trigger.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/menubar/menubar-sub-trigger.svelte
@@ -15,7 +15,7 @@
 
 <MenubarPrimitive.SubTrigger
 	class={cn(
-		"flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+		"flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground data-[disabled]:text-muted-foreground data-[disabled]:pointer-events-none",
 		inset && "pl-8",
 		className
 	)}

--- a/apps/www/src/lib/registry/new-york/ui/menubar/menubar-sub-trigger.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/menubar/menubar-sub-trigger.svelte
@@ -15,7 +15,7 @@
 
 <MenubarPrimitive.SubTrigger
 	class={cn(
-		"flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground data-[disabled]:text-muted-foreground data-[disabled]:pointer-events-none",
+		"flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground data-[disabled]:opacity-50 data-[disabled]:pointer-events-none",
 		inset && "pl-8",
 		className
 	)}


### PR DESCRIPTION
Small PR that fixes the Menubar.Sub style when it's disabled.
Here's how it looks like now:
![image](https://github.com/huntabyte/shadcn-svelte/assets/55807755/472f8578-89b1-4c71-ba03-077f18bbc24b)
