### PR TITLE
fix: make copy Button` visible in hex to channel inputs

### DIFF
--- a/apps/www/src/lib/components/docs/copy-button.svelte
+++ b/apps/www/src/lib/components/docs/copy-button.svelte
@@ -76,9 +76,9 @@
 			>
 				<span class="sr-only">Copy</span>
 				{#if copied}
-					<Check class="h-3 w-3" />
+					<Check class="h-3 w-3" tabindex="-1" />
 				{:else}
-					<Copy class="h-3 w-3" />
+					<Copy class="h-3 w-3" tabindex="-1" />
 				{/if}
 			</Button>
 		</DropdownMenu.Trigger>
@@ -111,9 +111,9 @@
 	>
 		<span class="sr-only">Copy</span>
 		{#if copied}
-			<Check class="h-3 w-3" />
+			<Check class="h-3 w-3" tabindex="-1" />
 		{:else}
-			<Copy class="h-3 w-3" />
+			<Copy class="h-3 w-3" tabindex="-1" />
 		{/if}
 	</button>
 {/if}

--- a/apps/www/src/lib/components/docs/hex-to-channels.svelte
+++ b/apps/www/src/lib/components/docs/hex-to-channels.svelte
@@ -25,14 +25,20 @@
 			<Input name="hex" bind:value={hex} maxlength={7} />
 		</div>
 		<div class="relative grid gap-2">
-			<CopyButton class="absolute right-2 top-[30px]" value={hslString} />
 			<Label for="hsl">HSL</Label>
 			<Input name="hsl" value={hslString} readonly />
+			<CopyButton
+				class="absolute right-2 top-[28.5px] text-primary hover:bg-accent hover:text-primary"
+				value={hslString}
+			/>
 		</div>
 		<div class="relative grid gap-2">
-			<CopyButton class="absolute right-2 top-[30px]" value={rgbString} />
 			<Label for="rgb">RGB</Label>
 			<Input name="rgb" value={rgbString} readonly />
+			<CopyButton
+				class="absolute right-2 top-[28.5px] text-primary hover:bg-accent hover:text-primary"
+				value={rgbString}
+			/>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
Copy buttons for HSL and RGB inputs was using the same color as background, making them invisible on https://www.shadcn-svelte.com/docs/theming.  

- updated `CopyButton` color and hover color for these instances
- fix position of the CopyButtons
- moved `CopyButton` below input to focus on input before focus on copy buttons when navigating using keyboard
- remove tabindex from SVGs, which was causing double focus, both for button and SVGs when using navigating using keyboard. 

### Before
![Screenshot-2024-03-25_11 25](https://github.com/huntabyte/shadcn-svelte/assets/27728956/ae34ff9c-c7a4-46dc-8006-8f939a4ca8be)

### After
![Screenshot-2024-03-25_11 20 2](https://github.com/huntabyte/shadcn-svelte/assets/27728956/27c9ec8e-3149-44a7-96dd-c2fdea9ef7db)


### Before submitting the PR, please make sure you do the following

- [x] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- [x] Format & lint the code with `pnpm format` and `pnpm lint`
