### PR TITLE
docs: improve metric cards

### DIFF
--- a/apps/www/src/lib/components/docs/charts/helpers.ts
+++ b/apps/www/src/lib/components/docs/charts/helpers.ts
@@ -2,9 +2,53 @@ export function color(opacity: string = "1") {
 	return () => `hsl(var(--primary) / ${opacity})`;
 }
 
-export function colorArray<T>() {
-	return (_: T, i: number) => {
-		if (i === 0) return `hsl(var(--primary))`;
-		return `hsl(var(--primary) / 0.25)`;
-	};
+export type Data = { average: number; today: number; id: number };
+
+/**
+ * If you want to set color for multiple lines at once, you'll have to define a colors array in your component and reference colors by index in the accessor function.
+ * For example, in this instance below, we know that we only have 2 lines, so we can hardcode the colors array to return 2 colors for the 2 indexes i.e. 2 lines.
+ */
+export function lineColors<T>(_: T, i: number) {
+	return ["hsl(var(--primary))", "hsl(var(--primary) / 0.25)"][i];
+}
+
+export function scatterPointColors<T>(_: T, i: number) {
+	return ["hsl(0, 0%, 100%)", "hsl(var(--primary) / 0.25)"][i];
+}
+
+export function scatterPointStrokeColors<T>(_: T, i: number) {
+	return ["hsl(var(--primary))", "hsl(var(--primary) / 0.25)"][i];
+}
+
+export function crosshairPointColors<T>(_: T, i: number) {
+	return ["hsl(var(--primary))", "hsl(var(--primary) / 0.25)"][i];
+}
+
+export function crosshairStrokeWidths<T>(_: T, i: number) {
+	return [2, 1][i];
+}
+
+export function tooltipTemplate(d: Data) {
+	return `
+<div class="rounded-lg border bg-background p-2 shadow-sm">
+  <div class="grid grid-cols-2 gap-2">
+    <div class="flex flex-col">
+      <span class="text-[0.70rem] uppercase text-muted-foreground">
+        Average
+      </span>
+      <span class="font-bold text-muted-foreground">
+        ${d.average}
+      </span>
+    </div>
+    <div class="flex flex-col">
+      <span class="text-[0.70rem] uppercase text-muted-foreground">
+        Today
+      </span>
+      <span class="font-bold text-foreground">
+        ${d.today}
+      </span>
+    </div>
+  </div>
+</div>
+`;
 }

--- a/apps/www/src/lib/components/docs/charts/metric.pcss
+++ b/apps/www/src/lib/components/docs/charts/metric.pcss
@@ -1,0 +1,7 @@
+/* TODO: Move these overrides to a more declarative format in the parent component once this is resolved: https://github.com/f5/unovis/issues/337 */
+/* Tooltip Overrides */
+:root {
+	--vis-tooltip-padding: "0px";
+	--vis-tooltip-background-color: "transparent";
+	--vis-tooltip-border-color: "transparent";
+}

--- a/apps/www/src/lib/components/docs/charts/metric.pcss
+++ b/apps/www/src/lib/components/docs/charts/metric.pcss
@@ -1,7 +1,0 @@
-/* TODO: Move these overrides to a more declarative format in the parent component once this is resolved: https://github.com/f5/unovis/issues/337 */
-/* Tooltip Overrides */
-:root {
-	--vis-tooltip-padding: "0px";
-	--vis-tooltip-background-color: "transparent";
-	--vis-tooltip-border-color: "transparent";
-}

--- a/apps/www/src/lib/components/docs/charts/metric.svelte
+++ b/apps/www/src/lib/components/docs/charts/metric.svelte
@@ -1,49 +1,47 @@
 <script lang="ts">
-	import { VisXYContainer, VisLine } from "@unovis/svelte";
-	import { colorArray } from "./helpers";
+	import { VisXYContainer, VisLine, VisTooltip, VisScatter, VisCrosshair } from "@unovis/svelte";
+	import {
+		lineColors,
+		type Data,
+		scatterPointColors,
+		scatterPointStrokeColors,
+		tooltipTemplate,
+		crosshairPointColors,
+		crosshairStrokeWidths,
+	} from "./helpers";
 
-	type Data = { average: number; today: number; id: number };
 	const data: Data[] = [
-		{
-			id: 1,
-			average: 400,
-			today: 240,
-		},
-		{
-			id: 2,
-			average: 300,
-			today: 139,
-		},
-		{
-			id: 3,
-			average: 200,
-			today: 980,
-		},
-		{
-			id: 4,
-			average: 278,
-			today: 390,
-		},
-		{
-			id: 5,
-			average: 189,
-			today: 480,
-		},
-		{
-			id: 6,
-			average: 239,
-			today: 380,
-		},
-		{
-			id: 7,
-			average: 349,
-			today: 430,
-		},
+		{ id: 1, average: 400, today: 240 },
+		{ id: 2, average: 300, today: 139 },
+		{ id: 3, average: 200, today: 980 },
+		{ id: 4, average: 278, today: 390 },
+		{ id: 5, average: 189, today: 480 },
+		{ id: 6, average: 239, today: 380 },
+		{ id: 7, average: 349, today: 430 },
 	];
+
 	const x = (d: Data) => d.id;
 	const y = [(d: Data) => d.today, (d: Data) => d.average];
 </script>
 
-<VisXYContainer {data} height={200}>
-	<VisLine {x} {y} color={colorArray()} />
+<VisXYContainer {data} height={200} margin={{ top: 5, right: 10, left: 10, bottom: 0 }}>
+	<VisTooltip />
+	<VisLine {x} {y} lineWidth={1} color={lineColors} />
+	<VisScatter
+		{x}
+		{y}
+		color={scatterPointColors}
+		size={6}
+		strokeColor={scatterPointStrokeColors}
+		strokeWidth={crosshairStrokeWidths}
+	/>
+	<VisCrosshair template={tooltipTemplate} color={crosshairPointColors} />
 </VisXYContainer>
+
+<style>
+	:root {
+		--vis-tooltip-padding: "0px";
+		--vis-tooltip-background-color: "transparent";
+		--vis-tooltip-border-color: "transparent";
+	}
+</style>

--- a/apps/www/src/lib/components/docs/charts/metric.svelte
+++ b/apps/www/src/lib/components/docs/charts/metric.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import "./metric.pcss";
 	import { VisXYContainer, VisLine, VisTooltip, VisScatter, VisCrosshair } from "@unovis/svelte";
 	import {
 		lineColors,
@@ -25,7 +24,12 @@
 	const y = [(d: Data) => d.today, (d: Data) => d.average];
 </script>
 
-<VisXYContainer {data} height={200} margin={{ top: 5, right: 10, left: 10, bottom: 0 }}>
+<VisXYContainer
+	class="vis-xy-container"
+	{data}
+	height={200}
+	margin={{ top: 5, right: 10, left: 10, bottom: 0 }}
+>
 	<VisTooltip />
 	<VisLine {x} {y} lineWidth={1} color={lineColors} />
 	<VisScatter
@@ -38,3 +42,11 @@
 	/>
 	<VisCrosshair template={tooltipTemplate} color={crosshairPointColors} />
 </VisXYContainer>
+
+<style>
+	:global(.vis-xy-container) {
+		--vis-tooltip-padding: "0px";
+		--vis-tooltip-background-color: "transparent";
+		--vis-tooltip-border-color: "transparent";
+	}
+</style>

--- a/apps/www/src/lib/components/docs/charts/metric.svelte
+++ b/apps/www/src/lib/components/docs/charts/metric.svelte
@@ -39,7 +39,7 @@
 </VisXYContainer>
 
 <style>
-	:root {
+	:global(:root) {
 		--vis-tooltip-padding: "0px";
 		--vis-tooltip-background-color: "transparent";
 		--vis-tooltip-border-color: "transparent";

--- a/apps/www/src/lib/components/docs/charts/metric.svelte
+++ b/apps/www/src/lib/components/docs/charts/metric.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import "./metric.pcss";
 	import { VisXYContainer, VisLine, VisTooltip, VisScatter, VisCrosshair } from "@unovis/svelte";
 	import {
 		lineColors,
@@ -37,11 +38,3 @@
 	/>
 	<VisCrosshair template={tooltipTemplate} color={crosshairPointColors} />
 </VisXYContainer>
-
-<style>
-	:global(:root) {
-		--vis-tooltip-padding: "0px";
-		--vis-tooltip-background-color: "transparent";
-		--vis-tooltip-border-color: "transparent";
-	}
-</style>

--- a/apps/www/src/lib/components/docs/charts/revenue.svelte
+++ b/apps/www/src/lib/components/docs/charts/revenue.svelte
@@ -1,40 +1,16 @@
 <script lang="ts">
-	import { VisXYContainer, VisLine } from "@unovis/svelte";
-	import { color } from "./helpers";
+	import { VisXYContainer, VisLine, VisScatter } from "@unovis/svelte";
+	import { color, scatterPointColors, scatterPointStrokeColors } from "./helpers";
 
 	const data = [
-		{
-			id: 1,
-			revenue: 10400,
-		},
-		{
-			id: 2,
-			revenue: 14405,
-		},
-		{
-			id: 3,
-			revenue: 9400,
-		},
-		{
-			id: 4,
-			revenue: 8200,
-		},
-		{
-			id: 5,
-			revenue: 7000,
-		},
-		{
-			id: 6,
-			revenue: 9600,
-		},
-		{
-			id: 7,
-			revenue: 11244,
-		},
-		{
-			id: 8,
-			revenue: 26475,
-		},
+		{ id: 1, revenue: 10400 },
+		{ id: 2, revenue: 14405 },
+		{ id: 3, revenue: 9400 },
+		{ id: 4, revenue: 8200 },
+		{ id: 5, revenue: 7000 },
+		{ id: 6, revenue: 9600 },
+		{ id: 7, revenue: 11244 },
+		{ id: 8, revenue: 26475 },
 	];
 	const x = (d: { revenue: number; id: number }) => d.id;
 	const y = (d: { revenue: number; id: number }) => d.revenue;
@@ -42,4 +18,12 @@
 
 <VisXYContainer {data} height="80">
 	<VisLine {x} {y} color={color()} />
+	<VisScatter
+		{x}
+		{y}
+		size={6}
+		color={scatterPointColors}
+		strokeColor={scatterPointStrokeColors}
+		strokeWidth={2}
+	/>
 </VisXYContainer>


### PR DESCRIPTION
Fixes: #789 

### Notes:

There is currently a warning/log.

```
[vite-plugin-svelte] /src/lib/components/docs/charts/metric.svelte:42:1 No scopable elements found in template. If you're using global styles in the style tag, you should move it into an external stylesheet file and import it in JS. See https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#where-should-i-put-my-global-styles.
```

This is on me. Because of an issue from Unovis,(the `style` prop issue), there is currently no way of overriding some styles, so what came to me right away was just using the `style` tags, and thus the warning. In the past, I just put said styles in a separate file as recommended by the warning, but I wanted to hear from you about an ideal approach/resolution.

P.S. If there is anything to add/remove, please lmk. 🙂 

### Before submitting the PR, please make sure you do the following

- [x] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Format & lint the code with `pnpm format` and `pnpm lint`
