### PR TITLE
fix: tasks example causing overflow on the page

### DIFF
--- a/apps/www/src/lib/registry/default/ui/table/table.svelte
+++ b/apps/www/src/lib/registry/default/ui/table/table.svelte
@@ -8,7 +8,7 @@
 	export { className as class };
 </script>
 
-<div class="w-full overflow-auto">
+<div class="relative w-full overflow-auto">
 	<table class={cn("w-full caption-bottom text-sm", className)} {...$$restProps}>
 		<slot />
 	</table>

--- a/apps/www/src/lib/registry/new-york/ui/table/table.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/table/table.svelte
@@ -8,7 +8,7 @@
 	export { className as class };
 </script>
 
-<div class="w-full overflow-auto">
+<div class="relative w-full overflow-auto">
 	<table class={cn("w-full caption-bottom text-sm", className)} {...$$restProps}>
 		<slot />
 	</table>

--- a/apps/www/src/routes/(app)/examples/tasks/(components)/data-table-faceted-filter.svelte
+++ b/apps/www/src/routes/(app)/examples/tasks/(components)/data-table-faceted-filter.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import type { Task } from "./../(data)/schemas.ts";
 	import PlusCircled from "svelte-radix/PlusCircled.svelte";
 	import Check from "svelte-radix/Check.svelte";
 	import type { statuses } from "../(data)/data.js";

