### PR TITLE
fix: styles for `Select.Trigger`

### DIFF
--- a/apps/www/src/lib/registry/default/example/cards/report-issue.svelte
+++ b/apps/www/src/lib/registry/default/example/cards/report-issue.svelte
@@ -79,7 +79,7 @@
 				<Select.Root selected={securityLevels[1]}>
 					<Select.Trigger
 						id="security-level-{id}"
-						class="w-full overflow-hidden truncate"
+						class="w-full truncate"
 					>
 						<Select.Value placeholder="Select level" />
 					</Select.Trigger>

--- a/apps/www/src/lib/registry/default/example/cards/report-issue.svelte
+++ b/apps/www/src/lib/registry/default/example/cards/report-issue.svelte
@@ -77,7 +77,10 @@
 			<div class="grid gap-2">
 				<Label for="security-level-{id}">Security Level</Label>
 				<Select.Root selected={securityLevels[1]}>
-					<Select.Trigger id="security-level-{id}" class="overflow w-full truncate">
+					<Select.Trigger
+						id="security-level-{id}"
+						class="w-full overflow-hidden truncate"
+					>
 						<Select.Value placeholder="Select level" />
 					</Select.Trigger>
 					<Select.Content>

--- a/apps/www/src/lib/registry/default/example/cards/report-issue.svelte
+++ b/apps/www/src/lib/registry/default/example/cards/report-issue.svelte
@@ -77,7 +77,7 @@
 			<div class="grid gap-2">
 				<Label for="security-level-{id}">Security Level</Label>
 				<Select.Root selected={securityLevels[1]}>
-					<Select.Trigger id="security-level-{id}" class="line-clamp-1 w-full truncate">
+					<Select.Trigger id="security-level-{id}" class="overflow w-full truncate">
 						<Select.Value placeholder="Select level" />
 					</Select.Trigger>
 					<Select.Content>

--- a/apps/www/src/lib/registry/default/example/cards/report-issue.svelte
+++ b/apps/www/src/lib/registry/default/example/cards/report-issue.svelte
@@ -77,10 +77,7 @@
 			<div class="grid gap-2">
 				<Label for="security-level-{id}">Security Level</Label>
 				<Select.Root selected={securityLevels[1]}>
-					<Select.Trigger
-						id="security-level-{id}"
-						class="w-full truncate"
-					>
+					<Select.Trigger id="security-level-{id}" class="w-full truncate">
 						<Select.Value placeholder="Select level" />
 					</Select.Trigger>
 					<Select.Content>

--- a/apps/www/src/lib/registry/new-york/example/cards/report-issue.svelte
+++ b/apps/www/src/lib/registry/new-york/example/cards/report-issue.svelte
@@ -76,7 +76,7 @@
 			<div class="grid gap-2">
 				<Label for="security-level-{id}">Security Level</Label>
 				<Select.Root selected={securityLevels[1]}>
-					<Select.Trigger id="security-level-{id}" class="line-clamp-1 truncate">
+					<Select.Trigger id="security-level-{id}" class="overflow truncate">
 						<Select.Value placeholder="Select level" />
 					</Select.Trigger>
 					<Select.Content>

--- a/apps/www/src/lib/registry/new-york/example/cards/report-issue.svelte
+++ b/apps/www/src/lib/registry/new-york/example/cards/report-issue.svelte
@@ -76,7 +76,7 @@
 			<div class="grid gap-2">
 				<Label for="security-level-{id}">Security Level</Label>
 				<Select.Root selected={securityLevels[1]}>
-					<Select.Trigger id="security-level-{id}" class="overflow-hidden truncate">
+					<Select.Trigger id="security-level-{id}" class="truncate">
 						<Select.Value placeholder="Select level" />
 					</Select.Trigger>
 					<Select.Content>

--- a/apps/www/src/lib/registry/new-york/example/cards/report-issue.svelte
+++ b/apps/www/src/lib/registry/new-york/example/cards/report-issue.svelte
@@ -76,7 +76,7 @@
 			<div class="grid gap-2">
 				<Label for="security-level-{id}">Security Level</Label>
 				<Select.Root selected={securityLevels[1]}>
-					<Select.Trigger id="security-level-{id}" class="overflow truncate">
+					<Select.Trigger id="security-level-{id}" class="overflow-hidden truncate">
 						<Select.Value placeholder="Select level" />
 					</Select.Trigger>
 					<Select.Content>


### PR DESCRIPTION
Fix an issue in "/themes" page - report issue component:
![Screenshot 2024-03-15 at 21 19 03](https://github.com/huntabyte/shadcn-svelte/assets/32222578/8ffc80e3-a949-4faf-8320-db554c8fb90b)
"line-clamp-1" is setting the display to "-webkit-box" which overwrite the "flex" class therefore I have remove "line-clamp-1" from the classes and add "overflow-hidden" instead.

Closes: #1020 