### PR TITLE
docs: fix empty data table when the email column is hidden

### DIFF
--- a/apps/www/src/content/components/data-table.md
+++ b/apps/www/src/content/components/data-table.md
@@ -1248,6 +1248,7 @@ Next, we'll enable the `addSelectedRows` plugin and import the `<Checkbox />` co
     page: addPagination(),
     sort: addSortBy({ disableMultiSort: true }),
     filter: addTableFilter({
+      includeHiddenColumns: true,
       fn: ({ filterValue, value }) => value.includes(filterValue),
     }),
     hide: addHiddenColumns(),


### PR DESCRIPTION
As per #1126, this is to fix an issue in the guide code (in the Data Table section), whereby, when I hide the email column then all the rows are removed, and the row selection checkbox is checked.