### PR TITLE
docs: Fix overflow issue with select in the card example

### DIFF
--- a/apps/www/src/routes/(app)/examples/cards/(components)/report-issue.svelte
+++ b/apps/www/src/routes/(app)/examples/cards/(components)/report-issue.svelte
@@ -74,7 +74,10 @@
 			<div class="grid gap-2">
 				<Label for="security-level">Security Level</Label>
 				<Select.Root selected={securityLevels[1]}>
-					<Select.Trigger id="security-level" class="line-clamp-1 flex w-[160px] truncate">
+					<Select.Trigger
+						id="security-level"
+						class="line-clamp-1 flex w-[160px] truncate"
+					>
 						<Select.Value placeholder="Select level" />
 					</Select.Trigger>
 					<Select.Content>

--- a/apps/www/src/routes/(app)/examples/cards/(components)/report-issue.svelte
+++ b/apps/www/src/routes/(app)/examples/cards/(components)/report-issue.svelte
@@ -74,7 +74,7 @@
 			<div class="grid gap-2">
 				<Label for="security-level">Security Level</Label>
 				<Select.Root selected={securityLevels[1]}>
-					<Select.Trigger id="security-level" class="line-clamp-1 w-[160px] truncate">
+					<Select.Trigger id="security-level" class="line-clamp-1 flex w-[160px] truncate">
 						<Select.Value placeholder="Select level" />
 					</Select.Trigger>
 					<Select.Content>


### PR DESCRIPTION
This pull request addressed #1121 

Fix UI bug for examples/card for one of the select fields by adding a flex. 

Look for the bottom right corner

Before: 
![Select-example-ui-issue-3](https://github.com/huntabyte/shadcn-svelte/assets/70580312/a3de7559-1876-44e5-b834-130c52b2e7cc)

After: 
![Select-example-ui-issue-2](https://github.com/huntabyte/shadcn-svelte/assets/70580312/056b6895-e937-4cc7-97bb-16194e25b2a8)
