### PR TITLE
feat(cli): Warn about deleted components, order and progress

### DIFF
--- a/.changeset/famous-suns-compete.md
+++ b/.changeset/famous-suns-compete.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": patch
+---
+
+chore: Added unused file warnings for the `update` command

--- a/packages/cli/.prettierrc
+++ b/packages/cli/.prettierrc
@@ -3,7 +3,7 @@
 	"tabWidth": 4,
 	"singleQuote": false,
 	"trailingComma": "es5",
-	"printWidth": 90,
+	"printWidth": 100,
 	"endOfLine": "lf",
 	"pluginSearchDirs": false,
 	"plugins": [],

--- a/packages/cli/src/astravel/attachComments.js
+++ b/packages/cli/src/astravel/attachComments.js
@@ -34,8 +34,7 @@ function attachCommentsToNode(traveler, state, parent, children, findHeadingComm
 			boundComments.push(comment);
 			comment = comments[++index];
 		}
-		if (boundComments.length !== 0 && parent.comments == null)
-			parent.comments = boundComments;
+		if (boundComments.length !== 0 && parent.comments == null) parent.comments = boundComments;
 	}
 	// Attach comments to children
 	for (let i = 0, { length } = children; comment != null && i < length; i++) {

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -47,8 +47,6 @@ export const add = new Command()
 	)
 	.option("-p, --path <path>", "the path to add the component to.")
 	.action(async (components: string[], opts) => {
-		const highlight = logger.highlight;
-
 		try {
 			const options = addOptionsSchema.parse({
 				components,
@@ -123,7 +121,7 @@ export const add = new Command()
 				return;
 			}
 
-			logger.info(`Selected components:\n${highlight(selectedComponents)}`);
+			logger.info(`Selected components:\n${logger.highlight(selectedComponents)}`);
 
 			if (!options.yes) {
 				const { proceed } = await prompts({
@@ -171,9 +169,9 @@ export const add = new Command()
 				if (existingComponent.length && !options.overwrite) {
 					if (selectedComponents.includes(item.name)) {
 						logger.warn(
-							`\nComponent ${highlight(
+							`\nComponent ${logger.highlight(
 								item.name
-							)} already exists at ${highlight(
+							)} already exists at ${logger.highlight(
 								componentPath
 							)}. Use ${chalk.green("--overwrite")} to overwrite.`
 						);
@@ -207,16 +205,9 @@ export const add = new Command()
 					}
 
 					const packageManager = await getPackageManager(cwd);
-					await execa(
-						packageManager,
-						[
-							packageManager === "npm" ? "install" : "add",
-							...item.dependencies,
-						],
-						{
-							cwd,
-						}
-					);
+					await execa(packageManager, ["add", ...item.dependencies], {
+						cwd,
+					});
 				}
 
 				componentPaths.push(componentPath);
@@ -232,9 +223,8 @@ export const add = new Command()
 				);
 			}
 			spinner.succeed(`Done.`);
-			logger.info(
-				`Components installed at:\n- ${[...componentPaths].join("\n- ")}`
-			);
+			logger.info("Components installed at:");
+			logger.info(logger.highlight(componentPaths.map((path) => `- ${path}`).join("\n")));
 		} catch (error) {
 			handleError(error);
 		}

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -19,11 +19,7 @@ import {
 import { getPackageManager } from "../utils/get-package-manager";
 import { handleError } from "../utils/handle-error";
 import { logger } from "../utils/logger";
-import {
-	getRegistryBaseColor,
-	getRegistryBaseColors,
-	getRegistryStyles,
-} from "../utils/registry";
+import { getRegistryBaseColor, getRegistryBaseColors, getRegistryStyles } from "../utils/registry";
 import * as templates from "../utils/templates";
 
 const PROJECT_DEPENDENCIES = ["tailwind-variants", "clsx", "tailwind-merge"] as const;
@@ -79,9 +75,7 @@ export const init = new Command()
 			logger.info("");
 			logger.info(`${chalk.green("Success!")} Project initialization completed.`);
 			logger.info("");
-			logger.info(
-				"Don't forget to add the aliases you configured to your svelte.config.js!"
-			);
+			logger.info("Don't forget to add the aliases you configured to your svelte.config.js!");
 			logger.info("");
 
 			// // Update svelte.config.js
@@ -96,11 +90,7 @@ export const init = new Command()
 		}
 	});
 
-async function promptForConfig(
-	cwd: string,
-	defaultConfig: Config | null = null,
-	skip = false
-) {
+async function promptForConfig(cwd: string, defaultConfig: Config | null = null, skip = false) {
 	const highlight = logger.highlight;
 	const styles = await getRegistryStyles();
 	const baseColors = await getRegistryBaseColors();
@@ -226,9 +216,7 @@ export async function runInit(cwd: string, config: Config) {
 	// Ensure all resolved paths directories exist.
 	for (const [key, resolvedPath] of Object.entries(config.resolvedPaths)) {
 		// Determine if the path is a file or directory.
-		let dirname = path.extname(resolvedPath)
-			? path.dirname(resolvedPath)
-			: resolvedPath;
+		let dirname = path.extname(resolvedPath) ? path.dirname(resolvedPath) : resolvedPath;
 
 		// If the utils alias is set to something like "@/lib/utils",
 		// assume this is a file and remove the "utils" file name.
@@ -257,11 +245,7 @@ export async function runInit(cwd: string, config: Config) {
 	// Write css file.
 	const baseColor = await getRegistryBaseColor(config.tailwind.baseColor);
 	if (baseColor) {
-		await fs.writeFile(
-			config.resolvedPaths.tailwindCss,
-			baseColor.cssVarsTemplate,
-			"utf8"
-		);
+		await fs.writeFile(config.resolvedPaths.tailwindCss, baseColor.cssVarsTemplate, "utf8");
 	}
 
 	const utilsPath = config.resolvedPaths.utils + (config.typescript ? ".ts" : ".js");
@@ -281,7 +265,7 @@ export async function runInit(cwd: string, config: Config) {
 		config.style === "new-york" ? "svelte-radix" : "lucide-svelte",
 	];
 
-	await execa(packageManager, [packageManager === "npm" ? "install" : "add", ...deps], {
+	await execa(packageManager, ["add", ...deps], {
 		cwd,
 	});
 	dependenciesSpinner?.succeed();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,11 +13,7 @@ async function main() {
 	const program = new Command()
 		.name("shadcn-svelte")
 		.description("Add shadcn-svelte components to your project")
-		.version(
-			packageInfo.version || "1.0.0",
-			"-v, --version",
-			"display the version number"
-		);
+		.version(packageInfo.version || "1.0.0", "-v, --version", "display the version number");
 
 	program.addCommand(init).addCommand(add).addCommand(update);
 

--- a/packages/cli/src/utils/find-tsconfig.ts
+++ b/packages/cli/src/utils/find-tsconfig.ts
@@ -33,10 +33,7 @@ export async function find(filename: string, options?: TSConfckFindOptions) {
 }
 
 // Modified to also search for jsconfig.json
-async function tsconfigInDir(
-	dir: string,
-	options?: TSConfckFindOptions
-): Promise<string | void> {
+async function tsconfigInDir(dir: string, options?: TSConfckFindOptions): Promise<string | void> {
 	const tsconfig = path.join(dir, "tsconfig.json");
 	const jsconfig = path.join(dir, "jsconfig.json");
 

--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -29,9 +29,7 @@ export const rawConfigSchema = z
 			// cssVariables: z.boolean().default(true)
 		}),
 		aliases: z.object({
-			components: z
-				.string()
-				.transform((v) => v.replace(/[\u{0080}-\u{FFFF}]/gu, "")),
+			components: z.string().transform((v) => v.replace(/[\u{0080}-\u{FFFF}]/gu, "")),
 			utils: z.string().transform((v) => v.replace(/[\u{0080}-\u{FFFF}]/gu, "")),
 		}),
 		typescript: z.boolean().default(true),
@@ -77,13 +75,9 @@ export async function resolveConfigPaths(cwd: string, config: RawConfig) {
 	const isSvelteKit = isUsingSvelteKit(cwd);
 	if (isSvelteKit) {
 		const packageManager = await getPackageManager(cwd);
-		await execa(
-			packageManager === "npm" ? "npx" : packageManager,
-			["svelte-kit", "sync"],
-			{
-				cwd,
-			}
-		);
+		await execa(packageManager === "npm" ? "npx" : packageManager, ["svelte-kit", "sync"], {
+			cwd,
+		});
 	}
 
 	const tsconfigPath = await find(path.resolve(cwd, "package.json"), { root: cwd });
@@ -144,8 +138,6 @@ export async function getRawConfig(cwd: string): Promise<RawConfig | null> {
 
 		return rawConfigSchema.parse(config);
 	} catch (error) {
-		throw new Error(
-			`Invalid configuration found in ${logger.highlight(configPath)}.`
-		);
+		throw new Error(`Invalid configuration found in ${logger.highlight(configPath)}.`);
 	}
 }

--- a/packages/cli/src/utils/logger.ts
+++ b/packages/cli/src/utils/logger.ts
@@ -16,6 +16,6 @@ export const logger = {
 		console.log(chalk.green(...args));
 	},
 	highlight(...args: unknown[]) {
-		return chalk.cyan(...args);
+		return chalk.bold(chalk.cyan(...args));
 	},
 };

--- a/packages/cli/src/utils/registry/index.ts
+++ b/packages/cli/src/utils/registry/index.ts
@@ -75,10 +75,7 @@ export async function getRegistryBaseColor(baseColor: string) {
 	}
 }
 
-export async function resolveTree(
-	index: z.infer<typeof registryIndexSchema>,
-	names: string[]
-) {
+export async function resolveTree(index: z.infer<typeof registryIndexSchema>, names: string[]) {
 	const tree: z.infer<typeof registryIndexSchema> = [];
 
 	for (const name of names) {
@@ -97,15 +94,11 @@ export async function resolveTree(
 	}
 
 	return tree.filter(
-		(component, index, self) =>
-			self.findIndex((c) => c.name === component.name) === index
+		(component, index, self) => self.findIndex((c) => c.name === component.name) === index
 	);
 }
 
-export async function fetchTree(
-	config: Config,
-	tree: z.infer<typeof registryIndexSchema>
-) {
+export async function fetchTree(config: Config, tree: z.infer<typeof registryIndexSchema>) {
 	try {
 		const trueStyle = config.typescript ? config.style : `${config.style}-js`;
 		const paths = tree.map((item) => `styles/${trueStyle}/${item.name}.json`);
@@ -132,10 +125,7 @@ export async function getItemTargetPath(
 		return null;
 	}
 
-	return path.join(
-		config.resolvedPaths[parent as keyof typeof config.resolvedPaths],
-		type
-	);
+	return path.join(config.resolvedPaths[parent as keyof typeof config.resolvedPaths], type);
 }
 
 async function fetchRegistry(paths: string[]) {

--- a/packages/cli/src/utils/set-config.ts
+++ b/packages/cli/src/utils/set-config.ts
@@ -86,10 +86,7 @@ export async function addAliases(dir: string = "./src/lib/components/ui") {
 					return;
 				}
 
-				if (
-					aliasProp.type === "Property" &&
-					aliasProp.value.type === "ObjectExpression"
-				) {
+				if (aliasProp.type === "Property" && aliasProp.value.type === "ObjectExpression") {
 					aliasProp.value.properties.push(...createAliasProperties());
 				}
 			}

--- a/packages/cli/test/commands/init.spec.ts
+++ b/packages/cli/test/commands/init.spec.ts
@@ -26,8 +26,7 @@ it("init (config-full)", async () => {
 			light: {},
 			dark: {},
 		},
-		inlineColorsTemplate:
-			"@tailwind base;\n@tailwind components;\n@tailwind utilities;\n",
+		inlineColorsTemplate: "@tailwind base;\n@tailwind components;\n@tailwind utilities;\n",
 		cssVarsTemplate: "@tailwind base;\n@tailwind components;\n@tailwind utilities;\n",
 	});
 
@@ -41,11 +40,7 @@ it("init (config-full)", async () => {
 	await runInit(targetDir, config);
 
 	// mkDir mocks
-	expect(mockMkdir).toHaveBeenNthCalledWith(
-		1,
-		expect.stringContaining("src"),
-		expect.anything()
-	);
+	expect(mockMkdir).toHaveBeenNthCalledWith(1, expect.stringContaining("src"), expect.anything());
 	expect(mockMkdir).toHaveBeenNthCalledWith(
 		2,
 		expect.stringContaining("src/lib/components"),

--- a/packages/cli/test/utils/get-config.spec.ts
+++ b/packages/cli/test/utils/get-config.spec.ts
@@ -84,11 +84,7 @@ describe("getConfig", () => {
 					"../fixtures/config-partial",
 					"./src/app.pcss"
 				),
-				utils: path.resolve(
-					__dirname,
-					"../fixtures/config-partial",
-					"./src/lib/utils"
-				),
+				utils: path.resolve(__dirname, "../fixtures/config-partial", "./src/lib/utils"),
 			},
 			typescript: true,
 		});
@@ -117,16 +113,8 @@ describe("getConfig", () => {
 					"../fixtures/config-full",
 					"./tailwind.config.js"
 				),
-				tailwindCss: path.resolve(
-					__dirname,
-					"../fixtures/config-full",
-					"./src/app.pcss"
-				),
-				utils: path.resolve(
-					__dirname,
-					"../fixtures/config-full",
-					"./src/lib/utils"
-				),
+				tailwindCss: path.resolve(__dirname, "../fixtures/config-full", "./src/app.pcss"),
+				utils: path.resolve(__dirname, "../fixtures/config-full", "./src/lib/utils"),
 			},
 			typescript: true,
 		});
@@ -155,16 +143,8 @@ describe("getConfig", () => {
 					"../fixtures/config-vite",
 					"./tailwind.config.js"
 				),
-				tailwindCss: path.resolve(
-					__dirname,
-					"../fixtures/config-vite",
-					"./src/app.pcss"
-				),
-				utils: path.resolve(
-					__dirname,
-					"../fixtures/config-vite",
-					"./src/lib/utils"
-				),
+				tailwindCss: path.resolve(__dirname, "../fixtures/config-vite", "./src/app.pcss"),
+				utils: path.resolve(__dirname, "../fixtures/config-vite", "./src/lib/utils"),
 			},
 			typescript: true,
 		});
@@ -198,11 +178,7 @@ describe("getConfig", () => {
 					"../fixtures/config-jsconfig",
 					"./src/app.pcss"
 				),
-				utils: path.resolve(
-					__dirname,
-					"../fixtures/config-jsconfig",
-					"./src/lib/utils"
-				),
+				utils: path.resolve(__dirname, "../fixtures/config-jsconfig", "./src/lib/utils"),
 			},
 			typescript: false,
 		});


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Format & lint the code with `pnpm format` and `pnpm lint`

Fixes #827.

As per our discussion, warns the user at the end of the update process whenever a processed component no longer uses some files present in its directory.
Additionally, sort the components processed by name, and display the progress through an `index + 1/total` counter.

Demo:

https://github.com/huntabyte/shadcn-svelte/assets/43064022/2a5ef818-3adb-4ba4-b57a-b475bbe0a1ea