### PR TITLE
chore: update superseded package

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -79,7 +79,7 @@
 		"paneforge": "^0.0.2",
 		"svelte-headless-table": "^0.18.2",
 		"svelte-legos": "^0.2.2",
-		"svelte-local-storage-store": "^0.5.0",
+		"svelte-persisted-store": "^0.11.0",
 		"svelte-radix": "^1.1.0",
 		"svelte-sonner": "^0.3.19",
 		"sveltekit-superforms": "^2.11.0",

--- a/apps/www/src/lib/stores/config.ts
+++ b/apps/www/src/lib/stores/config.ts
@@ -1,4 +1,4 @@
-import { persisted } from "svelte-local-storage-store";
+import { persisted } from "svelte-persisted-store";
 
 import type { Style } from "$lib/registry/styles.js";
 import type { Theme } from "$lib/registry/themes.js";

--- a/apps/www/src/lib/utils.ts
+++ b/apps/www/src/lib/utils.ts
@@ -5,7 +5,7 @@ import { derived, writable } from "svelte/store";
 import type { TransitionConfig } from "svelte/transition";
 import { twMerge } from "tailwind-merge";
 import { error } from "@sveltejs/kit";
-import { persisted } from "svelte-local-storage-store";
+import { persisted } from "svelte-persisted-store";
 import type { DocResolver } from "$lib/types/docs.js";
 
 export function cn(...inputs: ClassValue[]) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,9 +208,9 @@ importers:
       svelte-legos:
         specifier: ^0.2.2
         version: 0.2.2(svelte@4.2.12)
-      svelte-local-storage-store:
-        specifier: ^0.5.0
-        version: 0.5.0(svelte@4.2.12)
+      svelte-persisted-store:
+        specifier: ^0.11.0
+        version: 0.11.0(svelte@4.2.12)
       svelte-radix:
         specifier: ^1.1.0
         version: 1.1.0(svelte@4.2.12)
@@ -8409,11 +8409,11 @@ packages:
       svelte: 4.2.12
     dev: false
 
-  /svelte-local-storage-store@0.5.0(svelte@4.2.12):
-    resolution: {integrity: sha512-SEDrpapeia6fUqta+r1NvSLlJYPkZ4pBcl15EYIOSPNzy6vhpoXu8cnzUDmZxsWl7fZGAHxrVH9UyZCbyO4W+g==}
+  /svelte-persisted-store@0.11.0(svelte@4.2.12):
+    resolution: {integrity: sha512-9RgJ5DrawGyyfK22A80cfu8Jose3CV8YjEZKz9Tn94rQ0tWyEmYr+XI+wrVF6wjRbW99JMDSVcFRiM3XzVJj/w==}
     engines: {node: '>=0.14'}
     peerDependencies:
-      svelte: ^3.48.0 || ^4.0.0
+      svelte: ^3.48.0 || ^4.0.0 || ^5.0.0-next.0
     dependencies:
       svelte: 4.2.12
     dev: false


### PR DESCRIPTION
The PR updates a superseded dependency that doesn't receive updates anymore because it was moved to a new package name.

Ref.: https://www.npmjs.com/package/svelte-local-storage-store

<br>

I'm adding a little justification, since the contribution is missing the first step of the contribution guidelines of opening an issue first:

- Based on the issue templates, I couldn't classify a category that would fit to open an issue prior to the PR. 
- The rationale of the guidelines is to save a contributor's time. The most time-efficient way I could think of for this specific change was to open the PR directly. I'm okay if it's closed and not merged, as this would have saved time for me. Please don't hesitate to close it if the changes are not appropriate.