### PR TITLE
chore: More CLI optimizations

### DIFF
--- a/.changeset/fifty-falcons-dream.md
+++ b/.changeset/fifty-falcons-dream.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": patch
+---
+
+chore: Replaced `tsconfig-paths` for a custom path alias resolver

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,8 +48,7 @@
 		"find-up": "^7.0.0",
 		"https-proxy-agent": "^7.0.4",
 		"is-unicode-supported": "^2.0.0",
-		"node-fetch": "^3.3.2",
-		"tsconfig-paths": "^4.2.0"
+		"node-fetch": "^3.3.2"
 	},
 	"devDependencies": {
 		"@types/node": "^18.19.22",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,7 +7,7 @@ process.on("SIGINT", () => process.exit(0));
 process.on("SIGTERM", () => process.exit(0));
 
 const currentVersion = process.versions.node;
-const currentMajorVersion = parseInt(currentVersion.split(".")[0], 10);
+const currentMajorVersion = parseInt(currentVersion.split(".")[0]!, 10);
 const minimumMajorVersion = 18;
 
 if (currentMajorVersion < minimumMajorVersion) {

--- a/packages/cli/src/utils/get-package-manager.ts
+++ b/packages/cli/src/utils/get-package-manager.ts
@@ -63,7 +63,7 @@ async function detect(cwd: string) {
 	}
 
 	// detect based on lock
-	if (!agent && lockPath) agent = LOCKS[path.basename(lockPath)];
+	if (!agent && lockPath) agent = LOCKS[path.basename(lockPath)]!;
 
 	return agent;
 }

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -241,10 +241,10 @@ export const select = <Value>(opts: SelectOptions<Value>) => {
 
 			switch (this.state) {
 				case "submit":
-					return `${title}${color.gray(S_BAR)}  ${opt(this.options[this.cursor], "selected")}`;
+					return `${title}${color.gray(S_BAR)}  ${opt(this.options[this.cursor]!, "selected")}`;
 				case "cancel":
 					return `${title}${color.gray(S_BAR)}  ${opt(
-						this.options[this.cursor],
+						this.options[this.cursor]!,
 						"cancelled"
 					)}\n${color.gray(S_BAR)}`;
 				default: {
@@ -293,7 +293,7 @@ export const selectKey = <Value extends string>(opts: SelectOptions<Value>) => {
 						"selected"
 					)}`;
 				case "cancel":
-					return `${title}${color.gray(S_BAR)}  ${opt(this.options[0], "cancelled")}\n${color.gray(
+					return `${title}${color.gray(S_BAR)}  ${opt(this.options[0]!, "cancelled")}\n${color.gray(
 						S_BAR
 					)}`;
 				default: {
@@ -519,7 +519,7 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 							const groupActive =
 								!active &&
 								typeof option.group === "string" &&
-								this.options[this.cursor].value === option.group;
+								this.options[this.cursor]!.value === option.group;
 							if (groupActive) {
 								return opt(option, selected ? "group-active-selected" : "group-active", options);
 							}
@@ -543,7 +543,7 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 							const groupActive =
 								!active &&
 								typeof option.group === "string" &&
-								this.options[this.cursor].value === option.group;
+								this.options[this.cursor]!.value === option.group;
 							if (groupActive) {
 								return opt(option, selected ? "group-active-selected" : "group-active", options);
 							}

--- a/packages/cli/src/utils/registry/index.ts
+++ b/packages/cli/src/utils/registry/index.ts
@@ -112,6 +112,8 @@ export function getItemTargetPath(
 	}
 
 	const [parent, type] = item.type.split(":");
+	if (!parent || !type) return null;
+
 	if (!(parent in config.resolvedPaths)) {
 		return null;
 	}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -7,7 +7,8 @@
 		"module": "ES2020",
 		"target": "ES2020",
 		"skipLibCheck": true,
-		"strict": true
+		"strict": true,
+		"noUncheckedIndexedAccess": true
 	},
 	"include": ["src/**/*.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,9 +404,6 @@ importers:
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
-      tsconfig-paths:
-        specifier: ^4.2.0
-        version: 4.2.0
     devDependencies:
       '@types/node':
         specifier: ^18.19.22
@@ -5039,12 +5036,6 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
-  /json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
-    engines: {node: '>=6'}
-    hasBin: true
-    dev: false
-
   /jsonc-parser@3.2.1:
     resolution: {integrity: sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==}
     dev: true
@@ -7066,6 +7057,7 @@ packages:
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+    dev: true
 
   /strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
@@ -7696,15 +7688,6 @@ packages:
     dependencies:
       typescript: 5.3.3
     dev: true
-
-  /tsconfig-paths@4.2.0:
-    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
-    engines: {node: '>=6'}
-    dependencies:
-      json5: 2.2.3
-      minimist: 1.2.8
-      strip-bom: 3.0.0
-    dev: false
 
   /tslib@2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}


### PR DESCRIPTION
`tsconfig-paths` is a bit of a chonky dependency. I've replaced it for a custom path alias resolver that's much simpler for our needs.

### Before submitting the PR, please make sure you do the following

- [x] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Format & lint the code with `pnpm format` and `pnpm lint`
