### PR TITLE
fix: calendar selected day border radius

### DIFF
--- a/apps/www/src/lib/registry/default/ui/calendar/calendar-cell.svelte
+++ b/apps/www/src/lib/registry/default/ui/calendar/calendar-cell.svelte
@@ -12,7 +12,7 @@
 <CalendarPrimitive.Cell
 	{date}
 	class={cn(
-		"h-9 w-9 text-center text-sm p-0 relative [&:has([data-selected][data-outside-month])]:bg-accent/50 [&:has([data-selected])]:bg-accent first:[&:has([data-selected])]:rounded-l-md last:[&:has([data-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
+		"h-9 w-9 text-center text-sm p-0 relative [&:has([data-selected][data-outside-month])]:bg-accent/50 [&:has([data-selected])]:bg-accent [&:has([data-selected])]:rounded-md focus-within:relative focus-within:z-20",
 		className
 	)}
 	{...$$restProps}

--- a/apps/www/src/lib/registry/new-york/ui/calendar/calendar-cell.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/calendar/calendar-cell.svelte
@@ -12,7 +12,7 @@
 <CalendarPrimitive.Cell
 	{date}
 	class={cn(
-		"relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([data-selected][data-outside-month])]:bg-accent/50 [&:has([data-selected])]:bg-accent first:[&:has([data-selected])]:rounded-l-md last:[&:has([data-selected])]:rounded-r-md",
+		"relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([data-selected][data-outside-month])]:bg-accent/50 [&:has([data-selected])]:bg-accent [&:has([data-selected])]:rounded-md",
 		className
 	)}
 	{...$$restProps}


### PR DESCRIPTION
fixed the border radius of the selected day in the calendar component

### before (you might need to zoom in to see the dark corners)
![image](https://github.com/huntabyte/shadcn-svelte/assets/53095479/3ba5a0c9-78d5-4362-aec5-570a05e13596)

### after

<img width="1032" alt="image" src="https://github.com/huntabyte/shadcn-svelte/assets/53095479/28965f03-5220-49e3-80ff-107ce051ddfa">