### PR TITLE
fix: Add an error for unsupported runtimes

### DIFF
--- a/.changeset/calm-mails-fold.md
+++ b/.changeset/calm-mails-fold.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": patch
+---
+
+fix: Added an error for unsupported runtimes

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,13 @@ const currentVersion = process.versions.node;
 const currentMajorVersion = Number.parseInt(currentVersion.split(".")[0]!, 10);
 const minimumMajorVersion = 18;
 
+// @ts-expect-error types for these globals are not defined
+if (typeof Bun !== "undefined" || typeof Deno !== "undefined") {
+	console.error("You are currently using an unsupported runtime!");
+	console.error(`Please use Node.js v${minimumMajorVersion} or higher.`);
+	process.exit(1);
+}
+
 if (currentMajorVersion < minimumMajorVersion) {
 	console.error(`Node.js v${currentVersion} is out of date and unsupported!`);
 	console.error(`Please use Node.js v${minimumMajorVersion} or higher.`);


### PR DESCRIPTION
An error is now thrown when the CLI is running in an unsupported runtime (e.g. Bun or Deno).

closes #1003 

### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
