### PR TITLE
fix: block - default dashboard-06 table columns

### DIFF
--- a/apps/www/src/lib/registry/default/block/dashboard-06.svelte
+++ b/apps/www/src/lib/registry/default/block/dashboard-06.svelte
@@ -293,16 +293,16 @@
 							<Table.Root>
 								<Table.Header>
 									<Table.Row>
-										<Table.Head class="sm:table.-cell hidden w-[100px]">
+										<Table.Head class="sm:table-cell hidden w-[100px]">
 											<span class="sr-only">Image</span>
 										</Table.Head>
 										<Table.Head>Name</Table.Head>
 										<Table.Head>Status</Table.Head>
-										<Table.Head class="md:table.-cell hidden">Price</Table.Head>
-										<Table.Head class="md:table.-cell hidden">
+										<Table.Head class="md:table-cell hidden">Price</Table.Head>
+										<Table.Head class="md:table-cell hidden">
 											Total Sales
 										</Table.Head>
-										<Table.Head class="md:table.-cell hidden">
+										<Table.Head class="md:table-cell hidden">
 											Created at
 										</Table.Head>
 										<Table.Head>
@@ -312,7 +312,7 @@
 								</Table.Header>
 								<Table.Body>
 									<Table.Row>
-										<Table.Cell class="sm:table.-cell hidden">
+										<Table.Cell class="sm:table-cell hidden">
 											<img
 												alt="Product example"
 												class="aspect-square rounded-md object-cover"
@@ -327,11 +327,11 @@
 										<Table.Cell>
 											<Badge variant="outline">Draft</Badge>
 										</Table.Cell>
-										<Table.Cell class="md:table.-cell hidden">
+										<Table.Cell class="md:table-cell hidden">
 											$499.99
 										</Table.Cell>
-										<Table.Cell class="md:table.-cell hidden">25</Table.Cell>
-										<Table.Cell class="md:table.-cell hidden">
+										<Table.Cell class="md:table-cell hidden">25</Table.Cell>
+										<Table.Cell class="md:table-cell hidden">
 											2023-07-12 10:42 AM
 										</Table.Cell>
 										<Table.Cell>
@@ -356,7 +356,7 @@
 										</Table.Cell>
 									</Table.Row>
 									<Table.Row>
-										<Table.Cell class="sm:table.-cell hidden">
+										<Table.Cell class="sm:table-cell hidden">
 											<img
 												alt="Product"
 												class="aspect-square rounded-md object-cover"
@@ -371,11 +371,11 @@
 										<Table.Cell>
 											<Badge variant="outline">Active</Badge>
 										</Table.Cell>
-										<Table.Cell class="md:table.-cell hidden">
+										<Table.Cell class="md:table-cell hidden">
 											$129.99
 										</Table.Cell>
-										<Table.Cell class="md:table.-cell hidden">100</Table.Cell>
-										<Table.Cell class="md:table.-cell hidden">
+										<Table.Cell class="md:table-cell hidden">100</Table.Cell>
+										<Table.Cell class="md:table-cell hidden">
 											2023-10-18 03:21 PM
 										</Table.Cell>
 										<Table.Cell>
@@ -400,7 +400,7 @@
 										</Table.Cell>
 									</Table.Row>
 									<Table.Row>
-										<Table.Cell class="sm:table.-cell hidden">
+										<Table.Cell class="sm:table-cell hidden">
 											<img
 												alt="Product"
 												class="aspect-square rounded-md object-cover"
@@ -415,11 +415,11 @@
 										<Table.Cell>
 											<Badge variant="outline">Active</Badge>
 										</Table.Cell>
-										<Table.Cell class="md:table.-cell hidden">
+										<Table.Cell class="md:table-cell hidden">
 											$39.99
 										</Table.Cell>
-										<Table.Cell class="md:table.-cell hidden">50</Table.Cell>
-										<Table.Cell class="md:table.-cell hidden">
+										<Table.Cell class="md:table-cell hidden">50</Table.Cell>
+										<Table.Cell class="md:table-cell hidden">
 											2023-11-29 08:15 AM
 										</Table.Cell>
 										<Table.Cell>
@@ -444,7 +444,7 @@
 										</Table.Cell>
 									</Table.Row>
 									<Table.Row>
-										<Table.Cell class="sm:table.-cell hidden">
+										<Table.Cell class="sm:table-cell hidden">
 											<img
 												alt="Product"
 												class="aspect-square rounded-md object-cover"
@@ -459,9 +459,9 @@
 										<Table.Cell>
 											<Badge variant="secondary">Draft</Badge>
 										</Table.Cell>
