### PR TITLE
feat: Add Popover Close and minor type improvment

### DIFF
--- a/apps/www/src/lib/registry/default/ui/input/index.ts
+++ b/apps/www/src/lib/registry/default/ui/input/index.ts
@@ -1,6 +1,6 @@
 import Root from "./input.svelte";
 
-type FormInputEvent<T extends Event = Event> = T & {
+export type FormInputEvent<T extends Event = Event> = T & {
 	currentTarget: EventTarget & HTMLInputElement;
 };
 export type InputEvents = {

--- a/apps/www/src/lib/registry/default/ui/popover/index.ts
+++ b/apps/www/src/lib/registry/default/ui/popover/index.ts
@@ -2,13 +2,16 @@ import { Popover as PopoverPrimitive } from "bits-ui";
 import Content from "./popover-content.svelte";
 const Root = PopoverPrimitive.Root;
 const Trigger = PopoverPrimitive.Trigger;
+const Close = PopoverPrimitive.Close;
 
 export {
 	Root,
 	Content,
 	Trigger,
+	Close,
 	//
 	Root as Popover,
 	Content as PopoverContent,
 	Trigger as PopoverTrigger,
+	Close as PopoverClose,
 };

--- a/apps/www/src/lib/registry/new-york/ui/input/index.ts
+++ b/apps/www/src/lib/registry/new-york/ui/input/index.ts
@@ -1,6 +1,6 @@
 import Root from "./input.svelte";
 
-type FormInputEvent<T extends Event = Event> = T & {
+export type FormInputEvent<T extends Event = Event> = T & {
 	currentTarget: EventTarget & HTMLInputElement;
 };
 export type InputEvents = {

--- a/apps/www/src/lib/registry/new-york/ui/popover/index.ts
+++ b/apps/www/src/lib/registry/new-york/ui/popover/index.ts
@@ -2,13 +2,16 @@ import { Popover as PopoverPrimitive } from "bits-ui";
 import Content from "./popover-content.svelte";
 const Root = PopoverPrimitive.Root;
 const Trigger = PopoverPrimitive.Trigger;
+const Close = PopoverPrimitive.Close;
 
 export {
 	Root,
 	Content,
 	Trigger,
+	Close,
 	//
 	Root as Popover,
 	Content as PopoverContent,
 	Trigger as PopoverTrigger,
+	Close as PopoverClose,
 };


### PR DESCRIPTION
I needed to close the popover after the user clicks a button in the popover content.  That button would fire an event and does something.  However it would not close the popover.  By adding the existing popover close as a child its now possible to do this.

```
        <Popover.Root let:ids> 
            <Popover.Trigger asChild let:builder>
                <Button builders={[builder]} variant="outline">
                    <Upload/>
                    Upload PDF
                </Button>
            </Popover.Trigger>
            <Popover.Content> 
                <Popover.Close asChild let:builder>
                    <FileSelect builder={builder}/>
                </Popover.Close>
            </Popover.Content>
       </Popover.Root>
```

The inside my FileSelect component I can just use a button that does the file upload and it would close the popover.

```
	<Input type="file" on:change={handleFileChange} />
	<Button class="" on:click={handleFileUpload} disabled={isUploading} builders={[builder]}>
			Upload
	</Button>
```

Some minor improvement to input component useful to export FormInputEvent for other TS code to be properly typed.

`const handleChange = (event: FormInputEvent<Event>) => {...}`
