### PR TITLE
docs: button icon example typo

### DIFF
--- a/apps/www/src/lib/registry/default/example/button-icon.svelte
+++ b/apps/www/src/lib/registry/default/example/button-icon.svelte
@@ -4,5 +4,5 @@
 </script>
 
 <Button variant="outline" size="icon">
-	<ChevronRight className="h-4 w-4" />
+	<ChevronRight class="h-4 w-4" />
 </Button>

--- a/apps/www/src/lib/registry/new-york/example/button-icon.svelte
+++ b/apps/www/src/lib/registry/new-york/example/button-icon.svelte
@@ -4,5 +4,5 @@
 </script>
 
 <Button variant="outline" size="icon">
-	<ChevronRight className="h-4 w-4" />
+	<ChevronRight class="h-4 w-4" />
 </Button>


### PR DESCRIPTION
Should be `class` instead of `className`.
I spent too long trying to figure out why the styles weren't applying 😅 

- [x] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Format & lint the code with `pnpm format` and `pnpm lint`
