### PR TITLE
chore: Change unsupported runtime error

### DIFF
--- a/.changeset/fluffy-cobras-decide.md
+++ b/.changeset/fluffy-cobras-decide.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": patch
+---
+
+fix: Changed unsupported runtime error into a warning and fixed a Bun specific issue

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,14 +9,7 @@ process.on("SIGTERM", () => process.exit(0));
 
 const currentVersion = process.versions.node;
 const currentMajorVersion = Number.parseInt(currentVersion.split(".")[0]!, 10);
-const minimumMajorVersion = 18;
-
-// @ts-expect-error types for these globals are not defined
-if (typeof Bun !== "undefined" || typeof Deno !== "undefined") {
-	console.error("You are currently using an unsupported runtime!");
-	console.error(`Please use Node.js v${minimumMajorVersion} or higher.`);
-	process.exit(1);
-}
+export const minimumMajorVersion = 18;
 
 if (currentMajorVersion < minimumMajorVersion) {
 	console.error(`Node.js v${currentVersion} is out of date and unsupported!`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,7 +9,7 @@ process.on("SIGTERM", () => process.exit(0));
 
 const currentVersion = process.versions.node;
 const currentMajorVersion = Number.parseInt(currentVersion.split(".")[0]!, 10);
-export const minimumMajorVersion = 18;
+const minimumMajorVersion = 18;
 
 if (currentMajorVersion < minimumMajorVersion) {
 	console.error(`Node.js v${currentVersion} is out of date and unsupported!`);

--- a/packages/cli/src/utils/auto-detect.ts
+++ b/packages/cli/src/utils/auto-detect.ts
@@ -46,9 +46,9 @@ function find(dirPath: string, ignores: { dirPath: string; ig: Ignore }[]): stri
 	}
 
 	for (const file of files) {
-		const filepath = path.join(file.path, file.name);
+		const filepath = path.join(dirPath, file.name);
 		// ignore any of the common suspects
-		if (IGNORE.some((name) => file.path.includes(name))) continue;
+		if (IGNORE.some((name) => dirPath.includes(name))) continue;
 
 		// check if file is ignored
 		const ignored = ignores.some((parent) => {

--- a/packages/cli/src/utils/prompt-helpers.ts
+++ b/packages/cli/src/utils/prompt-helpers.ts
@@ -1,6 +1,5 @@
 import process from "node:process";
 import color from "chalk";
-import { minimumMajorVersion } from "../index.js";
 import * as p from "./prompts.js";
 import { getPackageInfo } from "./get-package-info.js";
 
@@ -13,7 +12,7 @@ export function intro() {
 	// @ts-expect-error types for these globals are not defined
 	if (typeof Bun !== "undefined" || typeof Deno !== "undefined") {
 		p.log.warn(
-			`You are currently using an unsupported runtime. Only Node.js v${minimumMajorVersion} or higher is officially supported. Continue at your own risk.`
+			`You are currently using an unsupported runtime. Only Node.js v18 or higher is officially supported. Continue at your own risk.`
 		);
 	}
 }

--- a/packages/cli/src/utils/prompt-helpers.ts
+++ b/packages/cli/src/utils/prompt-helpers.ts
@@ -1,5 +1,6 @@
 import process from "node:process";
 import color from "chalk";
+import { minimumMajorVersion } from "../index.js";
 import * as p from "./prompts.js";
 import { getPackageInfo } from "./get-package-info.js";
 
@@ -8,6 +9,13 @@ export function intro() {
 	const title = color.bgHex("#FF5500").black(" shadcn-svelte ");
 	const version = color.gray(` v${packageInfo.version} `);
 	p.intro(title + version);
+
+	// @ts-expect-error types for these globals are not defined
+	if (typeof Bun !== "undefined" || typeof Deno !== "undefined") {
+		p.log.warn(
+			`You are currently using an unsupported runtime. Only Node.js v${minimumMajorVersion} or higher is supported. Continue at your own risk.`
+		);
+	}
 }
 
 export function cancel() {

--- a/packages/cli/src/utils/prompt-helpers.ts
+++ b/packages/cli/src/utils/prompt-helpers.ts
@@ -13,7 +13,7 @@ export function intro() {
 	// @ts-expect-error types for these globals are not defined
 	if (typeof Bun !== "undefined" || typeof Deno !== "undefined") {
 		p.log.warn(
-			`You are currently using an unsupported runtime. Only Node.js v${minimumMajorVersion} or higher is supported. Continue at your own risk.`
+			`You are currently using an unsupported runtime. Only Node.js v${minimumMajorVersion} or higher is officially supported. Continue at your own risk.`
 		);
 	}
 }


### PR DESCRIPTION
Bun's compatibility module for Node's `fs` module is [incomplete](https://bun.sh/docs/runtime/nodejs-apis#node-fs). This resulted in an error when trying to access the `path` prop of a Dirent, which didn't exist (see: https://github.com/oven-sh/bun/issues/7358). 

In this particular case, the fix was trivial. However, future incompatibility issues isn't guaranteed to be as easy. Additionally, their compatibility promise for Node is incomplete. As such, Bun will stay unsupported.

I've also changed the "unsupported runtime error" message into a warning so it's no longer a hard block.

Closes #1003
Closes #1009 

### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