--- a/apps/www/src/routes/(app)/examples/tasks/(components)/data-table-faceted-filter.svelte
+++ b/apps/www/src/routes/(app)/examples/tasks/(components)/data-table-faceted-filter.svelte
@@ -58,6 +58,7 @@
 				<Command.Empty>No results found.</Command.Empty>
 				<Command.Group>
 					{#each options as option}
+						{@const Icon = option.icon}
 						<Command.Item
 							value={option.value}
 							onSelect={(currentValue) => {
@@ -74,6 +75,7 @@
 							>
 								<Check className={cn("h-4 w-4")} />
 							</div>
+							<Icon class="mr-2 h-4 w-4 text-muted-foreground" />
 							<span>
 								{option.label}
 							</span>

--- a/apps/www/src/routes/(app)/examples/tasks/(components)/data-table-faceted-filter.svelte
+++ b/apps/www/src/routes/(app)/examples/tasks/(components)/data-table-faceted-filter.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import type { Task } from "./../(data)/schemas.ts";
 	import PlusCircled from "svelte-radix/PlusCircled.svelte";
 	import Check from "svelte-radix/Check.svelte";
 	import type { statuses } from "../(data)/data.js";
@@ -12,6 +13,7 @@
 	export let filterValues: string[] = [];
 	export let title: string;
 	export let options = [] as typeof statuses;
+	export let counts: { [index: string]: number } = {};
 
 	let open = false;
 
@@ -79,6 +81,13 @@
 							<span>
 								{option.label}
 							</span>
+							{#if counts[option.value]}
+								<span
+									class="ml-auto flex h-4 w-4 items-center justify-center font-mono text-xs"
+								>
+									{counts[option.value]}
+								</span>
+							{/if}
 						</Command.Item>
 					{/each}
 				</Command.Group>

--- a/apps/www/src/routes/(app)/examples/tasks/(components)/data-table-row-actions.svelte
+++ b/apps/www/src/routes/(app)/examples/tasks/(components)/data-table-row-actions.svelte
@@ -17,7 +17,9 @@
 			class="flex h-8 w-8 p-0 data-[state=open]:bg-muted"
 		>
 			<DotsHorizontal class="h-4 w-4" />
-			<span class="sr-only">Open menu</span>
+			<span class="relative">
+				<span class="sr-only">Open Menu</span>
+			</span>
 		</Button>
 	</DropdownMenu.Trigger>
 	<DropdownMenu.Content class="w-[160px]" align="end">

--- a/apps/www/src/routes/(app)/examples/tasks/(components)/data-table-row-actions.svelte
+++ b/apps/www/src/routes/(app)/examples/tasks/(components)/data-table-row-actions.svelte
@@ -17,9 +17,7 @@
 			class="flex h-8 w-8 p-0 data-[state=open]:bg-muted"
 		>
 			<DotsHorizontal class="h-4 w-4" />
-			<span class="relative">
-				<span class="sr-only">Open Menu</span>
-			</span>
+			<span class="sr-only">Open Menu</span>
 		</Button>
 	</DropdownMenu.Trigger>
 	<DropdownMenu.Content class="w-[160px]" align="end">

--- a/apps/www/src/routes/(app)/examples/tasks/(components)/data-table-toolbar.svelte
+++ b/apps/www/src/routes/(app)/examples/tasks/(components)/data-table-toolbar.svelte
@@ -9,6 +9,22 @@
 	import { Input } from "$lib/registry/new-york/ui/input/index.js";
 
 	export let tableModel: TableViewModel<Task>;
+	export let data: Task[];
+
+	const counts = data.reduce<{
+		status: { [index: string]: number };
+		priority: { [index: string]: number };
+	}>(
+		(acc, { status, priority }) => {
+			acc.status[status] = (acc.status[status] || 0) + 1;
+			acc.priority[priority] = (acc.priority[priority] || 0) + 1;
+			return acc;
+		},
+		{
+			status: {},
+			priority: {},
+		}
+	);
 
 	const { pluginStates } = tableModel;
 	const {
@@ -42,11 +58,13 @@
 			bind:filterValues={$filterValues.status}
 			title="Status"
 			options={statuses}
+			counts={counts.status}
 		/>
 		<DataTableFacetedFilter
 			bind:filterValues={$filterValues.priority}
 			title="Priority"
 			options={priorities}
+			counts={counts.priority}
 		/>
 		{#if showReset}
 			<Button

--- a/apps/www/src/routes/(app)/examples/tasks/(components)/data-table.svelte
+++ b/apps/www/src/routes/(app)/examples/tasks/(components)/data-table.svelte
@@ -164,7 +164,7 @@
 </script>
 
 <div class="space-y-4">
-	<DataTableToolbar {tableModel} />
+	<DataTableToolbar {tableModel} {data} />
 	<div class="rounded-md border">
 		<Table.Root {...$tableAttrs}>
 			<Table.Header>

--- a/apps/www/static/registry/styles/default-js/table.json
+++ b/apps/www/static/registry/styles/default-js/table.json
@@ -37,7 +37,7 @@
 		},
 		{
 			"name": "table.svelte",
-			"content": "<script>\n\timport { cn } from \"$lib/utils.js\";\n\tlet className = undefined;\n\texport { className as class };\n</script>\n\n<div class=\"w-full overflow-auto\">\n\t<table class={cn(\"w-full caption-bottom text-sm\", className)} {...$$restProps}>\n\t\t<slot />\n\t</table>\n</div>\n"
+			"content": "<script>\n\timport { cn } from \"$lib/utils.js\";\n\tlet className = undefined;\n\texport { className as class };\n</script>\n\n<div class=\"relative w-full overflow-auto\">\n\t<table class={cn(\"w-full caption-bottom text-sm\", className)} {...$$restProps}>\n\t\t<slot />\n\t</table>\n</div>\n"
 		}
 	],
 	"type": "components:ui"

--- a/apps/www/static/registry/styles/default/table.json
+++ b/apps/www/static/registry/styles/default/table.json
@@ -37,7 +37,7 @@
 		},
 		{
 			"name": "table.svelte",
-			"content": "<script lang=\"ts\">\n\timport type { HTMLTableAttributes } from \"svelte/elements\";\n\timport { cn } from \"$lib/utils.js\";\n\n\ttype $$Props = HTMLTableAttributes;\n\n\tlet className: $$Props[\"class\"] = undefined;\n\texport { className as class };\n</script>\n\n<div class=\"w-full overflow-auto\">\n\t<table class={cn(\"w-full caption-bottom text-sm\", className)} {...$$restProps}>\n\t\t<slot />\n\t</table>\n</div>\n"
+			"content": "<script lang=\"ts\">\n\timport type { HTMLTableAttributes } from \"svelte/elements\";\n\timport { cn } from \"$lib/utils.js\";\n\n\ttype $$Props = HTMLTableAttributes;\n\n\tlet className: $$Props[\"class\"] = undefined;\n\texport { className as class };\n</script>\n\n<div class=\"relative w-full overflow-auto\">\n\t<table class={cn(\"w-full caption-bottom text-sm\", className)} {...$$restProps}>\n\t\t<slot />\n\t</table>\n</div>\n"
 		}
 	],
 	"type": "components:ui"

--- a/apps/www/static/registry/styles/new-york-js/table.json
+++ b/apps/www/static/registry/styles/new-york-js/table.json
@@ -37,7 +37,7 @@
 		},
 		{
 			"name": "table.svelte",
-			"content": "<script>\n\timport { cn } from \"$lib/utils.js\";\n\tlet className = undefined;\n\texport { className as class };\n</script>\n\n<div class=\"w-full overflow-auto\">\n\t<table class={cn(\"w-full caption-bottom text-sm\", className)} {...$$restProps}>\n\t\t<slot />\n\t</table>\n</div>\n"
+			"content": "<script>\n\timport { cn } from \"$lib/utils.js\";\n\tlet className = undefined;\n\texport { className as class };\n</script>\n\n<div class=\"relative w-full overflow-auto\">\n\t<table class={cn(\"w-full caption-bottom text-sm\", className)} {...$$restProps}>\n\t\t<slot />\n\t</table>\n</div>\n"
 		}
 	],
 	"type": "components:ui"

