### PR TITLE
feat: Ability to add a button to close a dialog

### DIFF
--- a/apps/www/src/lib/registry/default/ui/dialog/index.ts
+++ b/apps/www/src/lib/registry/default/ui/dialog/index.ts
@@ -33,5 +33,5 @@ export {
 	Overlay as DialogOverlay,
 	Content as DialogContent,
 	Description as DialogDescription,
-	Close as DialogClose
+	Close as DialogClose,
 };

--- a/apps/www/src/lib/registry/default/ui/dialog/index.ts
+++ b/apps/www/src/lib/registry/default/ui/dialog/index.ts
@@ -10,6 +10,7 @@ import Description from "./dialog-description.svelte";
 
 const Root = DialogPrimitive.Root;
 const Trigger = DialogPrimitive.Trigger;
+const Close = DialogPrimitive.Close;
 
 export {
 	Root,
@@ -21,6 +22,7 @@ export {
 	Overlay,
 	Content,
 	Description,
+	Close,
 	//
 	Root as Dialog,
 	Title as DialogTitle,
@@ -31,4 +33,5 @@ export {
 	Overlay as DialogOverlay,
 	Content as DialogContent,
 	Description as DialogDescription,
+	Close as DialogClose
 };

--- a/apps/www/src/lib/registry/new-york/ui/dialog/index.ts
+++ b/apps/www/src/lib/registry/new-york/ui/dialog/index.ts
@@ -33,5 +33,5 @@ export {
 	Overlay as DialogOverlay,
 	Content as DialogContent,
 	Description as DialogDescription,
-	Close as DialogClose
+	Close as DialogClose,
 };

--- a/apps/www/src/lib/registry/new-york/ui/dialog/index.ts
+++ b/apps/www/src/lib/registry/new-york/ui/dialog/index.ts
@@ -10,6 +10,7 @@ import Description from "./dialog-description.svelte";
 
 const Root = DialogPrimitive.Root;
 const Trigger = DialogPrimitive.Trigger;
+const Close = DialogPrimitive.Close;
 
 export {
 	Root,
@@ -21,6 +22,7 @@ export {
 	Overlay,
 	Content,
 	Description,
+	Close,
 	//
 	Root as Dialog,
 	Title as DialogTitle,
@@ -31,4 +33,5 @@ export {
 	Overlay as DialogOverlay,
 	Content as DialogContent,
 	Description as DialogDescription,
+	Close as DialogClose
 };


### PR DESCRIPTION
This PR exposes the DialogPrimitive.Close as DialogClose to give the ability to use a button to close a dialog.

Code according to the solution discussed in this discussion #1030 
Solution to issue #1029 
