### PR TITLE
fix: dashboard-01 dropdown not showing

### DIFF
--- a/apps/www/src/lib/registry/default/block/dashboard-01.svelte
+++ b/apps/www/src/lib/registry/default/block/dashboard-01.svelte
@@ -83,7 +83,12 @@
 			</form>
 			<DropdownMenu.Root>
 				<DropdownMenu.Trigger asChild let:builder>
-					<Button builders={[builder]} variant="secondary" size="icon" class="rounded-full">
+					<Button
+						builders={[builder]}
+						variant="secondary"
+						size="icon"
+						class="rounded-full"
+					>
 						<CircleUser class="h-5 w-5" />
 						<span class="sr-only">Toggle user menu</span>
 					</Button>

--- a/apps/www/src/lib/registry/default/block/dashboard-01.svelte
+++ b/apps/www/src/lib/registry/default/block/dashboard-01.svelte
@@ -82,8 +82,8 @@
 				</div>
 			</form>
 			<DropdownMenu.Root>
-				<DropdownMenu.Trigger asChild>
-					<Button variant="secondary" size="icon" class="rounded-full">
+				<DropdownMenu.Trigger asChild let:builder>
+					<Button builders={[builder]} variant="secondary" size="icon" class="rounded-full">
 						<CircleUser class="h-5 w-5" />
 						<span class="sr-only">Toggle user menu</span>
 					</Button>


### PR DESCRIPTION
Fixes a minor issue where the dropdown wasn't showing on click (reproducible from https://www.shadcn-svelte.com/blocks#dashboard-01)

Repro: Click the user icon in the top-right of the page.

Expected result: Dropdown shows up

Actual result: Nothing happens

P.S. Let me know if this should be edited elsewhere, I was just playing around with the code locally.

### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
