### PR TITLE
Revert "docs: pluginState.page is now pluginState.pagination"

### DIFF
--- a/apps/www/src/content/components/data-table.md
+++ b/apps/www/src/content/components/data-table.md
@@ -631,7 +631,7 @@ Next, we'll add pagination to our table
   const { headerRows, pageRows, tableAttrs, tableBodyAttrs, pluginStates } =
     table.createViewModel(columns);
 
-  const { hasNextPage, hasPreviousPage, pageIndex } = pluginStates.pagination;
+  const { hasNextPage, hasPreviousPage, pageIndex } = pluginStates.page;
 </script>
 ```
 
@@ -770,7 +770,7 @@ Let's enable the `addSortBy` plugin and import the `<ArrowUpDown />` icon which 
   const { headerRows, pageRows, tableAttrs, tableBodyAttrs, pluginStates } =
     table.createViewModel(columns);
 
-  const { hasNextPage, hasPreviousPage, pageIndex } = pluginStates.pagination;
+  const { hasNextPage, hasPreviousPage, pageIndex } = pluginStates.page;
 </script>
 ```
 
@@ -945,7 +945,7 @@ We'll start by enabling the `addTableFilter` plugin and importing the `<Input />
   const { headerRows, pageRows, tableAttrs, tableBodyAttrs, pluginStates } =
     table.createViewModel(columns);
 
-  const { pageIndex, hasNextPage, hasPreviousPage } = pluginStates.pagination;
+  const { pageIndex, hasNextPage, hasPreviousPage } = pluginStates.page;
   const { filterValue } = pluginStates.filter;
 </script>
 ```
@@ -1115,7 +1115,7 @@ We'll start by enabling the `addHiddenColumns` plugin. We'll also need a `<Chevr
     flatColumns,
   } = table.createViewModel(columns);
 
-  const { pageIndex, hasNextPage, hasPreviousPage } = pluginStates.pagination;
+  const { pageIndex, hasNextPage, hasPreviousPage } = pluginStates.page;
   const { filterValue } = pluginStates.filter;
   const { hiddenColumnIds } = pluginStates.hide;
 
@@ -1342,7 +1342,7 @@ Next, we'll enable the `addSelectedRows` plugin and import the `<Checkbox />` co
     rows,
   } = table.createViewModel(columns);
 
-  const { pageIndex, hasNextPage, hasPreviousPage } = pluginStates.pagination;
+  const { pageIndex, hasNextPage, hasPreviousPage } = pluginStates.page;
   const { filterValue } = pluginStates.filter;
   const { hiddenColumnIds } = pluginStates.hide;
   const { selectedDataIds } = pluginStates.select;

