### PR TITLE
fix: add `for` to labels in default/example/dialog-demo.svelte

### DIFF
--- a/apps/www/src/lib/registry/default/example/dialog-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/dialog-demo.svelte
@@ -16,11 +16,11 @@
 		</Dialog.Header>
 		<div class="grid gap-4 py-4">
 			<div class="grid grid-cols-4 items-center gap-4">
-				<Label class="text-right">Name</Label>
+				<Label for="name" class="text-right">Name</Label>
 				<Input id="name" value="Pedro Duarte" class="col-span-3" />
 			</div>
 			<div class="grid grid-cols-4 items-center gap-4">
-				<Label class="text-right">Username</Label>
+				<Label for="username" class="text-right">Username</Label>
 				<Input id="username" value="@peduarte" class="col-span-3" />
 			</div>
 		</div>


### PR DESCRIPTION
Added the html `for` attribute in labels for best practice. For some reason, this was featured in [New York](https://github.com/huntabyte/shadcn-svelte/blob/main/apps/www/src/lib/registry/new-york/example/dialog-demo.svelte) style but not default.