--- a/apps/www/static/registry/styles/new-york/table.json
+++ b/apps/www/static/registry/styles/new-york/table.json
@@ -37,7 +37,7 @@
 		},
 		{
 			"name": "table.svelte",
-			"content": "<script lang=\"ts\">\n\timport type { HTMLTableAttributes } from \"svelte/elements\";\n\timport { cn } from \"$lib/utils.js\";\n\n\ttype $$Props = HTMLTableAttributes;\n\n\tlet className: $$Props[\"class\"] = undefined;\n\texport { className as class };\n</script>\n\n<div class=\"w-full overflow-auto\">\n\t<table class={cn(\"w-full caption-bottom text-sm\", className)} {...$$restProps}>\n\t\t<slot />\n\t</table>\n</div>\n"
+			"content": "<script lang=\"ts\">\n\timport type { HTMLTableAttributes } from \"svelte/elements\";\n\timport { cn } from \"$lib/utils.js\";\n\n\ttype $$Props = HTMLTableAttributes;\n\n\tlet className: $$Props[\"class\"] = undefined;\n\texport { className as class };\n</script>\n\n<div class=\"relative w-full overflow-auto\">\n\t<table class={cn(\"w-full caption-bottom text-sm\", className)} {...$$restProps}>\n\t\t<slot />\n\t</table>\n</div>\n"
 		}
 	],
 	"type": "components:ui"


### PR DESCRIPTION
## Overflow
Faced this issue in my own project, and remembered I copied it from this example.
~The original shadcn does not need this workaround.. can't figure out why...~

Before:
- Shrink the page horizontally so that the table starts overflow-scrolling by a big chunk (>100px), the sr-only text in the triple dots menu will start overflowing the page too.

https://github.com/huntabyte/shadcn-svelte/assets/11229056/802bb127-2e83-499f-9230-9d5ba0c06415

After:
~- By wrapping the sr-only text in a relative span, as explained by a _maintainer_ of tailwindcss [here](https://github.com/tailwindlabs/tailwindcss/discussions/12429), we can prevent the page from overflowing... nice!~

The original shadcn fixes this using relative on the table component, instead of per sr-only span.
Last commit fixes this.

https://github.com/huntabyte/shadcn-svelte/assets/11229056/313f9ae6-f7c0-4fc1-b130-3dd2704b4e89


## Faceted Filter
Before:
<img width="193" alt="before" src="https://github.com/huntabyte/shadcn-svelte/assets/11229056/660487be-8ff2-428b-85a4-09edd9b811e1">


After:
<img width="235" alt="after" src="https://github.com/huntabyte/shadcn-svelte/assets/11229056/d9214ec3-c3ba-418c-831a-e42c35a78802">



TLDR:
- Fixed table component by adding relative, to fix overflowing bugs above
- Added icons and counts to the faceted filters

