### PR TITLE
docs: add docs to skip confirmation prompt to `update` command

### DIFF
--- a/apps/www/src/content/cli.md
+++ b/apps/www/src/content/cli.md
@@ -103,6 +103,7 @@ Arguments:
 
 Options:
   -a, --all        update all existing components. (default: false)
+  -y, --yes        skip confirmation prompt. (default: false)
   -c, --cwd <cwd>  the working directory. (default: the current directory)
   -h, --help       display help for command
 ```

--- a/apps/www/src/content/cli.md
+++ b/apps/www/src/content/cli.md
@@ -74,8 +74,8 @@ Arguments:
 
 Options:
   --nodep            disable adding & installing dependencies (advanced) (default: false)
-  -a, --all          Add all components to your project. (default: false)
-  -y, --yes          Skip confirmation prompt. (default: false)
+  -a, --all          add all components to your project. (default: false)
+  -y, --yes          skip confirmation prompt. (default: false)
   -o, --overwrite    overwrite existing files. (default: false)
   --proxy            fetch components from registry using a proxy.
   -c, --cwd <cwd>    the working directory. (default: the current directory)


### PR DESCRIPTION
I have added the option to skip the confirmation prompt to the `update` command to the cli docs. The option to the command is already present in the cli.

I have also written two description texts of options of the `add` command in lower case and thus aligned them with the other description texts. I hope it's okay that I have added this in this PR.