### PR TITLE
fix: Links to view source code in /examples

### DIFF
--- a/apps/www/src/lib/config/docs.ts
+++ b/apps/www/src/lib/config/docs.ts
@@ -354,41 +354,41 @@ export const examples: Example[] = [
 	{
 		name: "Mail",
 		href: "/examples/mail",
-		code: "https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/routes/examples/mail",
+		code: "https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/routes/(app)/examples/mail",
 	},
 	{
 		name: "Dashboard",
 		href: "/examples/dashboard",
-		code: "https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/lib/components/docs/dashboard",
+		code: "https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/routes/(app)/examples/dashboard",
 	},
 	{
 		name: "Cards",
 		href: "/examples/cards",
-		code: "https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/routes/examples/cards",
+		code: "https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/routes/(app)/examples/cards",
 	},
 	{
 		name: "Tasks",
 		href: "/examples/tasks",
-		code: "https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/routes/examples/tasks",
+		code: "https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/routes/(app)/examples/tasks",
 	},
 	{
 		name: "Playground",
 		href: "/examples/playground",
-		code: "https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/routes/examples/playground",
+		code: "https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/routes/(app)/examples/playground",
 	},
 	{
 		name: "Forms",
 		href: "/examples/forms",
-		code: "https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/routes/examples/forms",
+		code: "https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/routes/(app)/examples/forms",
 	},
 	{
 		name: "Music",
 		href: "/examples/music",
-		code: "https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/routes/examples/music",
+		code: "https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/routes/(app)/examples/music",
 	},
 	{
 		name: "Authentication",
 		href: "/examples/authentication",
-		code: "https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/routes/examples/authentication",
+		code: "https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/routes/(app)/examples/authentication",
 	},
 ];


### PR DESCRIPTION
Appended (app) route group to source code links.

e.g

from
`-code: "https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/routes/examples/mail",`

to

`code: "https://github.com/huntabyte/shadcn-svelte/tree/main/apps/www/src/routes/(app)/examples/mail",`


### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`

