### PR TITLE
docs: fix wrong line highlighting in form example

### DIFF
--- a/apps/www/src/content/components/form.md
+++ b/apps/www/src/content/components/form.md
@@ -158,7 +158,7 @@ We'll pass the `form` from the data returned from the load function to the form 
 
 ### Create an Action that handles the form submission
 
-```ts title="src/routes/settings/+page.server.ts" showLineNumbers {1-2,12-24}
+```ts title="src/routes/settings/+page.server.ts" showLineNumbers {1-2,13-25}
 import type { PageServerLoad, Actions } from "./$types.js";
 import { fail } from "@sveltejs/kit";
 import { superValidate } from "sveltekit-superforms";


### PR DESCRIPTION
In step 5 of the [form example](https://www.shadcn-svelte.com/docs/components/form), the highlighting of what lines need to be added is off. 

The last semicolon isn't highlighted, which could cause syntax errors for anyone following along with the example.

Shifting the highlighting by 1 line fixes this.