### PR TITLE
docs: make button size in site-header uniform

### DIFF
--- a/apps/www/src/lib/components/docs/mode-toggle.svelte
+++ b/apps/www/src/lib/components/docs/mode-toggle.svelte
@@ -8,7 +8,7 @@
 
 <DropdownMenu.Root>
 	<DropdownMenu.Trigger asChild let:builder>
-		<Button builders={[builder]} variant="ghost" class="w-9 px-0">
+		<Button builders={[builder]} variant="ghost" class="h-8 w-8 px-0">
 			<Sun
 				class="dark:-roate-90 h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:scale-0"
 			/>

--- a/apps/www/src/lib/components/docs/site-header.svelte
+++ b/apps/www/src/lib/components/docs/site-header.svelte
@@ -29,7 +29,7 @@
 								size: "sm",
 								variant: "ghost",
 							}),
-							"w-9 px-0"
+							"h-8 w-8 px-0"
 						)}
 					>
 						<Icons.gitHub class="h-4 w-4" />
@@ -43,7 +43,7 @@
 								size: "sm",
 								variant: "ghost",
 							}),
-							"w-9 px-0"
+							"h-8 w-8 px-0"
 						)}
 					>
 						<Icons.twitter class="h-3 w-3 fill-current" />


### PR DESCRIPTION
Current:
|shadcn-svelte|shadcn/ui|
|-|-|
|![Screenshot_20240714_132306](https://github.com/user-attachments/assets/9f5a3cee-f272-40c6-8568-0739197c4290)![Screenshot_20240714_132257](https://github.com/user-attachments/assets/6c8781d8-534e-48bc-b767-f8712aa76345)|![Screenshot_20240714_132333](https://github.com/user-attachments/assets/9eed9c32-77fb-48f3-af29-a87a1039d023)![Screenshot_20240714_132337](https://github.com/user-attachments/assets/16d25978-d67c-45d4-969d-e6e0c508e391)|

The update makes the button sizes uniform and adapts them to the upstream style.
It does so by using the same tailwind classes that shadcn is using (ref. https://github.com/shadcn-ui/ui/blob/f170784f78b553641abbfe17c76a500a9563cf50/apps/www/components/site-header.tsx#L33). Personally, for squares, I would use the `size-` class, which combines `h-` and `w-`.

I did check the next branch to make sure the change that I'm not re-authoring a change which is already included.

<br>

---

As a justification, since the contribution is missing the first step of the contribution guidelines of opening an issue first:
 
The rationale of the guidelines is to save a contributor's time. In regards to the submitted changes, the most time-efficient approach for me was to open a descriptive PR directly. I'm okay if it's closed and not merged, as this would still save time for me. Please don't hesitate to close it if the changes are not appropriate. In the end, this might save time on your side as well. Apologies for not following the guidelines.