### PR TITLE
fix: Allow a registry dependency to be optionally overwritten

### DIFF
--- a/.changeset/moody-seas-compete.md
+++ b/.changeset/moody-seas-compete.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": patch
+---
+
+fix: Allow a registry dependency to optionally be overwritten

--- a/packages/cli/src/utils/registry/index.ts
+++ b/packages/cli/src/utils/registry/index.ts
@@ -68,7 +68,7 @@ export async function getRegistryBaseColor(baseColor: string) {
 }
 
 type RegistryIndex = v.Output<typeof schemas.registryIndexSchema>;
-export async function resolveTree(index: RegistryIndex, names: string[]) {
+export async function resolveTree(index: RegistryIndex, names: string[], includeRegDeps = true) {
 	const tree: RegistryIndex = [];
 
 	for (const name of names) {
@@ -80,7 +80,7 @@ export async function resolveTree(index: RegistryIndex, names: string[]) {
 
 		tree.push(entry);
 
-		if (entry.registryDependencies) {
+		if (includeRegDeps && entry.registryDependencies) {
 			const dependencies = await resolveTree(index, entry.registryDependencies);
 			tree.push(...dependencies);
 		}


### PR DESCRIPTION
closes #1056

If a component that uses a registry dependency (e.g. `carousel` depends on `button`) is selected, and the user already has that dependency installed (in this case, `button`), the user will be prompted to see if they'd like to overwrite it.

### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
