### PR TITLE
fix(docs): mail example github code url

### DIFF
--- a/apps/www/src/lib/config/docs.ts
+++ b/apps/www/src/lib/config/docs.ts
@@ -346,7 +346,7 @@ export const examples: Example[] = [
 	{
 		name: "Mail",
 		href: "/examples/mail",
-		code: "https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/lib/components/docs/mail",
+		code: "https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/routes/examples/mail",
 	},
 	{
 		name: "Dashboard",


### PR DESCRIPTION
the github url for the mail example in the docs leads to a 404
