### PR TITLE
docs:  data table project structure section

### DIFF
--- a/apps/www/src/styles/markdown.pcss
+++ b/apps/www/src/styles/markdown.pcss
@@ -39,6 +39,10 @@
 	@apply inline-block min-h-[1.5rem] w-full px-4 py-0.5;
 }
 
+[data-rehype-pretty-code-figure] > pre[data-language="txt"] > code[data-language="txt"] span[data-line] {
+	color: white;
+}
+
 [data-rehype-pretty-code-figure] [data-line-numbers] [data-line] {
 	@apply px-2;
 }


### PR DESCRIPTION
fixes: #802

on light theme the data table project structure section, text has same color as bg so is not showing
fixed in the markdown.pcss with a selector