### PR TITLE
feat: data-attribute-remover

### DIFF
--- a/apps/www/src/lib/components/docs/block-copy-code-button.svelte
+++ b/apps/www/src/lib/components/docs/block-copy-code-button.svelte
@@ -12,6 +12,21 @@
 			hasCopied = false;
 		}, 2000);
 	}
+
+	function copyToClipboard() {
+		// Remove data-x-chunk-name and data-x-chunk-description attributes from the code
+		const re = /<([a-zA-Z0-9.]+)([^>]*)data-x-chunk-name="[^"]*"([^>]*)>/g;
+
+		const result = code.replace(re, (_all, elementName, p2, p3) => {
+			// remove data-x-chunk-description from p2, leaves only the other attributes (scattered in p2 and p3)
+			const otherAttributes = (p2 + p3)
+				.replace(/data-x-chunk-description="[^"]*"/, "")
+				.trim();
+			return otherAttributes ? `<${elementName} ${otherAttributes}>` : `<${elementName}>`;
+		});
+
+		navigator.clipboard.writeText(result);
+	}
 </script>
 
 <Tooltip.Root>
@@ -22,7 +37,7 @@
 			class="h-7 w-7 rounded-[6px] [&_svg]:size-3.5"
 			builders={[builder]}
 			on:click={() => {
-				navigator.clipboard.writeText(code);
+				copyToClipboard();
 				hasCopied = true;
 			}}
 			{...$$restProps}


### PR DESCRIPTION
Just an example, the data-x-block attributes are a bit annoying when copying the code.

Added function that uses regex to remove the data-x-block-name and description attributes and leaves a clean element.
```
<Card.Root data......" class="abc"> becomes <Card.Root class="abc">
<Card.Root data......"> becomes <Card.Root>
```
No leftover whitespace AFAIK.