### PR TITLE
feat: add overflow-auto, remove sm:text-center to sheet

### DIFF
--- a/apps/www/src/lib/registry/default/ui/sheet/sheet-content.svelte
+++ b/apps/www/src/lib/registry/default/ui/sheet/sheet-content.svelte
@@ -27,7 +27,7 @@
 		{inTransitionConfig}
 		{outTransition}
 		{outTransitionConfig}
-		class={cn(sheetVariants({ side }), className)}
+		class={cn("overflow-auto", sheetVariants({ side }), className)}
 		{...$$restProps}
 	>
 		<slot />

--- a/apps/www/src/lib/registry/default/ui/sheet/sheet-header.svelte
+++ b/apps/www/src/lib/registry/default/ui/sheet/sheet-header.svelte
@@ -8,6 +8,6 @@
 	export { className as class };
 </script>
 
-<div class={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...$$restProps}>
+<div class={cn("flex flex-col space-y-2 text-left", className)} {...$$restProps}>
 	<slot />
 </div>


### PR DESCRIPTION
This component would be much better out of the box if it had 'overflow-auto' set. Additionally, `text-center` on smaller screens doesn't look very good and it spoils the look of the forms by making them look worse. 


Before:
![image](https://github.com/huntabyte/shadcn-svelte/assets/75502784/69528e63-95a4-44cc-bc51-2f7243839407)
After:
![image](https://github.com/huntabyte/shadcn-svelte/assets/75502784/459f9b30-27f0-49fc-8d3a-84f2544a8885)
