### PR TITLE
docs: update two small mistakes on data-table walkthrough

### DIFF
--- a/apps/www/src/content/components/data-table.md
+++ b/apps/www/src/content/components/data-table.md
@@ -646,7 +646,7 @@ We can add pagination controls to our table using the `<Button />` component and
       <!-- .... -->
     </Table.Root>
   </div>
-  <div class="flex items-center justify-end space-x-2 py-4">
+  <div class="flex items-center justify-end space-x-4 py-4">
     <Button
       variant="outline"
       size="sm"

--- a/apps/www/src/content/components/data-table.md
+++ b/apps/www/src/content/components/data-table.md
@@ -1189,7 +1189,7 @@ We'll start by creating a new component called `data-table-checkbox.svelte` whic
 
 Next, we'll enable the `addSelectedRows` plugin and import the `<Checkbox />` component we just created.
 
-```svelte showLineNumbers title="routes/payments/data-table.svelte" {13,22,48,54-67,119,125}
+```svelte showLineNumbers title="routes/payments/data-table.svelte" {13,22,48,54-67,119,125,130}
 <script lang="ts">
   import {
     createTable,


### PR DESCRIPTION
I noticed just two small "issues" when reading through the docs of data table, nothing fancy.

### Changes

1. Added a line highlight to one change that was missing.
**Before**
![image](https://github.com/huntabyte/shadcn-svelte/assets/86835927/22e82d0e-9054-4f11-a41e-4fefea65411b)
**After**
![image](https://github.com/huntabyte/shadcn-svelte/assets/86835927/2b1bed73-f737-4a10-a878-18ac38491d1c)

2. Updated a space-x-2 to space-x-4 since it was changed between the first and the next code block that Pagination appears.

### Before submitting the PR, please make sure you do the following

- [x] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Format & lint the code with `pnpm format` and `pnpm lint`
