### PR TITLE
fix: search icon position

### DIFF
--- a/apps/www/src/routes/(app)/examples/mail/(components)/mail.svelte
+++ b/apps/www/src/routes/(app)/examples/mail/(components)/mail.svelte
@@ -90,7 +90,7 @@
 				>
 					<form>
 						<div class="relative">
-							<Search class="absolute left-2 top-3 h-4 w-4 text-muted-foreground" />
+							<Search class="absolute left-2 top-[50%] translate-y-[-50%] h-4 w-4 text-muted-foreground" />
 							<Input placeholder="Search" class="pl-8" />
 						</div>
 					</form>

--- a/apps/www/src/routes/(app)/examples/mail/(components)/mail.svelte
+++ b/apps/www/src/routes/(app)/examples/mail/(components)/mail.svelte
@@ -90,7 +90,9 @@
 				>
 					<form>
 						<div class="relative">
-							<Search class="absolute left-2 top-[50%] translate-y-[-50%] h-4 w-4 text-muted-foreground" />
+							<Search
+								class="absolute left-2 top-[50%] h-4 w-4 translate-y-[-50%] text-muted-foreground"
+							/>
 							<Input placeholder="Search" class="pl-8" />
 						</div>
 					</form>


### PR DESCRIPTION
The landing/examples page's mail example has a searchbox that contains a search icon.
The icon wasn't centered. Quick fix.

Before:
<img width="284" alt="image" src="https://github.com/Humbarrt/shadcn-svelte/assets/16487684/37cd963f-e5b2-473e-93aa-f8bb4525f73e">

Now:
<img width="282" alt="image" src="https://github.com/Humbarrt/shadcn-svelte/assets/16487684/a0caee61-2d02-4ded-9c4c-9923539a7b36">

Have a nice day, hope I could help.
Cheers!