### PR TITLE
fix: use UTC timezone for DOB field in account form example

### DIFF
--- a/apps/www/src/routes/(app)/examples/forms/account/account-form.svelte
+++ b/apps/www/src/routes/(app)/examples/forms/account/account-form.svelte
@@ -112,7 +112,7 @@
 								validate("dob");
 								return;
 							}
-							$formData.dob = value.toDate(getLocalTimeZone()).toISOString();
+							$formData.dob = value.toDate("UTC").toISOString();
 							validate("dob");
 						}}
 					/>


### PR DESCRIPTION
fixes #884 by hardcoding the timezone to UTC when the user selects a date of birth