### PR TITLE
feat: allow for default select icon to be hidden

### DIFF
--- a/apps/www/src/lib/registry/new-york/ui/select/select-item.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/select/select-item.svelte
@@ -1,37 +1,45 @@
 <script lang="ts">
-	import { cn } from "$lib/utils";
-	import { Select as SelectPrimitive } from "bits-ui";
-	import Check from "svelte-radix/Check.svelte";
+    import { cn } from '$lib/utils'
+    import Check from 'lucide-svelte/icons/check'
+    import { Select as SelectPrimitive } from 'bits-ui'
 
-	type $$Props = SelectPrimitive.ItemProps;
-	type $$Events = Required<SelectPrimitive.ItemEvents>;
+    type $$Props = SelectPrimitive.ItemProps
+    type $$Events = SelectPrimitive.ItemEvents
 
-	let className: $$Props["class"] = undefined;
-	export let value: $$Props["value"];
-	export let label: $$Props["label"] = undefined;
-	export let disabled: $$Props["disabled"] = undefined;
-	export { className as class };
+    let className: $$Props['class'] = undefined
+    export let value: $$Props['value']
+    export let label: $$Props['label'] = undefined
+    export let disabled: $$Props['disabled'] = undefined
+    export let showSelectIcon: $$Props['customItem'] = true
+    export { className as class }
 </script>
 
 <SelectPrimitive.Item
-	{value}
-	{disabled}
-	{label}
-	class={cn(
-		"relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:opacity-50",
-		className
-	)}
-	{...$$restProps}
-	on:click
-	on:pointermove
-	on:focusin
+    {value}
+    {disabled}
+    {label}
+    class={cn(
+        `relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 ${showSelectIcon ? 'pl-8' : 'py-1.5'} pr-2 text-sm outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:opacity-50`,
+        className
+    )}
+    {...$$restProps}
+    on:click
+    on:keydown
+    on:focusin
+    on:focusout
+    on:pointerleave
+    on:pointermove
 >
-	<span class="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
-		<SelectPrimitive.ItemIndicator>
-			<Check class="h-4 w-4" />
-		</SelectPrimitive.ItemIndicator>
-	</span>
-	<slot>
-		{label ? label : value}
-	</slot>
+    {#if showSelectIcon}
+        <span
+            class="absolute left-2 flex h-3.5 w-3.5 items-center justify-center"
+        >
+            <SelectPrimitive.ItemIndicator>
+                <Check class="h-4 w-4" />
+            </SelectPrimitive.ItemIndicator>
+        </span>
+    {/if}
+    <slot>
+        {label ? label : value}
+    </slot>
 </SelectPrimitive.Item>


### PR DESCRIPTION
I'd like to propose adding an option to switch off the default `select icon` in the `Select Input`.
This would allow using custom icons with ease by providing them right in the slot, or none at all if the dev prefers.

Example:
<img width="224" alt="Screenshot 2024-02-25 at 11 23 13" src="https://github.com/huntabyte/shadcn-svelte/assets/2837147/0100fcd5-166d-4b2e-9166-c190857b632e">

### Before submitting the PR, please make sure you do the following

- [x] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Format & lint the code with `pnpm format` and `pnpm lint`
