### PR TITLE
fix: superForm validation errors in examples that use froms

### DIFF
--- a/apps/www/src/lib/registry/default/example/checkbox-form-multiple.svelte
+++ b/apps/www/src/lib/registry/default/example/checkbox-form-multiple.svelte
@@ -45,8 +45,7 @@
 	import * as Form from "$lib/registry/default/ui/form/index.js";
 	import { Checkbox } from "$lib/registry/default/ui/checkbox/index.js";
 
-	let data: SuperValidated<Infer<FormSchema>> = $page.data.checkboxMultiple;
-	export { data as form };
+	export let data: SuperValidated<Infer<FormSchema>> = $page.data.checkboxMultiple;
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/apps/www/src/lib/registry/default/example/checkbox-form-single.svelte
+++ b/apps/www/src/lib/registry/default/example/checkbox-form-single.svelte
@@ -14,8 +14,8 @@
 	import { page } from "$app/stores";
 	import * as Form from "$lib/registry/default/ui/form/index.js";
 	import { Checkbox } from "$lib/registry/default/ui/checkbox/index.js";
-	let data: SuperValidated<Infer<FormSchema>> = $page.data.checkboxSingle;
-	export { data as form };
+
+	export let data: SuperValidated<Infer<FormSchema>> = $page.data.checkboxSingle;
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/apps/www/src/lib/registry/default/example/combobox-form.svelte
+++ b/apps/www/src/lib/registry/default/example/combobox-form.svelte
@@ -38,8 +38,8 @@
 	import * as Command from "$lib/registry/default/ui/command/index.js";
 	import { cn } from "$lib/utils.js";
 	import { buttonVariants } from "$lib/registry/default/ui/button/index.js";
-	let data: SuperValidated<Infer<FormSchema>> = $page.data.combobox;
-	export { data as form };
+
+	export let data: SuperValidated<Infer<FormSchema>> = $page.data.combobox;
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/apps/www/src/lib/registry/default/example/date-picker-form.svelte
+++ b/apps/www/src/lib/registry/default/example/date-picker-form.svelte
@@ -29,8 +29,8 @@
 	import { Calendar } from "$lib/registry/default/ui/calendar/index.js";
 	import * as Popover from "$lib/registry/default/ui/popover/index.js";
 	import * as Form from "$lib/registry/default/ui/form/index.js";
-	let data: SuperValidated<Infer<FormSchema>> = $page.data.datePicker;
-	export { data as form };
+
+	export let data: SuperValidated<Infer<FormSchema>> = $page.data.datePicker;
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/apps/www/src/lib/registry/default/example/form-demo.svelte
+++ b/apps/www/src/lib/registry/default/example/form-demo.svelte
@@ -15,8 +15,8 @@
 	import * as Form from "$lib/registry/default/ui/form/index.js";
 	import { Input } from "$lib/registry/default/ui/input/index.js";
 
