### PR TITLE
fix: Edit import of "$lib/utils" in new component "ScrollArea" for consistency across the repo

### DIFF
--- a/apps/www/src/lib/registry/default/ui/scroll-area/scroll-area-scrollbar.svelte
+++ b/apps/www/src/lib/registry/default/ui/scroll-area/scroll-area-scrollbar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { ScrollArea as ScrollAreaPrimitive } from "bits-ui";
-	import { cn } from "$lib/utils.js";
+	import { cn } from "$lib/utils";
 
 	type $$Props = ScrollAreaPrimitive.ScrollbarProps & {
 		orientation?: "vertical" | "horizontal";

--- a/apps/www/src/lib/registry/default/ui/scroll-area/scroll-area.svelte
+++ b/apps/www/src/lib/registry/default/ui/scroll-area/scroll-area.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { ScrollArea as ScrollAreaPrimitive } from "bits-ui";
-	import { cn } from "$lib/utils.js";
+	import { cn } from "$lib/utils";
 	import { Scrollbar } from "./index.js";
 
 	type $$Props = ScrollAreaPrimitive.Props & {


### PR DESCRIPTION
Make a small edit in the import of a new component to stay consistent and prevent potential conflicts, if only "utils.ts" and not "utils.js" exists