### PR TITLE
fix(cli): Fix update script end log incorrectly displaying, fix init script utils file creation

### DIFF
--- a/.changeset/twenty-apes-rescue.md
+++ b/.changeset/twenty-apes-rescue.md
@@ -2,4 +2,4 @@
 "shadcn-svelte": patch
 ---
 
-fix: Fix line of log incorrectly showing
+fix: Fixed component update warning and malformed filename for `utils`

--- a/.changeset/twenty-apes-rescue.md
+++ b/.changeset/twenty-apes-rescue.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": patch
+---
+
+fix: Fix line of log incorrectly showing

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -209,7 +209,7 @@ export const update = new Command()
 					files.map((file) => chalk.white(`- ${path.relative(cwd, file)}`)).join("\n")
 				);
 			}
-			if (Object.keys(componentsToRemove)) {
+			if (Object.keys(componentsToRemove).length > 0) {
 				logger.warn("\nYou may want to remove them.");
 			}
 		} catch (e) {

--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -12,7 +12,7 @@ import { resolveImport } from "./resolve-imports";
 
 export const DEFAULT_STYLE = "default";
 export const DEFAULT_COMPONENTS = "$lib/components";
-export const DEFAULT_UTILS = "$lib/utils.js";
+export const DEFAULT_UTILS = "$lib/utils";
 export const DEFAULT_TAILWIND_CSS = "src/app.pcss";
 export const DEFAULT_TAILWIND_CONFIG = "tailwind.config.cjs";
 export const DEFAULT_TAILWIND_BASE_COLOR = "slate";


### PR DESCRIPTION
### Before submitting the PR, please make sure you do the following

- [x] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Format & lint the code with `pnpm format` and `pnpm lint`

Fixes #914, which fixes #844.

Fix incorrect falsy value when checking if there are components to remove at the end of the update process.

Also, fix the init script, which incorrectly creates a `utils.js.ts` file. The file extension is already added upon creation, so we don't need this. We might however need the file extension within the config file or a better alias resolution mechanism, so maybe I should move that out of this PR? Or maybe it's a good first fix for the file creation?