### PR TITLE
docs: fix varsIgnorePattern in .eslintrc

### DIFF
--- a/apps/www/src/content/installation/index.md
+++ b/apps/www/src/content/installation/index.md
@@ -101,7 +101,7 @@ One option is to add a `.eslintrc` file in the directory where you define your c
       "warn",
       {
         "argsIgnorePattern": "^_",
-        "varsIgnorePattern": "^\\$\\$(Props|Events|Slots|Generic)$"
+        "varsIgnorePattern": "^\\\\$\\\\$(Props|Events|Slots|Generic)$"
       }
     ]
   }


### PR DESCRIPTION
### Notes

Currently, if you head over to https://www.shadcn-svelte.com/docs/installation#eslint-configuration, you'll notice that the ignore pattern displayed is
```
"varsIgnorePattern": "^\$\$(Props|Events|Slots|Generic)$"
```

This is wrong, since pasting that in your IDE yields:

```
Unnecessary escape character: \$.eslint[no-useless-escape](https://eslint.org/docs/latest/rules/no-useless-escape)
Unnecessary escape character: \$.eslint[no-useless-escape](https://eslint.org/docs/latest/rules/no-useless-escape)
```

The strange thing is, in the content docs, the correct config is written down, but for some reason some backslashes are "escaped."

I don't know if my fix is ideal, but I added extra backslashes to account for this, such that the correct var pattern is rendered in the UI.

i.e.

```
 "varsIgnorePattern": "^\\$\\$(Props|Events|Slots|Generic)$"
```

---

If you think there's a better way to correct this (at the `mdsvex` layer, maybe?), please let me know.

---

### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
