### PR TITLE
feat: expose `scrollSnaps` `selectedIndex` `scrollTo`

### DIFF
--- a/apps/www/src/lib/registry/default/ui/carousel/carousel.svelte
+++ b/apps/www/src/lib/registry/default/ui/carousel/carousel.svelte
@@ -20,6 +20,8 @@
 	const canScrollNext = writable(false);
 	const optionsStore = writable(opts);
 	const pluginStore = writable(plugins);
+	const scrollSnapsStore = writable<number[]>([]);
+	const selectedIndexStore = writable(0);
 
 	$: orientationStore.set(orientation);
 	$: pluginStore.set(plugins);
@@ -30,6 +32,9 @@
 	}
 	function scrollNext() {
 		api?.scrollNext();
+	}
+	function scrollTo(index: number, jump?: boolean) {
+		api?.scrollTo(index, jump);
 	}
 
 	function onSelect(api: CarouselAPI) {
@@ -65,6 +70,9 @@
 		options: optionsStore,
 		plugins: pluginStore,
 		onInit,
+		scrollSnaps: scrollSnapsStore,
+		selectedIndex: selectedIndexStore,
+		scrollTo,
 	});
 
 	function onInit(event: CustomEvent<CarouselAPI>) {

--- a/apps/www/src/lib/registry/default/ui/carousel/context.ts
+++ b/apps/www/src/lib/registry/default/ui/carousel/context.ts
@@ -38,6 +38,9 @@ type EmblaContext = {
 	options: Writable<CarouselOptions>;
 	plugins: Writable<CarouselPlugins>;
 	onInit: (e: CustomEvent<CarouselAPI>) => void;
+	scrollTo: (index: number, jump?: boolean) => void;
+	scrollSnaps: Readable<number[]>;
+	selectedIndex: Readable<number>;
 };
 
 export function setEmblaContext(config: EmblaContext): EmblaContext {

--- a/apps/www/src/lib/registry/new-york/ui/carousel/carousel.svelte
+++ b/apps/www/src/lib/registry/new-york/ui/carousel/carousel.svelte
@@ -20,6 +20,8 @@
 	const canScrollNext = writable(false);
 	const optionsStore = writable(opts);
 	const pluginStore = writable(plugins);
+	const scrollSnapsStore = writable<number[]>([]);
+	const selectedIndexStore = writable(0);
 
 	$: orientationStore.set(orientation);
 	$: pluginStore.set(plugins);
@@ -30,6 +32,9 @@
 	}
 	function scrollNext() {
 		api?.scrollNext();
+	}
+	function scrollTo(index: number, jump?: boolean) {
+		api?.scrollTo(index, jump);
 	}
 
 	function onSelect(api: CarouselAPI) {
@@ -65,6 +70,9 @@
 		options: optionsStore,
 		plugins: pluginStore,
 		onInit,
+		scrollSnaps: scrollSnapsStore,
+		selectedIndex: selectedIndexStore,
+		scrollTo,
 	});
 
 	function onInit(event: CustomEvent<CarouselAPI>) {

--- a/apps/www/src/lib/registry/new-york/ui/carousel/context.ts
+++ b/apps/www/src/lib/registry/new-york/ui/carousel/context.ts
@@ -38,6 +38,9 @@ type EmblaContext = {
 	options: Writable<CarouselOptions>;
 	plugins: Writable<CarouselPlugins>;
 	onInit: (e: CustomEvent<CarouselAPI>) => void;
+	scrollTo: (index: number, jump?: boolean) => void;
+	scrollSnaps: Readable<number[]>;
+	selectedIndex: Readable<number>;
 };
 
 export function setEmblaContext(config: EmblaContext): EmblaContext {


### PR DESCRIPTION
> Had briefly touched on this is in the server, bringing it here for your consideration;

This P.R lays the groundwork necessary to create a dots-scroll-to feature like in the video. From now on, one need only reach into the context and grab these stores+function and style however they wish.

```ts
const { scrollTo, scrollSnaps, selectedIndex } = getEmblaContext('<Carousel.Dots/>');
```

It's pretty easy to set up yourself, but having it come with the `carousel` component saves some time. 🙂 
(And I don't think this introduction violates/deviates from the original, wouldn't you agree? - at least components-wise)

---


https://github.com/huntabyte/shadcn-svelte/assets/87414827/bc054fdc-503d-4e57-9801-0628366cdbc0



### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