-										<Table.Cell class="md:table.-cell hidden">$2.99</Table.Cell>
-										<Table.Cell class="md:table.-cell hidden">0</Table.Cell>
-										<Table.Cell class="md:table.-cell hidden">
+										<Table.Cell class="md:table-cell hidden">$2.99</Table.Cell>
+										<Table.Cell class="md:table-cell hidden">0</Table.Cell>
+										<Table.Cell class="md:table-cell hidden">
 											2023-12-25 11:59 PM
 										</Table.Cell>
 										<Table.Cell>
@@ -486,7 +486,7 @@
 										</Table.Cell>
 									</Table.Row>
 									<Table.Row>
-										<Table.Cell class="sm:table.-cell hidden">
+										<Table.Cell class="sm:table-cell hidden">
 											<img
 												alt="Product"
 												class="aspect-square rounded-md object-cover"
@@ -501,11 +501,11 @@
 										<Table.Cell>
 											<Badge variant="outline">Active</Badge>
 										</Table.Cell>
-										<Table.Cell class="md:table.-cell hidden">
+										<Table.Cell class="md:table-cell hidden">
 											$59.99
 										</Table.Cell>
-										<Table.Cell class="md:table.-cell hidden">75</Table.Cell>
-										<Table.Cell class="md:table.-cell hidden">
+										<Table.Cell class="md:table-cell hidden">75</Table.Cell>
+										<Table.Cell class="md:table-cell hidden">
 											2024-01-01 12:00 AM
 										</Table.Cell>
 										<Table.Cell>
@@ -530,7 +530,7 @@
 										</Table.Cell>
 									</Table.Row>
 									<Table.Row>
-										<Table.Cell class="sm:table.-cell hidden">
+										<Table.Cell class="sm:table-cell hidden">
 											<img
 												alt="Product"
 												class="aspect-square rounded-md object-cover"
@@ -545,11 +545,11 @@
 										<Table.Cell>
 											<Badge variant="outline">Active</Badge>
 										</Table.Cell>
-										<Table.Cell class="md:table.-cell hidden">
+										<Table.Cell class="md:table-cell hidden">
 											$199.99
 										</Table.Cell>
-										<Table.Cell class="md:table.-cell hidden">30</Table.Cell>
-										<Table.Cell class="md:table.-cell hidden">
+										<Table.Cell class="md:table-cell hidden">30</Table.Cell>
+										<Table.Cell class="md:table-cell hidden">
 											2024-02-14 02:14 PM
 										</Table.Cell>
 										<Table.Cell>

--- a/apps/www/src/lib/registry/default/block/dashboard-06.svelte
+++ b/apps/www/src/lib/registry/default/block/dashboard-06.svelte
@@ -293,16 +293,16 @@
 							<Table.Root>
 								<Table.Header>
 									<Table.Row>
-										<Table.Head class="sm:table-cell hidden w-[100px]">
+										<Table.Head class="hidden w-[100px] sm:table-cell">
 											<span class="sr-only">Image</span>
 										</Table.Head>
 										<Table.Head>Name</Table.Head>
 										<Table.Head>Status</Table.Head>
-										<Table.Head class="md:table-cell hidden">Price</Table.Head>
-										<Table.Head class="md:table-cell hidden">
+										<Table.Head class="hidden md:table-cell">Price</Table.Head>
+										<Table.Head class="hidden md:table-cell">
 											Total Sales
 										</Table.Head>
-										<Table.Head class="md:table-cell hidden">
+										<Table.Head class="hidden md:table-cell">
 											Created at
 										</Table.Head>
 										<Table.Head>
@@ -312,7 +312,7 @@
 								</Table.Header>
 								<Table.Body>
 									<Table.Row>
-										<Table.Cell class="sm:table-cell hidden">
+										<Table.Cell class="hidden sm:table-cell">
 											<img
 												alt="Product example"
 												class="aspect-square rounded-md object-cover"
@@ -327,11 +327,11 @@
 										<Table.Cell>
 											<Badge variant="outline">Draft</Badge>
 										</Table.Cell>
-										<Table.Cell class="md:table-cell hidden">
+										<Table.Cell class="hidden md:table-cell">
 											$499.99
 										</Table.Cell>
-										<Table.Cell class="md:table-cell hidden">25</Table.Cell>
-										<Table.Cell class="md:table-cell hidden">
+										<Table.Cell class="hidden md:table-cell">25</Table.Cell>
+										<Table.Cell class="hidden md:table-cell">
 											2023-07-12 10:42 AM
 										</Table.Cell>
 										<Table.Cell>
@@ -356,7 +356,7 @@
 										</Table.Cell>
 									</Table.Row>
 									<Table.Row>
-										<Table.Cell class="sm:table-cell hidden">
+										<Table.Cell class="hidden sm:table-cell">
 											<img
 												alt="Product"
 												class="aspect-square rounded-md object-cover"
@@ -371,11 +371,11 @@
 										<Table.Cell>
 											<Badge variant="outline">Active</Badge>
 										</Table.Cell>
