### PR TITLE
chore: Remove `@sveltejs/enhanced-img`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ web_modules/
 packages/cli/dist
 dist/
 dist
+generated-assets

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -31,7 +31,6 @@
 		"@playwright/test": "^1.42.1",
 		"@prettier/sync": "0.3.0",
 		"@sveltejs/adapter-cloudflare": "4.1.0",
-		"@sveltejs/enhanced-img": "^0.1.8",
 		"@sveltejs/kit": "^2.5.2",
 		"@sveltejs/vite-plugin-svelte": "^3.0.2",
 		"@types/d3-scale": "^4.0.8",

--- a/apps/www/src/__registry__/index.js
+++ b/apps/www/src/__registry__/index.js
@@ -411,7 +411,7 @@ export const Index = {
 		"combobox-dropdown-menu": {
 			name: "combobox-dropdown-menu",
 			type: "components:example",
-			registryDependencies: ["command", "dropdown-menu", "button"],
+			registryDependencies: ["button", "command", "dropdown-menu"],
 			component: () =>
 				import("../lib/registry/default/example/combobox-dropdown-menu.svelte").then(
 					(m) => m.default
@@ -431,7 +431,7 @@ export const Index = {
 		"combobox-popover": {
 			name: "combobox-popover",
 			type: "components:example",
-			registryDependencies: ["command", "popover", "button"],
+			registryDependencies: ["button", "command", "popover"],
 			component: () =>
 				import("../lib/registry/default/example/combobox-popover.svelte").then(
 					(m) => m.default
@@ -1649,7 +1649,7 @@ export const Index = {
 		"combobox-dropdown-menu": {
 			name: "combobox-dropdown-menu",
 			type: "components:example",
-			registryDependencies: ["command", "dropdown-menu", "button"],
+			registryDependencies: ["button", "command", "dropdown-menu"],
 			component: () =>
 				import("../lib/registry/new-york/example/combobox-dropdown-menu.svelte").then(
 					(m) => m.default
@@ -1669,7 +1669,7 @@ export const Index = {
 		"combobox-popover": {
 			name: "combobox-popover",
 			type: "components:example",
-			registryDependencies: ["command", "popover", "button"],
+			registryDependencies: ["button", "command", "popover"],
 			component: () =>
 				import("../lib/registry/new-york/example/combobox-popover.svelte").then(
 					(m) => m.default

--- a/apps/www/src/lib/components/docs/dashboard/dashboard-page.svelte
+++ b/apps/www/src/lib/components/docs/dashboard/dashboard-page.svelte
@@ -16,13 +16,13 @@
 		TeamSwitcher,
 	} from "./index.js";
 	import DatePickerWithRange from "$lib/registry/new-york/example/date-picker-with-range.svelte";
-	import DashboardLight from "$lib/img/examples/dashboard-light.png?enhanced";
-	import DashboardDark from "$lib/img/examples/dashboard-dark.png?enhanced";
+	import DashboardLight from "$lib/img/examples/dashboard-light.png";
+	import DashboardDark from "$lib/img/examples/dashboard-dark.png";
 </script>
 
 <div class="md:hidden">
-	<enhanced:img src={DashboardLight} alt="Dashboard Light" class="block dark:hidden" />
-	<enhanced:img src={DashboardDark} alt="Dashboard Dark" class="hidden dark:block" />
+	<img src={DashboardLight} width={1280} height={866} alt="Dashboard" class="block dark:hidden" />
+	<img src={DashboardDark} width={1280} height={866} alt="Dashboard" class="hidden dark:block" />
 </div>
 <div class="hidden flex-col md:flex">
 	<div class="border-b">

--- a/apps/www/src/routes/+page.svelte
+++ b/apps/www/src/routes/+page.svelte
@@ -7,8 +7,8 @@
 	import { cn } from "$lib/utils.js";
 	import Mail from "./examples/mail/(components)/mail.svelte";
 	import { accounts, mails } from "./examples/mail/data.js";
-	import MailLight from "$lib/img/examples/mail-light.png?enhanced";
-	import MailDark from "$lib/img/examples/mail-dark.png?enhanced";
+	import MailLight from "$lib/img/examples/mail-light.png";
+	import MailDark from "$lib/img/examples/mail-dark.png";
 
 	export let data;
 </script>
@@ -54,8 +54,8 @@
 		class="overflow-hidden rounded-lg border bg-background shadow-md md:hidden md:shadow-xl"
 	>
 		<div class="md:hidden">
-			<enhanced:img src={MailLight} alt="Mail" class="block dark:hidden" />
-			<enhanced:img src={MailDark} alt="Mail" class="hidden dark:block" />
+			<img src={MailLight} width={1280} height={727} alt="Mail" class="block dark:hidden" />
+			<img src={MailDark} width={1280} height={727} alt="Mail" class="hidden dark:block" />
 		</div>
 	</section>
 	<section class="hidden md:block">

--- a/apps/www/src/routes/examples/authentication/+page.svelte
+++ b/apps/www/src/routes/examples/authentication/+page.svelte
@@ -1,13 +1,25 @@
 <script lang="ts">
 	import { Button } from "$lib/registry/default/ui/button/index.js";
 	import UserAuthForm from "./(components)/user-auth-form.svelte";
-	import AuthenticationLight from "$lib/img/examples/authentication-light.png?enhanced";
-	import AuthenticationDark from "$lib/img/examples/authentication-dark.png?enhanced";
+	import AuthenticationLight from "$lib/img/examples/authentication-light.png";
+	import AuthenticationDark from "$lib/img/examples/authentication-dark.png";
 </script>
 
 <div class="md:hidden">
-	<enhanced:img src={AuthenticationLight} alt="Authentication" class="block dark:hidden" />
-	<enhanced:img src={AuthenticationDark} alt="Authentication" class="hidden dark:block" />
+	<img
+		src={AuthenticationLight}
+		width={1280}
+		height={843}
+		alt="Authentication"
+		class="block dark:hidden"
+	/>
+	<img
+		src={AuthenticationDark}
+		width={1280}
+		height={843}
+		alt="Authentication"
+		class="hidden dark:block"
+	/>
 </div>
 <div
 	class="container relative hidden h-[800px] flex-col items-center justify-center md:grid lg:max-w-none lg:grid-cols-2 lg:px-0"

--- a/apps/www/src/routes/examples/cards/+page.svelte
+++ b/apps/www/src/routes/examples/cards/+page.svelte
@@ -10,13 +10,13 @@
 		DemoContainer,
 		CardsTeamMembers,
 	} from "./(components)/index.js";
-	import CardsLight from "$lib/img/examples/cards-light.png?enhanced";
-	import CardsDark from "$lib/img/examples/cards-dark.png?enhanced";
+	import CardsLight from "$lib/img/examples/cards-light.png";
+	import CardsDark from "$lib/img/examples/cards-dark.png";
 </script>
 
 <div class="md:hidden">
-	<enhanced:img src={CardsLight} alt="Cards" class="block dark:hidden" />
-	<enhanced:img src={CardsDark} alt="Cards" class="hidden dark:block" />
+	<img src={CardsLight} width={1280} height={1214} alt="Cards" class="block dark:hidden" />
+	<img src={CardsDark} width={1280} height={1214} alt="Cards" class="hidden dark:block" />
 </div>
 <div
 	class="hidden items-start justify-center gap-6 rounded-lg p-8 md:grid lg:grid-cols-2 xl:grid-cols-3"

--- a/apps/www/src/routes/examples/forms/+layout.svelte
+++ b/apps/www/src/routes/examples/forms/+layout.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { Separator } from "$lib/registry/new-york/ui/separator/index.js";
 	import SidebarNav from "./(components)/sidebar-nav.svelte";
-	import FormsLight from "$lib/img/examples/forms-light.png?enhanced";
-	import FormsDark from "$lib/img/examples/forms-dark.png?enhanced";
+	import FormsLight from "$lib/img/examples/forms-light.png";
+	import FormsDark from "$lib/img/examples/forms-dark.png";
 
 	const sidebarNavItems = [
 		{
@@ -29,8 +29,8 @@
 </script>
 
 <div class="md:hidden">
-	<enhanced:img src={FormsLight} alt="Forms" class="block dark:hidden" />
-	<enhanced:img src={FormsDark} alt="Forms" class="hidden dark:block" />
+	<img src={FormsLight} width={1280} height={791} alt="Forms" class="block dark:hidden" />
+	<img src={FormsDark} width={1280} height={791} alt="Forms" class="hidden dark:block" />
 </div>
 <div class="hidden space-y-6 p-10 pb-16 md:block">
 	<div class="space-y-0.5">

--- a/apps/www/src/routes/examples/mail/(components)/mail.svelte
+++ b/apps/www/src/routes/examples/mail/(components)/mail.svelte
@@ -12,8 +12,8 @@
 	import * as Tabs from "$lib/registry/new-york/ui/tabs/index.js";
 	import Search from "lucide-svelte/icons/search";
 	import type { Account, Mail } from "../data.js";
-	import MailLight from "$lib/img/examples/mail-light.png?enhanced";
-	import MailDark from "$lib/img/examples/mail-dark.png?enhanced";
+	import MailLight from "$lib/img/examples/mail-light.png";
+	import MailDark from "$lib/img/examples/mail-dark.png";
 
 	export let accounts: Account[];
 	export let mails: Mail[];
@@ -39,8 +39,8 @@
 </script>
 
 <div class="md:hidden">
-	<enhanced:img src={MailLight} alt="Mail" class="block dark:hidden" />
-	<enhanced:img src={MailDark} alt="Mail" class="hidden dark:block" />
+	<img src={MailLight} width={1280} height={1114} alt="Mail" class="block dark:hidden" />
+	<img src={MailDark} width={1280} height={1114} alt="Mail" class="hidden dark:block" />
 </div>
 <div class="hidden md:block">
 	<Resizable.PaneGroup

--- a/apps/www/src/routes/examples/music/+page.svelte
+++ b/apps/www/src/routes/examples/music/+page.svelte
@@ -7,13 +7,13 @@
 	import { AlbumArtwork, Sidebar, Menu, PodcastEmptyPlaceholder } from "./(components)/index.js";
 	import { playlists } from "./(data)/playlists.js";
 	import { listenNowAlbums, madeForYouAlbums } from "./(data)/albums.js";
-	import MusicLight from "$lib/img/examples/music-light.png?enhanced";
-	import MusicDark from "$lib/img/examples/music-dark.png?enhanced";
+	import MusicLight from "$lib/img/examples/music-light.png";
+	import MusicDark from "$lib/img/examples/music-dark.png";
 </script>
 
 <div class="md:hidden">
-	<enhanced:img src={MusicLight} alt="Music" class="block dark:hidden" />
-	<enhanced:img src={MusicDark} alt="Music" class="hidden dark:block" />
+	<img src={MusicLight} width={1280} height={1114} alt="Music" class="block dark:hidden" />
+	<img src={MusicDark} width={1280} height={1114} alt="Music" class="hidden dark:block" />
 </div>
 <div class="hidden md:block">
 	<Menu />

--- a/apps/www/src/routes/examples/playground/+page.svelte
+++ b/apps/www/src/routes/examples/playground/+page.svelte
@@ -19,13 +19,25 @@
 	} from "./(components)/index.js";
 	import { models, types } from "./(data)/models.js";
 	import { presets } from "./(data)/presets.js";
-	import PlaygroundLight from "$lib/img/examples/playground-light.png?enhanced";
-	import PlaygroundDark from "$lib/img/examples/playground-dark.png?enhanced";
+	import PlaygroundLight from "$lib/img/examples/playground-light.png";
+	import PlaygroundDark from "$lib/img/examples/playground-dark.png";
 </script>
 
 <div class="md:hidden">
-	<enhanced:img src={PlaygroundLight} alt="Playground" class="block dark:hidden" />
-	<enhanced:img src={PlaygroundDark} alt="Playground" class="hidden dark:block" />
+	<img
+		src={PlaygroundLight}
+		width={1280}
+		height={916}
+		alt="Playground"
+		class="block dark:hidden"
+	/>
+	<img
+		src={PlaygroundDark}
+		width={1280}
+		height={916}
+		alt="Playground"
+		class="hidden dark:block"
+	/>
 </div>
 <div class="hidden h-full flex-col md:flex">
 	<div

--- a/apps/www/src/routes/examples/tasks/+page.svelte
+++ b/apps/www/src/routes/examples/tasks/+page.svelte
@@ -2,13 +2,13 @@
 	import DataTable from "./(components)/data-table.svelte";
 	import UserNav from "./(components)/user-nav.svelte";
 	import data from "./(data)/tasks.json";
-	import TasksLight from "$lib/img/examples/tasks-light.png?enhanced";
-	import TasksDark from "$lib/img/examples/tasks-dark.png?enhanced";
+	import TasksLight from "$lib/img/examples/tasks-light.png";
+	import TasksDark from "$lib/img/examples/tasks-dark.png";
 </script>
 
 <div class="md:hidden">
-	<enhanced:img src={TasksLight} alt="Tasks" class="block dark:hidden" />
-	<enhanced:img src={TasksDark} alt="Tasks" class="hidden dark:block" />
+	<img src={TasksLight} alt="Tasks" class="block dark:hidden" />
+	<img src={TasksDark} alt="Tasks" class="hidden dark:block" />
 </div>
 <div class="hidden h-full flex-1 flex-col space-y-8 p-8 md:flex">
 	<div class="flex items-center justify-between space-y-2">

--- a/apps/www/static/registry/styles/default-js/breadcrumb.json
+++ b/apps/www/static/registry/styles/default-js/breadcrumb.json
@@ -5,7 +5,7 @@
 	"files": [
 		{
 			"name": "breadcrumb-ellipsis.svelte",
-			"content": "<script>\n\timport MoreHorizontal from \"lucide-svelte/icons/more-horizontal\";\n\timport { cn } from \"$lib/utils.js\";\n\texport let el = undefined;\n\tlet className = undefined;\n\texport { className as class };\n</script>\n\n<span\n\tbind:this={el}\n\trole=\"presentation\"\n\taria-hidden=\"true\"\n\tclass={cn(\"flex h-9 w-9 items-center justify-center\", className)}\n\t{...$$restProps}\n>\n\t<MoreHorizontal class=\"h-4 w-4\" />\n\t<span class=\"sr-only\">More</span>\n</span>\n"
+			"content": "<script>\n\timport { cn } from \"$lib/utils.js\";\n\timport Ellipsis from \"lucide-svelte/icons/ellipsis\";\n\texport let el = undefined;\n\tlet className = undefined;\n\texport { className as class };\n</script>\n\n<span\n\tbind:this={el}\n\trole=\"presentation\"\n\taria-hidden=\"true\"\n\tclass={cn(\"flex h-9 w-9 items-center justify-center\", className)}\n\t{...$$restProps}\n>\n\t<Ellipsis class=\"h-4 w-4\" />\n\t<span class=\"sr-only\">More</span>\n</span>\n"
 		},
 		{
 			"name": "breadcrumb-item.svelte",

--- a/apps/www/static/registry/styles/default-js/pagination.json
+++ b/apps/www/static/registry/styles/default-js/pagination.json
@@ -17,7 +17,7 @@
 		},
 		{
 			"name": "pagination-ellipsis.svelte",
-			"content": "<script>\n\timport MoreHorizontal from \"lucide-svelte/icons/more-horizontal\";\n\timport { cn } from \"$lib/utils.js\";\n\tlet className = undefined;\n\texport { className as class };\n</script>\n\n<span\n\taria-hidden\n\tclass={cn(\"flex h-9 w-9 items-center justify-center\", className)}\n\t{...$$restProps}\n>\n\t<MoreHorizontal class=\"h-4 w-4\" />\n\t<span class=\"sr-only\">More pages</span>\n</span>\n"
+			"content": "<script>\n\timport { cn } from \"$lib/utils.js\";\n\timport Ellipsis from \"lucide-svelte/icons/ellipsis\";\n\tlet className = undefined;\n\texport { className as class };\n</script>\n\n<span\n\taria-hidden\n\tclass={cn(\"flex h-9 w-9 items-center justify-center\", className)}\n\t{...$$restProps}\n>\n\t<Ellipsis class=\"h-4 w-4\" />\n\t<span class=\"sr-only\">More pages</span>\n</span>\n"
 		},
 		{
 			"name": "pagination-item.svelte",

--- a/apps/www/static/registry/styles/default/breadcrumb.json
+++ b/apps/www/static/registry/styles/default/breadcrumb.json
@@ -5,7 +5,7 @@
 	"files": [
 		{
 			"name": "breadcrumb-ellipsis.svelte",
-			"content": "<script lang=\"ts\">\n\timport type { HTMLAttributes } from \"svelte/elements\";\n\timport MoreHorizontal from \"lucide-svelte/icons/more-horizontal\";\n\timport { cn } from \"$lib/utils.js\";\n\n\ttype $$Props = HTMLAttributes<HTMLSpanElement> & {\n\t\tel?: HTMLSpanElement;\n\t};\n\n\texport let el: $$Props[\"el\"] = undefined;\n\tlet className: $$Props[\"class\"] = undefined;\n\texport { className as class };\n</script>\n\n<span\n\tbind:this={el}\n\trole=\"presentation\"\n\taria-hidden=\"true\"\n\tclass={cn(\"flex h-9 w-9 items-center justify-center\", className)}\n\t{...$$restProps}\n>\n\t<MoreHorizontal class=\"h-4 w-4\" />\n\t<span class=\"sr-only\">More</span>\n</span>\n"
+			"content": "<script lang=\"ts\">\n\timport { cn } from \"$lib/utils.js\";\n\timport Ellipsis from \"lucide-svelte/icons/ellipsis\";\n\timport type { HTMLAttributes } from \"svelte/elements\";\n\n\ttype $$Props = HTMLAttributes<HTMLSpanElement> & {\n\t\tel?: HTMLSpanElement;\n\t};\n\n\texport let el: $$Props[\"el\"] = undefined;\n\tlet className: $$Props[\"class\"] = undefined;\n\texport { className as class };\n</script>\n\n<span\n\tbind:this={el}\n\trole=\"presentation\"\n\taria-hidden=\"true\"\n\tclass={cn(\"flex h-9 w-9 items-center justify-center\", className)}\n\t{...$$restProps}\n>\n\t<Ellipsis class=\"h-4 w-4\" />\n\t<span class=\"sr-only\">More</span>\n</span>\n"
 		},
 		{
 			"name": "breadcrumb-item.svelte",

--- a/apps/www/static/registry/styles/default/pagination.json
+++ b/apps/www/static/registry/styles/default/pagination.json
@@ -17,7 +17,7 @@
 		},
 		{
 			"name": "pagination-ellipsis.svelte",
-			"content": "<script lang=\"ts\">\n\timport MoreHorizontal from \"lucide-svelte/icons/more-horizontal\";\n\timport { cn } from \"$lib/utils.js\";\n\timport type { HTMLAttributes } from \"svelte/elements\";\n\n\ttype $$Props = HTMLAttributes<HTMLSpanElement>;\n\n\tlet className: $$Props[\"class\"] = undefined;\n\texport { className as class };\n</script>\n\n<span\n\taria-hidden\n\tclass={cn(\"flex h-9 w-9 items-center justify-center\", className)}\n\t{...$$restProps}\n>\n\t<MoreHorizontal class=\"h-4 w-4\" />\n\t<span class=\"sr-only\">More pages</span>\n</span>\n"
+			"content": "<script lang=\"ts\">\n\timport { cn } from \"$lib/utils.js\";\n\timport Ellipsis from \"lucide-svelte/icons/ellipsis\";\n\timport type { HTMLAttributes } from \"svelte/elements\";\n\n\ttype $$Props = HTMLAttributes<HTMLSpanElement>;\n\n\tlet className: $$Props[\"class\"] = undefined;\n\texport { className as class };\n</script>\n\n<span\n\taria-hidden\n\tclass={cn(\"flex h-9 w-9 items-center justify-center\", className)}\n\t{...$$restProps}\n>\n\t<Ellipsis class=\"h-4 w-4\" />\n\t<span class=\"sr-only\">More pages</span>\n</span>\n"
 		},
 		{
 			"name": "pagination-item.svelte",

--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -1,9 +1,8 @@
 import { sveltekit } from "@sveltejs/kit/vite";
 import { defineConfig } from "vitest/config";
-import { enhancedImages } from "@sveltejs/enhanced-img";
 
 export default defineConfig({
-	plugins: [enhancedImages(), sveltekit()],
+	plugins: [sveltekit()],
 	test: {
 		include: ["src/**/*.{test,spec}.{js,ts}"],
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,9 +262,6 @@ importers:
       '@sveltejs/adapter-cloudflare':
         specifier: 4.1.0
         version: 4.1.0(@sveltejs/kit@2.5.2)
-      '@sveltejs/enhanced-img':
-        specifier: ^0.1.8
-        version: 0.1.8(svelte@4.2.12)
       '@sveltejs/kit':
         specifier: ^2.5.2
         version: 2.5.2(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@4.2.12)(vite@5.1.5)
@@ -880,14 +877,6 @@ packages:
   /@cloudflare/workers-types@4.20240222.0:
     resolution: {integrity: sha512-luO0BdK3rLlCv3B240+cTrfqm+XSbHtpk+88aJtGwzyVK9QF/Xz8lBgE/oZZLN8nCTmOvxAZnszyxUuZ8GP8Cg==}
     dev: true
-
-  /@emnapi/runtime@0.45.0:
-    resolution: {integrity: sha512-Txumi3td7J4A/xTTwlssKieHKTGl3j4A1tglBx72auZ49YK7ePY6XZricgIg9mnZT4xPfA+UPCUdnhRuEFDL+w==}
-    requiresBuild: true
-    dependencies:
-      tslib: 2.6.2
-    dev: true
-    optional: true
 
   /@emotion/babel-plugin@11.11.0:
     resolution: {integrity: sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==}
@@ -1863,194 +1852,6 @@ packages:
       - supports-color
     dev: true
 
-  /@img/sharp-darwin-arm64@0.33.2:
-    resolution: {integrity: sha512-itHBs1rPmsmGF9p4qRe++CzCgd+kFYktnsoR1sbIAfsRMrJZau0Tt1AH9KVnufc2/tU02Gf6Ibujx+15qRE03w==}
-    engines: {glibc: '>=2.26', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.0.1
-    dev: true
-    optional: true
-
-  /@img/sharp-darwin-x64@0.33.2:
-    resolution: {integrity: sha512-/rK/69Rrp9x5kaWBjVN07KixZanRr+W1OiyKdXcbjQD6KbW+obaTeBBtLUAtbBsnlTTmWthw99xqoOS7SsySDg==}
-    engines: {glibc: '>=2.26', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.0.1
-    dev: true
-    optional: true
-
-  /@img/sharp-libvips-darwin-arm64@1.0.1:
-    resolution: {integrity: sha512-kQyrSNd6lmBV7O0BUiyu/OEw9yeNGFbQhbxswS1i6rMDwBBSX+e+rPzu3S+MwAiGU3HdLze3PanQ4Xkfemgzcw==}
-    engines: {macos: '>=11', npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@img/sharp-libvips-darwin-x64@1.0.1:
-    resolution: {integrity: sha512-eVU/JYLPVjhhrd8Tk6gosl5pVlvsqiFlt50wotCvdkFGf+mDNBJxMh+bvav+Wt3EBnNZWq8Sp2I7XfSjm8siog==}
-    engines: {macos: '>=10.13', npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@img/sharp-libvips-linux-arm64@1.0.1:
-    resolution: {integrity: sha512-bnGG+MJjdX70mAQcSLxgeJco11G+MxTz+ebxlz8Y3dxyeb3Nkl7LgLI0mXupoO+u1wRNx/iRj5yHtzA4sde1yA==}
-    engines: {glibc: '>=2.26', npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@img/sharp-libvips-linux-arm@1.0.1:
-    resolution: {integrity: sha512-FtdMvR4R99FTsD53IA3LxYGghQ82t3yt0ZQ93WMZ2xV3dqrb0E8zq4VHaTOuLEAuA83oDawHV3fd+BsAPadHIQ==}
-    engines: {glibc: '>=2.28', npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@img/sharp-libvips-linux-s390x@1.0.1:
-    resolution: {integrity: sha512-3+rzfAR1YpMOeA2zZNp+aYEzGNWK4zF3+sdMxuCS3ey9HhDbJ66w6hDSHDMoap32DueFwhhs3vwooAB2MaK4XQ==}
-    engines: {glibc: '>=2.28', npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@img/sharp-libvips-linux-x64@1.0.1:
-    resolution: {integrity: sha512-3NR1mxFsaSgMMzz1bAnnKbSAI+lHXVTqAHgc1bgzjHuXjo4hlscpUxc0vFSAPKI3yuzdzcZOkq7nDPrP2F8Jgw==}
-    engines: {glibc: '>=2.26', npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@img/sharp-libvips-linuxmusl-arm64@1.0.1:
-    resolution: {integrity: sha512-5aBRcjHDG/T6jwC3Edl3lP8nl9U2Yo8+oTl5drd1dh9Z1EBfzUKAJFUDTDisDjUwc7N4AjnPGfCA3jl3hY8uDg==}
-    engines: {musl: '>=1.2.2', npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@img/sharp-libvips-linuxmusl-x64@1.0.1:
-    resolution: {integrity: sha512-dcT7inI9DBFK6ovfeWRe3hG30h51cBAP5JXlZfx6pzc/Mnf9HFCQDLtYf4MCBjxaaTfjCCjkBxcy3XzOAo5txw==}
-    engines: {musl: '>=1.2.2', npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@img/sharp-linux-arm64@0.33.2:
-    resolution: {integrity: sha512-pz0NNo882vVfqJ0yNInuG9YH71smP4gRSdeL09ukC2YLE6ZyZePAlWKEHgAzJGTiOh8Qkaov6mMIMlEhmLdKew==}
-    engines: {glibc: '>=2.26', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.0.1
-    dev: true
-    optional: true
-
-  /@img/sharp-linux-arm@0.33.2:
-    resolution: {integrity: sha512-Fndk/4Zq3vAc4G/qyfXASbS3HBZbKrlnKZLEJzPLrXoJuipFNNwTes71+Ki1hwYW5lch26niRYoZFAtZVf3EGA==}
-    engines: {glibc: '>=2.28', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.0.1
-    dev: true
-    optional: true
-
-  /@img/sharp-linux-s390x@0.33.2:
-    resolution: {integrity: sha512-MBoInDXDppMfhSzbMmOQtGfloVAflS2rP1qPcUIiITMi36Mm5YR7r0ASND99razjQUpHTzjrU1flO76hKvP5RA==}
-    engines: {glibc: '>=2.28', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.0.1
-    dev: true
-    optional: true
-
-  /@img/sharp-linux-x64@0.33.2:
-    resolution: {integrity: sha512-xUT82H5IbXewKkeF5aiooajoO1tQV4PnKfS/OZtb5DDdxS/FCI/uXTVZ35GQ97RZXsycojz/AJ0asoz6p2/H/A==}
-    engines: {glibc: '>=2.26', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.0.1
-    dev: true
-    optional: true
-
-  /@img/sharp-linuxmusl-arm64@0.33.2:
-    resolution: {integrity: sha512-F+0z8JCu/UnMzg8IYW1TMeiViIWBVg7IWP6nE0p5S5EPQxlLd76c8jYemG21X99UzFwgkRo5yz2DS+zbrnxZeA==}
-    engines: {musl: '>=1.2.2', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.0.1
-    dev: true
-    optional: true
-
-  /@img/sharp-linuxmusl-x64@0.33.2:
-    resolution: {integrity: sha512-+ZLE3SQmSL+Fn1gmSaM8uFusW5Y3J9VOf+wMGNnTtJUMUxFhv+P4UPaYEYT8tqnyYVaOVGgMN/zsOxn9pSsO2A==}
-    engines: {musl: '>=1.2.2', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.0.1
-    dev: true
-    optional: true
-
-  /@img/sharp-wasm32@0.33.2:
-    resolution: {integrity: sha512-fLbTaESVKuQcpm8ffgBD7jLb/CQLcATju/jxtTXR1XCLwbOQt+OL5zPHSDMmp2JZIeq82e18yE0Vv7zh6+6BfQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
-    cpu: [wasm32]
-    requiresBuild: true
-    dependencies:
-      '@emnapi/runtime': 0.45.0
-    dev: true
-    optional: true
-
-  /@img/sharp-win32-ia32@0.33.2:
-    resolution: {integrity: sha512-okBpql96hIGuZ4lN3+nsAjGeggxKm7hIRu9zyec0lnfB8E7Z6p95BuRZzDDXZOl2e8UmR4RhYt631i7mfmKU8g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@img/sharp-win32-x64@0.33.2:
-    resolution: {integrity: sha512-E4magOks77DK47FwHUIGH0RYWSgRBfGdK56kIHSVeB9uIS4pPFr4N2kIVsXdQQo4LzOsENKV5KAhRlRL7eMAdg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@internationalized/date@3.5.2:
     resolution: {integrity: sha512-vo1yOMUt2hzp63IutEaTUxROdvQg1qlMRsbCvbay2AK2Gai7wIgCyK5weEX3nHkiLgo4qCXHijFNC/ILhlRpOQ==}
     dependencies:
@@ -2247,20 +2048,6 @@ packages:
       prettier: 3.2.5
     dev: true
 
-  /@rollup/pluginutils@5.1.0:
-    resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-    dependencies:
-      '@types/estree': 1.0.5
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-    dev: true
-
   /@rollup/rollup-android-arm-eabi@4.12.1:
     resolution: {integrity: sha512-iU2Sya8hNn1LhsYyf0N+L4Gf9Qc+9eBTJJJsaOGUp+7x4n2M9dxTt8UvhJl3oeftSjblSlpCfvjA/IfP3g5VjQ==}
     cpu: [arm]
@@ -2410,17 +2197,6 @@ packages:
       '@sveltejs/kit': 2.5.2(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@4.2.12)(vite@5.1.5)
       esbuild: 0.19.12
       worktop: 0.8.0-next.18
-    dev: true
-
-  /@sveltejs/enhanced-img@0.1.8(svelte@4.2.12):
-    resolution: {integrity: sha512-0cLVR9KiO0/t3VVm64OM7bPHTkdaT2aaz1rwoAhao+EBXR3vMvLoYXLHvz8o9/552PSV8G844RkH7qkGc3YAiQ==}
-    dependencies:
-      magic-string: 0.30.8
-      svelte-parse-markup: 0.1.2(svelte@4.2.12)
-      vite-imagetools: 6.2.9
-    transitivePeerDependencies:
-      - rollup
-      - svelte
     dev: true
 
   /@sveltejs/kit@2.5.2(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@4.2.12)(vite@5.1.5):
@@ -3714,21 +3490,6 @@ packages:
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  /color-string@1.9.1:
-    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
-    dependencies:
-      color-name: 1.1.4
-      simple-swizzle: 0.2.2
-    dev: true
-
-  /color@4.2.3:
-    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
-    engines: {node: '>=12.5.0'}
-    dependencies:
-      color-convert: 2.0.1
-      color-string: 1.9.1
-    dev: true
-
   /comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
     dev: true
@@ -4179,11 +3940,6 @@ packages:
 
   /detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /detect-libc@2.0.2:
-    resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
     engines: {node: '>=8'}
     dev: true
 
@@ -4685,10 +4441,6 @@ packages:
   /estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
-    dev: true
-
-  /estree-walker@2.0.2:
-    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
     dev: true
 
   /estree-walker@3.0.3:
@@ -5412,13 +5164,6 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
-  /imagetools-core@6.0.4:
-    resolution: {integrity: sha512-N1qs5qn7u9nR3kboISkYuvJm8MohiphCfBa+wx1UOropVaFis9/mh6wuDPLHJNhl6/64C7q2Pch5NASVKAaSrg==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      sharp: 0.33.2
-    dev: true
-
   /import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
@@ -5478,10 +5223,6 @@ packages:
 
   /is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
-
-  /is-arrayish@0.3.2:
-    resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
-    dev: true
 
   /is-bigint@1.0.4:
     resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
@@ -7581,36 +7322,6 @@ packages:
       has-property-descriptors: 1.0.2
     dev: true
 
-  /sharp@0.33.2:
-    resolution: {integrity: sha512-WlYOPyyPDiiM07j/UO+E720ju6gtNtHjEGg5vovUk1Lgxyjm2LFO+37Nt/UI3MMh2l6hxTWQWi7qk3cXJTutcQ==}
-    engines: {libvips: '>=8.15.1', node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    requiresBuild: true
-    dependencies:
-      color: 4.2.3
-      detect-libc: 2.0.2
-      semver: 7.6.0
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.33.2
-      '@img/sharp-darwin-x64': 0.33.2
-      '@img/sharp-libvips-darwin-arm64': 1.0.1
-      '@img/sharp-libvips-darwin-x64': 1.0.1
-      '@img/sharp-libvips-linux-arm': 1.0.1
-      '@img/sharp-libvips-linux-arm64': 1.0.1
-      '@img/sharp-libvips-linux-s390x': 1.0.1
-      '@img/sharp-libvips-linux-x64': 1.0.1
-      '@img/sharp-libvips-linuxmusl-arm64': 1.0.1
-      '@img/sharp-libvips-linuxmusl-x64': 1.0.1
-      '@img/sharp-linux-arm': 0.33.2
-      '@img/sharp-linux-arm64': 0.33.2
-      '@img/sharp-linux-s390x': 0.33.2
-      '@img/sharp-linux-x64': 0.33.2
-      '@img/sharp-linuxmusl-arm64': 0.33.2
-      '@img/sharp-linuxmusl-x64': 0.33.2
-      '@img/sharp-wasm32': 0.33.2
-      '@img/sharp-win32-ia32': 0.33.2
-      '@img/sharp-win32-x64': 0.33.2
-    dev: true
-
   /shebang-command@1.2.0:
     resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
     engines: {node: '>=0.10.0'}
@@ -7664,12 +7375,6 @@ packages:
     resolution: {integrity: sha512-TtCytVYfV77pILCkzVxpOSgYKHQyaO7fBI/iwG5bLGb0dIo/v/K1Y1IZ5DN40RQu6WNNJiN0gkuRvSYjxOhFog==}
     hasBin: true
     requiresBuild: true
-    dev: true
-
-  /simple-swizzle@0.2.2:
-    resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
-    dependencies:
-      is-arrayish: 0.3.2
     dev: true
 
   /sirv@2.0.4:
@@ -8071,14 +7776,6 @@ packages:
       svelte: 4.2.12
     dev: false
 
-  /svelte-parse-markup@0.1.2(svelte@4.2.12):
-    resolution: {integrity: sha512-DycY7DJr7VqofiJ63ut1/NEG92HrWWL56VWITn/cJCu+LlZhMoBkBXT4opUitPEEwbq1nMQbv4vTKUfbOqIW1g==}
-    peerDependencies:
-      svelte: ^3.0.0 || ^4.0.0
-    dependencies:
-      svelte: 4.2.12
-    dev: true
-
   /svelte-preprocess@5.1.3(postcss-load-config@4.0.2)(postcss@8.4.35)(svelte@4.2.12)(typescript@5.3.3):
     resolution: {integrity: sha512-xxAkmxGHT+J/GourS5mVJeOXZzne1FR5ljeOUAMXUkfEhkLEllRreXpbl3dIYJlcJRfL1LO1uIAPpBpBfiqGPw==}
     engines: {node: '>= 16.0.0', pnpm: ^8.0.0}
@@ -8234,6 +7931,23 @@ packages:
     peerDependencies:
       '@sveltejs/kit': 1.x || 2.x
       svelte: 3.x || 4.x || >=5.0.0-next.51
+    peerDependenciesMeta:
+      '@sinclair/typebox':
+        optional: true
+      '@vinejs/vine':
+        optional: true
+      arktype:
+        optional: true
+      joi:
+        optional: true
+      superstruct:
+        optional: true
+      valibot:
+        optional: true
+      yup:
+        optional: true
+      zod:
+        optional: true
     dependencies:
       '@sveltejs/kit': 2.5.2(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@4.2.12)(vite@5.1.5)
       devalue: 4.3.2
@@ -8873,16 +8587,6 @@ packages:
       '@types/unist': 3.0.2
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
-    dev: true
-
-  /vite-imagetools@6.2.9:
-    resolution: {integrity: sha512-C4ZYhgj2vAj43/TpZ06XlDNP0p/7LIeYbgUYr+xG44nM++4HGX6YZBKAYpiBNgiCFUTJ6eXkRppWBrfPMevgmg==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@rollup/pluginutils': 5.1.0
-      imagetools-core: 6.0.4
-    transitivePeerDependencies:
-      - rollup
     dev: true
 
   /vite-node@0.34.6(@types/node@18.19.22):


### PR DESCRIPTION
While `@sveltejs/enhanced-img` is a great plugin for optimizing images for SK, it unfortunately slows down our build pipeline by a significant amount. Previously, it would take a little under 2 minutes to complete a fresh build, whereas now it takes about 8 minutes. 

Currently, there's no available plugin/config option to cache the generated images, meaning that all images need to be processed (twice!) on _every_ build. Our little GH runner just can't keep up. 

We'll reevaluate once the ability to cache is implemented.

### Before submitting the PR, please make sure you do the following

- [ ] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [ ] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Format & lint the code with `pnpm format` and `pnpm lint`
