### PR TITLE
docs: form usage instruction fix

### DIFF
--- a/apps/www/src/content/components/form.md
+++ b/apps/www/src/content/components/form.md
@@ -118,9 +118,9 @@ For this example, we'll be passing the `form` returned from the load function as
   } from "sveltekit-superforms";
   import { zodClient } from "sveltekit-superforms/adapters";
 
-  export let data: SuperValidated<Infer<FormSchema>>;
+  export let data;
 
-  const form = superForm(data, {
+  const form = superForm(data.form, {
     validators: zodClient(formSchema),
   });
 


### PR DESCRIPTION
following instructions resulting in internal server error.

superForm accepts SuperValidated<Infer<FormSchema>> which is available at data.form not data


### Before submitting the PR, please make sure you do the following


- [x] If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- [x] Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- [x] This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