-	let data: SuperValidated<Infer<FormSchema>>;
-	export { data as form };
+	export let data: SuperValidated<Infer<FormSchema>>;
+
 	const form = superForm(data, {
 		validators: zodClient(formSchema),
 		onUpdated: ({ form: f }) => {

--- a/apps/www/src/lib/registry/default/example/radio-group-form.svelte
+++ b/apps/www/src/lib/registry/default/example/radio-group-form.svelte
@@ -18,8 +18,7 @@
 	import * as Form from "$lib/registry/default/ui/form/index.js";
 	import * as RadioGroup from "$lib/registry/default/ui/radio-group/index.js";
 
-	let data: SuperValidated<Infer<FormSchema>> = $page.data.radioGroup;
-	export { data as form };
+	export let data: SuperValidated<Infer<FormSchema>> = $page.data.radioGroup;
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/apps/www/src/lib/registry/default/example/select-form.svelte
+++ b/apps/www/src/lib/registry/default/example/select-form.svelte
@@ -16,8 +16,8 @@
 	import { page } from "$app/stores";
 	import * as Form from "$lib/registry/default/ui/form/index.js";
 	import * as Select from "$lib/registry/default/ui/select/index.js";
-	let data: SuperValidated<Infer<FormSchema>> = $page.data.select;
-	export { data as form };
+
+	export let data: SuperValidated<Infer<FormSchema>> = $page.data.select;
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/apps/www/src/lib/registry/default/example/switch-form.svelte
+++ b/apps/www/src/lib/registry/default/example/switch-form.svelte
@@ -15,8 +15,8 @@
 	import { page } from "$app/stores";
 	import * as Form from "$lib/registry/default/ui/form/index.js";
 	import { Switch } from "$lib/registry/default/ui/switch/index.js";
-	let data: SuperValidated<Infer<FormSchema>> = $page.data.switch;
-	export { data as form };
+
+	export let data: SuperValidated<Infer<FormSchema>> = $page.data.switch;
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/apps/www/src/lib/registry/default/example/textarea-form.svelte
+++ b/apps/www/src/lib/registry/default/example/textarea-form.svelte
@@ -18,8 +18,7 @@
 	import * as Form from "$lib/registry/default/ui/form/index.js";
 	import { Textarea } from "$lib/registry/default/ui/textarea/index.js";
 
-	let data: SuperValidated<Infer<FormSchema>> = $page.data.textarea;
-	export { data as form };
+	export let data: SuperValidated<Infer<FormSchema>> = $page.data.textarea;
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/apps/www/src/lib/registry/new-york/example/checkbox-form-multiple.svelte
+++ b/apps/www/src/lib/registry/new-york/example/checkbox-form-multiple.svelte
@@ -44,8 +44,8 @@
 	import { page } from "$app/stores";
 	import * as Form from "$lib/registry/new-york/ui/form/index.js";
 	import { Checkbox } from "$lib/registry/new-york/ui/checkbox/index.js";
-	let data: SuperValidated<Infer<FormSchema>> = $page.data.checkboxMultiple;
-	export { data as form };
+
+	export let data: SuperValidated<Infer<FormSchema>> = $page.data.checkboxMultiple;
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/apps/www/src/lib/registry/new-york/example/checkbox-form-single.svelte
+++ b/apps/www/src/lib/registry/new-york/example/checkbox-form-single.svelte
@@ -14,8 +14,8 @@
 	import { page } from "$app/stores";
 	import * as Form from "$lib/registry/new-york/ui/form/index.js";
 	import { Checkbox } from "$lib/registry/new-york/ui/checkbox/index.js";
-	let data: SuperValidated<Infer<FormSchema>> = $page.data.checkboxSingle;
-	export { data as form };
+
+	export let data: SuperValidated<Infer<FormSchema>> = $page.data.checkboxSingle;
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/apps/www/src/lib/registry/new-york/example/combobox-form.svelte
+++ b/apps/www/src/lib/registry/new-york/example/combobox-form.svelte
@@ -38,8 +38,8 @@
 	import * as Command from "$lib/registry/new-york/ui/command/index.js";
 	import { cn } from "$lib/utils.js";
 	import { buttonVariants } from "$lib/registry/new-york/ui/button/index.js";
-	let data: SuperValidated<Infer<FormSchema>> = $page.data.combobox;
-	export { data as form };
+
+	export let data: SuperValidated<Infer<FormSchema>> = $page.data.combobox;
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/apps/www/src/lib/registry/new-york/example/date-picker-form.svelte
+++ b/apps/www/src/lib/registry/new-york/example/date-picker-form.svelte
@@ -29,8 +29,8 @@
 	import { Calendar } from "$lib/registry/new-york/ui/calendar/index.js";
 	import * as Popover from "$lib/registry/new-york/ui/popover/index.js";
 	import * as Form from "$lib/registry/new-york/ui/form/index.js";
-	let data: SuperValidated<Infer<FormSchema>> = $page.data.datePicker;
-	export { data as form };
+
+	export let data: SuperValidated<Infer<FormSchema>> = $page.data.datePicker;
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/apps/www/src/lib/registry/new-york/example/form-demo.svelte
+++ b/apps/www/src/lib/registry/new-york/example/form-demo.svelte
@@ -15,8 +15,7 @@
 	import * as Form from "$lib/registry/new-york/ui/form/index.js";
 	import { Input } from "$lib/registry/new-york/ui/input/index.js";
 
-	let data: SuperValidated<Infer<FormSchema>>;
-	export { data as form };
+	export let data: SuperValidated<Infer<FormSchema>>;
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/apps/www/src/lib/registry/new-york/example/radio-group-form.svelte
+++ b/apps/www/src/lib/registry/new-york/example/radio-group-form.svelte
@@ -18,8 +18,7 @@
 	import * as Form from "$lib/registry/new-york/ui/form/index.js";
 	import * as RadioGroup from "$lib/registry/new-york/ui/radio-group/index.js";
 
-	let data: SuperValidated<Infer<FormSchema>> = $page.data.radioGroup;
-	export { data as form };
+	export let data: SuperValidated<Infer<FormSchema>> = $page.data.radioGroup;
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/apps/www/src/lib/registry/new-york/example/select-form.svelte
+++ b/apps/www/src/lib/registry/new-york/example/select-form.svelte
@@ -16,8 +16,8 @@
 	import { page } from "$app/stores";
 	import * as Form from "$lib/registry/new-york/ui/form/index.js";
 	import * as Select from "$lib/registry/new-york/ui/select/index.js";
-	let data: SuperValidated<Infer<FormSchema>> = $page.data.select;
-	export { data as form };
+
+	export let data: SuperValidated<Infer<FormSchema>> = $page.data.select;
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/apps/www/src/lib/registry/new-york/example/switch-form.svelte
+++ b/apps/www/src/lib/registry/new-york/example/switch-form.svelte
@@ -15,8 +15,8 @@
 	import { page } from "$app/stores";
 	import * as Form from "$lib/registry/new-york/ui/form/index.js";
 	import { Switch } from "$lib/registry/new-york/ui/switch/index.js";
-	let data: SuperValidated<Infer<FormSchema>> = $page.data.switch;
-	export { data as form };
+
+	export let data: SuperValidated<Infer<FormSchema>> = $page.data.switch;
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/apps/www/src/lib/registry/new-york/example/textarea-form.svelte
+++ b/apps/www/src/lib/registry/new-york/example/textarea-form.svelte
@@ -18,8 +18,7 @@
 	import * as Form from "$lib/registry/new-york/ui/form/index.js";
 	import { Textarea } from "$lib/registry/new-york/ui/textarea/index.js";
 
-	let data: SuperValidated<Infer<FormSchema>> = $page.data.textarea;
-	export { data as form };
+	export let data: SuperValidated<Infer<FormSchema>> = $page.data.textarea;
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),


### PR DESCRIPTION
Currently, examples that use forms with validation and a destructured export of data run into an internal error, namely:

```
SuperFormError: No form data sent to superForm. Make sure the output from superValidate is used (usually data.form) and that it's not null or undefined. Alternatively, an object with default valu
```

The PR updates the export to match the one used in the example of the Form component itself and other working examples that use forms.
