### PR TITLE
fix: header height in `dashboard-03`

### DIFF
--- a/apps/www/src/lib/registry/default/block/dashboard-03.svelte
+++ b/apps/www/src/lib/registry/default/block/dashboard-03.svelte
@@ -138,7 +138,7 @@
 	</aside>
 	<div class="flex flex-col">
 		<header
-			class="sticky top-0 z-10 flex h-[53px] items-center gap-1 border-b bg-background px-4"
+			class="sticky top-0 z-10 flex h-[57px] items-center gap-1 border-b bg-background px-4"
 		>
 			<h1 class="text-xl font-semibold">Playground</h1>
 			<Drawer.Root>

--- a/apps/www/src/lib/registry/new-york/block/dashboard-03.svelte
+++ b/apps/www/src/lib/registry/new-york/block/dashboard-03.svelte
@@ -138,7 +138,7 @@
 	</aside>
 	<div class="flex flex-col">
 		<header
-			class="sticky top-0 z-10 flex h-[53px] items-center gap-1 border-b bg-background px-4"
+			class="sticky top-0 z-10 flex h-[57px] items-center gap-1 border-b bg-background px-4"
 		>
 			<h1 class="text-xl font-semibold">Playground</h1>
 			<Drawer.Root>


### PR DESCRIPTION
Fixes #961 by increasing header height to 57px, aligned to height in equivalent shadcn/ui block.

### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