-										<Table.Cell class="md:table-cell hidden">
+										<Table.Cell class="hidden md:table-cell">
 											$129.99
 										</Table.Cell>
-										<Table.Cell class="md:table-cell hidden">100</Table.Cell>
-										<Table.Cell class="md:table-cell hidden">
+										<Table.Cell class="hidden md:table-cell">100</Table.Cell>
+										<Table.Cell class="hidden md:table-cell">
 											2023-10-18 03:21 PM
 										</Table.Cell>
 										<Table.Cell>
@@ -400,7 +400,7 @@
 										</Table.Cell>
 									</Table.Row>
 									<Table.Row>
-										<Table.Cell class="sm:table-cell hidden">
+										<Table.Cell class="hidden sm:table-cell">
 											<img
 												alt="Product"
 												class="aspect-square rounded-md object-cover"
@@ -415,11 +415,9 @@
 										<Table.Cell>
 											<Badge variant="outline">Active</Badge>
 										</Table.Cell>
-										<Table.Cell class="md:table-cell hidden">
-											$39.99
-										</Table.Cell>
-										<Table.Cell class="md:table-cell hidden">50</Table.Cell>
-										<Table.Cell class="md:table-cell hidden">
+										<Table.Cell class="hidden md:table-cell">$39.99</Table.Cell>
+										<Table.Cell class="hidden md:table-cell">50</Table.Cell>
+										<Table.Cell class="hidden md:table-cell">
 											2023-11-29 08:15 AM
 										</Table.Cell>
 										<Table.Cell>
@@ -444,7 +442,7 @@
 										</Table.Cell>
 									</Table.Row>
 									<Table.Row>
-										<Table.Cell class="sm:table-cell hidden">
+										<Table.Cell class="hidden sm:table-cell">
 											<img
 												alt="Product"
 												class="aspect-square rounded-md object-cover"
@@ -459,9 +457,9 @@
 										<Table.Cell>
 											<Badge variant="secondary">Draft</Badge>
 										</Table.Cell>
-										<Table.Cell class="md:table-cell hidden">$2.99</Table.Cell>
-										<Table.Cell class="md:table-cell hidden">0</Table.Cell>
-										<Table.Cell class="md:table-cell hidden">
+										<Table.Cell class="hidden md:table-cell">$2.99</Table.Cell>
+										<Table.Cell class="hidden md:table-cell">0</Table.Cell>
+										<Table.Cell class="hidden md:table-cell">
 											2023-12-25 11:59 PM
 										</Table.Cell>
 										<Table.Cell>
@@ -486,7 +484,7 @@
 										</Table.Cell>
 									</Table.Row>
 									<Table.Row>
-										<Table.Cell class="sm:table-cell hidden">
+										<Table.Cell class="hidden sm:table-cell">
 											<img
 												alt="Product"
 												class="aspect-square rounded-md object-cover"
@@ -501,11 +499,9 @@
 										<Table.Cell>
 											<Badge variant="outline">Active</Badge>
 										</Table.Cell>
-										<Table.Cell class="md:table-cell hidden">
-											$59.99
-										</Table.Cell>
-										<Table.Cell class="md:table-cell hidden">75</Table.Cell>
-										<Table.Cell class="md:table-cell hidden">
+										<Table.Cell class="hidden md:table-cell">$59.99</Table.Cell>
+										<Table.Cell class="hidden md:table-cell">75</Table.Cell>
+										<Table.Cell class="hidden md:table-cell">
 											2024-01-01 12:00 AM
 										</Table.Cell>
 										<Table.Cell>
@@ -530,7 +526,7 @@
 										</Table.Cell>
 									</Table.Row>
 									<Table.Row>
-										<Table.Cell class="sm:table-cell hidden">
+										<Table.Cell class="hidden sm:table-cell">
 											<img
 												alt="Product"
 												class="aspect-square rounded-md object-cover"
@@ -545,11 +541,11 @@
 										<Table.Cell>
 											<Badge variant="outline">Active</Badge>
 										</Table.Cell>
-										<Table.Cell class="md:table-cell hidden">
+										<Table.Cell class="hidden md:table-cell">
 											$199.99
 										</Table.Cell>
-										<Table.Cell class="md:table-cell hidden">30</Table.Cell>
-										<Table.Cell class="md:table-cell hidden">
+										<Table.Cell class="hidden md:table-cell">30</Table.Cell>
+										<Table.Cell class="hidden md:table-cell">
 											2024-02-14 02:14 PM
 										</Table.Cell>
 										<Table.Cell>


### PR DESCRIPTION
On the dashboard block, dashboard-06, some of the columns have the class table.-cell. I have went in and replaced them with table-cell.

Without this fix, the columns with table.-cell will not show at any screen width.
