### PR TITLE
docs: replace 'payment' with 'data' for consistency

### DIFF
--- a/apps/www/src/content/components/data-table.md
+++ b/apps/www/src/content/components/data-table.md
@@ -68,7 +68,7 @@ type Payment = {
   email: string;
 };
 
-export const payments: Payment[] = [
+export const data: Payment[] = [
   {
     id: "728ed52f",
     amount: 100,


### PR DESCRIPTION
For consistency, this PR replaces `payment` with `data` to align with the terminology used throughout the page (https://www.shadcn-svelte.com/docs/components/data-table)