### PR TITLE
fix: pnpx -> pnpm dlx in copy button

### DIFF
--- a/apps/www/src/lib/components/docs/copy-button.svelte
+++ b/apps/www/src/lib/components/docs/copy-button.svelte
@@ -42,7 +42,7 @@
 			commands = {
 				npm: value,
 				yarn: value.replace(/^npx/, "yarn dlx"),
-				pnpm: value.replace(/^npx/, "pnpx"),
+				pnpm: value.replace(/^npx/, "pnpm dlx"),
 				bun: value.replace(/^npx/, "bunx"),
 			};
 		}


### PR DESCRIPTION
Because pnpx is [deprecated](https://github.com/pnpm/pnpm/pull/3652) and doesn't work in v7+ versions on pnpm.
