### PR TITLE
fix(www): Fix color circles not rendering in /themes

### DIFF
--- a/apps/www/src/lib/components/docs/theme-customizer/customizer.svelte
+++ b/apps/www/src/lib/components/docs/theme-customizer/customizer.svelte
@@ -109,7 +109,7 @@
 							}));
 						}}
 						class={cn("justify-start", isActive && "border-2 border-primary")}
-						style="--theme-primary: hsl({theme?.activeColor[$mode ?? 'dark']}"
+						style="--theme-primary: hsl({theme.activeColor[$mode ?? 'dark']})"
 					>
 						<span
 							class="mr-1 flex h-5 w-5 shrink-0 -translate-x-1 items-center justify-center rounded-full bg-[--theme-primary]"


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Format & lint the code with `pnpm format` and `pnpm lint`

Fix the color circles in /themes within the Customize button popover (sometimes) not displaying.

> [!NOTE]
> On prod, the color is sometimes resolved as `undefined` (the missing `)` is not the single issue), but for some reason I _cannot_ reproduce it in dev.  
> So I'm not sure the issue is 100% fixed but it seems to be working in the Vercel Preview