### PR TITLE
fix: default textarea event types

### DIFF
--- a/apps/www/src/lib/registry/default/ui/textarea/textarea.svelte
+++ b/apps/www/src/lib/registry/default/ui/textarea/textarea.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import type { HTMLTextareaAttributes } from "svelte/elements";
 	import { cn } from "$lib/utils.js";
+	import type { TextareaEvents } from "./index.js";
 
 	type $$Props = HTMLTextareaAttributes;
+	type $$Events = TextareaEvents;
 
 	let className: $$Props["class"] = undefined;
 	export let value: $$Props["value"] = undefined;

--- a/apps/www/src/lib/registry/default/ui/textarea/textarea.svelte
+++ b/apps/www/src/lib/registry/default/ui/textarea/textarea.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { HTMLTextareaAttributes } from "svelte/elements";
-	import { cn } from "$lib/utils.js";
 	import type { TextareaEvents } from "./index.js";
+	import { cn } from "$lib/utils.js";
 
 	type $$Props = HTMLTextareaAttributes;
 	type $$Events = TextareaEvents;


### PR DESCRIPTION
The default textarea component was missing the custom event types. This fix makes the components' event typing work the same way as other components do.

The new york variant is already typed correctly so only the default needs to be changed.