### PR TITLE
chore: add event forwarding & types for default/ui/switch

### DIFF
--- a/apps/www/src/lib/registry/default/ui/switch/switch.svelte
+++ b/apps/www/src/lib/registry/default/ui/switch/switch.svelte
@@ -3,6 +3,7 @@
 	import { cn } from "$lib/utils";
 
 	type $$Props = SwitchPrimitive.Props;
+	type $$Events = SwitchPrimitive.Events;
 
 	let className: $$Props["class"] = undefined;
 	export let checked: $$Props["checked"] = undefined;
@@ -16,6 +17,8 @@
 		className
 	)}
 	{...$$restProps}
+	on:click
+	on:keydown
 >
 	<SwitchPrimitive.Thumb
 		class={cn(


### PR DESCRIPTION
# Add event forwarding & types for default/ui/switch

PR #220 added these events to `new-york/ui/switch.svelte`, but not into the `default` version of this component. This small change closes that gap, and also adds `type $$Events` for further parity with the New York component.
