### PR TITLE
docs(installation): comment on eslint flat file config format

### DIFF
--- a/apps/www/src/content/installation/index.md
+++ b/apps/www/src/content/installation/index.md
@@ -115,6 +115,36 @@ The main benefit of adding an additional `.eslintrc` file just to `$lib/componen
 
 If this is not important to you, then another option is to use a similar rule override in your global ESLint configuration file, usually `.eslintrc.cjs`. For inspiration, please refer to [this gist](https://gist.github.com/huntabyte/b73073a93a7a664f3cbad7c50376c9c9).
 
+If your global ESLint configuration is using the [flat config format](https://eslint.org/docs/latest/use/configure/configuration-files) or you would like to migrate to the flat config format [Configuration Migration Guide](https://eslint.org/docs/latest/use/configure/migration-guide) you could add another rule block in your `eslint.config.js` for example:
+
+```js title="src/eslint.config.js"
+/** @type {import('eslint').Linter.FlatConfig[]} */
+export default [
+  /* ... */
+  {
+    files: ["**/*.svelte"],
+    languageOptions: {
+      parserOptions: {
+        parser: ts.parser,
+      },
+    },
+  },
+  {
+    /* location of your components where you would like to apply these rules  */
+    files: ["**/components/ui/**/*.svelte"],
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^\\$\\$(Props|Events|Slots|Generic)$",
+        },
+      ],
+    },
+  },
+];
+```
+
 ## VSCode extension
 
 Install the shadcn-svelte [VSCode extension](https://marketplace.visualstudio.com/items?itemName=Selemondev.vscode-shadcn-svelte) by [@selemondev](https://github.com/selemondev) in Visual Studio Code to easily add Shadcn Svelte components to your project.


### PR DESCRIPTION
Small documentation remark on how to apply rules when using eslint flat file format, including links to the eslint documentation on using flat file format and migrating to flat file format. 

New projects use flat file config and older projects might want to migrate. This pr might be redundant or unnecessary, but for the love of all, I could not get it working with a separate config file.

English is not my first language, so I used Grammarly to make it readable.

### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
