### PR TITLE
docs: synced readmes of playgrounds

### DIFF
--- a/apps/playground-ts/README.md
+++ b/apps/playground-ts/README.md
@@ -1,38 +1,5 @@
-# create-svelte
+## Using the playground
 
-Everything you need to build a Svelte project, powered by [`create-svelte`](https://github.com/sveltejs/kit/tree/main/packages/create-svelte).
-
-## Creating a project
-
-If you're seeing this, you've probably already done this step. Congrats!
-
-```bash
-# create a new project in the current directory
-npm create svelte@latest
-
-# create a new project in my-app
-npm create svelte@latest my-app
-```
-
-## Developing
-
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
-
-```bash
-npm run dev
-
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
-```
-
-## Building
-
-To create a production version of your app:
-
-```bash
-npm run build
-```
-
-You can preview the production build with `npm run preview`.
-
-> To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs/adapters) for your target environment.
+1. Run the dev server of `www`, ensuring it's running on port 5173.
+2. Run `pnpm scn <command_here>` to run a command in the playground.
+3. Run `pnpm reset` to reset the scn-specific configurations of the playground.


### PR DESCRIPTION
fixes: #833 
copied contents of playground-js/README to playground-ts/README