### PR TITLE
fix escape sequence in `.eslintrc` example

### DIFF
--- a/apps/www/src/content/installation/index.md
+++ b/apps/www/src/content/installation/index.md
@@ -101,7 +101,7 @@ One option is to add a `.eslintrc` file in the directory where you define your c
       "warn",
       {
         "argsIgnorePattern": "^_",
-        "varsIgnorePattern": "^\\$\\$(Props|Events|Slots|Generic)$"
+        "varsIgnorePattern": "^\\\\$\\\\$(Props|Events|Slots|Generic)$"
       }
     ]
   }


### PR DESCRIPTION
fixes #888.

The double escape sequence does the trick, tested locally.