--- a/apps/www/src/lib/registry/default/example/cards/data-table.svelte
+++ b/apps/www/src/lib/registry/default/example/cards/data-table.svelte
@@ -61,7 +61,7 @@
 
 	const table = createTable(readable(data), {
 		sort: addSortBy({ disableMultiSort: true }),
-		pagination: addPagination(),
+		page: addPagination(),
 		filter: addTableFilter({
 			fn: ({ filterValue, value }) => value.includes(filterValue),
 		}),
@@ -151,7 +151,7 @@
 		.filter(([, hide]) => !hide)
 		.map(([id]) => id);
 
-	const { hasNextPage, hasPreviousPage, pageIndex } = pluginStates.pagination;
+	const { hasNextPage, hasPreviousPage, pageIndex } = pluginStates.page;
 	const { filterValue } = pluginStates.filter;
 
 	const { selectedDataIds } = pluginStates.select;

--- a/apps/www/src/lib/registry/default/example/data-table-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/data-table-demo.svelte
@@ -60,7 +60,7 @@
 
 	const table = createTable(readable(data), {
 		sort: addSortBy({ disableMultiSort: true }),
-		pagination: addPagination(),
+		page: addPagination(),
 		filter: addTableFilter({
 			fn: ({ filterValue, value }) => value.includes(filterValue),
 		}),
@@ -157,7 +157,7 @@
 		.filter(([, hide]) => !hide)
 		.map(([id]) => id);
 
-	const { hasNextPage, hasPreviousPage, pageIndex } = pluginStates.pagination;
+	const { hasNextPage, hasPreviousPage, pageIndex } = pluginStates.page;
 	const { filterValue } = pluginStates.filter;
 
 	const { selectedDataIds } = pluginStates.select;

--- a/apps/www/src/lib/registry/new-york/example/cards/data-table.svelte
+++ b/apps/www/src/lib/registry/new-york/example/cards/data-table.svelte
@@ -61,7 +61,7 @@
 
 	const table = createTable(readable(data), {
 		sort: addSortBy({ disableMultiSort: true }),
-		pagination: addPagination(),
+		page: addPagination(),
 		filter: addTableFilter({
 			fn: ({ filterValue, value }) => value.includes(filterValue),
 		}),
@@ -151,7 +151,7 @@
 		.filter(([, hide]) => !hide)
 		.map(([id]) => id);
 
-	const { hasNextPage, hasPreviousPage, pageIndex } = pluginStates.pagination;
+	const { hasNextPage, hasPreviousPage, pageIndex } = pluginStates.page;
 	const { filterValue } = pluginStates.filter;
 
 	const { selectedDataIds } = pluginStates.select;

--- a/apps/www/src/lib/registry/new-york/example/data-table-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/data-table-demo.svelte
@@ -60,7 +60,7 @@
 
 	const table = createTable(readable(data), {
 		sort: addSortBy({ disableMultiSort: true }),
-		pagination: addPagination(),
+		page: addPagination(),
 		filter: addTableFilter({
 			fn: ({ filterValue, value }) => value.includes(filterValue),
 		}),
@@ -157,7 +157,7 @@
 		.filter(([, hide]) => !hide)
 		.map(([id]) => id);
 
-	const { hasNextPage, hasPreviousPage, pageIndex } = pluginStates.pagination;
+	const { hasNextPage, hasPreviousPage, pageIndex } = pluginStates.page;
 	const { filterValue } = pluginStates.filter;
 
 	const { selectedDataIds } = pluginStates.select;

--- a/apps/www/src/routes/(app)/examples/data-table/data-table.svelte
+++ b/apps/www/src/routes/(app)/examples/data-table/data-table.svelte
@@ -60,7 +60,7 @@
 
 	const table = createTable(readable(data), {
 		sort: addSortBy({ disableMultiSort: true }),
-		pagination: addPagination(),
+		page: addPagination(),
 		filter: addTableFilter({
 			fn: ({ filterValue, value }) => value.includes(filterValue),
 		}),
@@ -146,7 +146,7 @@
 		.filter(([, hide]) => !hide)
 		.map(([id]) => id);
 
-	const { hasNextPage, hasPreviousPage, pageIndex } = pluginStates.pagination;
+	const { hasNextPage, hasPreviousPage, pageIndex } = pluginStates.page;
 	const { filterValue } = pluginStates.filter;
 
 	const { selectedDataIds } = pluginStates.select;

--- a/apps/www/src/routes/(app)/examples/tasks/(components)/data-table-pagination.svelte
+++ b/apps/www/src/routes/(app)/examples/tasks/(components)/data-table-pagination.svelte
@@ -12,8 +12,7 @@
 
 	const { pageRows, pluginStates, rows } = tableModel;
 
-	const { hasNextPage, hasPreviousPage, pageIndex, pageCount, pageSize } =
-		pluginStates.pagination;
+	const { hasNextPage, hasPreviousPage, pageIndex, pageCount, pageSize } = pluginStates.page;
 
 	const { selectedDataIds } = pluginStates.select;
 </script>


### PR DESCRIPTION
Reverts huntabyte/shadcn-svelte#1075

This shouldn't have been changed given that we're following `svelte-headless-table`'s convention of naming it `page`. It also caused parts of our docs to be inconsistent now too, where `page` was being defined and `.pagination` was being used.

closes #1079 