### PR TITLE
Fix: ui fix for labels of sidebarNavItem

### DIFF
--- a/apps/www/src/lib/components/docs/nav/docs-sidebar-nav-items.svelte
+++ b/apps/www/src/lib/components/docs/nav/docs-sidebar-nav-items.svelte
@@ -13,7 +13,7 @@
 				<a
 					href={item.href}
 					class={cn(
-						"group flex w-full items-center rounded-md border border-transparent px-2 py-1 hover:underline",
+						"w-full rounded-md border border-transparent px-2 py-1 hover:underline",
 						item.disabled && "cursor-not-allowed opacity-60",
 						$page.url.pathname === item.href
 							? "font-medium text-foreground"
@@ -25,7 +25,7 @@
 					{item.title}
 					{#if item.label}
 						<span
-							class="ml-2 rounded-md bg-[#adfa1d] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline"
+							class="inline-block ml-1 rounded-md bg-[#adfa1d] px-1.5 py-0.5 text-xs leading-none text-[#000000]"
 						>
 							{item.label}
 						</span>


### PR DESCRIPTION
The labels of sidebarNavItem were erroneously displaying underlines despite having the no-underline class applied.

The no-underline class alone was not affecting the span element's style as expected. This is because the text-decoration property was being inherited from the parent <a /> element. By setting the display property of the label to "inline-block", we prevent it from inheriting the underline style when the anchor is hovered over.

before
![Screenshot 2024-03-19 at 22 04 56](https://github.com/huntabyte/shadcn-svelte/assets/32222578/31220c30-9e1e-42ea-ac8e-6af8eae34563)

after
![image](https://github.com/huntabyte/shadcn-svelte/assets/32222578/2b3f438a-3634-43bd-acfa-7ba2625b9d5a)
