### PR TITLE
feat: Add `--no-deps` flag to `init` command

### DIFF
--- a/.changeset/afraid-melons-remain.md
+++ b/.changeset/afraid-melons-remain.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": patch
+---
+
+breaking: Changed `--nodep` flag to `--no-deps` for `add` command

--- a/.changeset/plenty-rockets-hear.md
+++ b/.changeset/plenty-rockets-hear.md
@@ -2,4 +2,4 @@
 "shadcn-svelte": minor
 ---
 
-feat: Adds `--nodeps` flag to init command
+feat: Added `--no-deps` flag to `init` command

--- a/.changeset/plenty-rockets-hear.md
+++ b/.changeset/plenty-rockets-hear.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": minor
+---
+
+feat: Adds `--nodeps` flag to init command

--- a/apps/www/src/content/cli.md
+++ b/apps/www/src/content/cli.md
@@ -3,10 +3,6 @@ title: CLI
 description: Use the CLI to add components to your project.
 ---
 
-<script>
-  import { ManualInstall } from '$lib/components/docs';
-</script>
-
 ## init
 
 Use the `init` command to initialize dependencies for a new project.
@@ -46,16 +42,6 @@ Options:
   --utils-alias <path>       import alias for utils
   -h, --help                 display help for command
 ```
-
-<ManualInstall title="Install after --nodeps">
-
-1. Install `tailwind-variants, clsx, and tailwind-merge`:
-
-```bash
-npm install tailwind-variants clsx tailwind-merge
-```
-
-</ManualInstall>
 
 ## add
 

--- a/apps/www/src/content/cli.md
+++ b/apps/www/src/content/cli.md
@@ -3,6 +3,10 @@ title: CLI
 description: Use the CLI to add components to your project.
 ---
 
+<script>
+  import { ManualInstall } from '$lib/components/docs';
+</script>
+
 ## init
 
 Use the `init` command to initialize dependencies for a new project.
@@ -32,7 +36,8 @@ Usage: shadcn-svelte init [options]
 initialize your project and install dependencies
 
 Options:
-  -c, --cwd <cwd>            the working directory. defaults to the current directory. (default: the current directory)
+  -c, --cwd <cwd>            the working directory. defaults to the current directory.
+  --nodeps                   disable adding & installing dependencies (advanced) (default: false)
   --style <name>             the style for the components (choices: "default", "new-york")
   --base-color <name>        the base color for the components (choices: "slate", "gray", "zinc", "neutral", "stone")
   --css <path>               path to the global CSS file
@@ -41,6 +46,16 @@ Options:
   --utils-alias <path>       import alias for utils
   -h, --help                 display help for command
 ```
+
+<ManualInstall title="Install after --nodeps">
+
+1. Install `tailwind-variants, clsx, and tailwind-merge`:
+
+```bash
+npm install tailwind-variants clsx tailwind-merge
+```
+
+</ManualInstall>
 
 ## add
 

--- a/apps/www/src/content/cli.md
+++ b/apps/www/src/content/cli.md
@@ -32,8 +32,8 @@ Usage: shadcn-svelte init [options]
 initialize your project and install dependencies
 
 Options:
-  -c, --cwd <cwd>            the working directory. defaults to the current directory.
-  --nodeps                   disable adding & installing dependencies (advanced) (default: false)
+  -c, --cwd <cwd>            the working directory (default: the current directory)
+  --no-deps                  disable adding & installing dependencies
   --style <name>             the style for the components (choices: "default", "new-york")
   --base-color <name>        the base color for the components (choices: "slate", "gray", "zinc", "neutral", "stone")
   --css <path>               path to the global CSS file
@@ -79,13 +79,13 @@ Arguments:
   components         name of components
 
 Options:
-  --nodep            disable adding & installing dependencies (advanced) (default: false)
-  -a, --all          add all components to your project. (default: false)
-  -y, --yes          skip confirmation prompt. (default: false)
-  -o, --overwrite    overwrite existing files. (default: false)
-  --proxy            fetch components from registry using a proxy.
-  -c, --cwd <cwd>    the working directory. (default: the current directory)
-  -p, --path <path>  the path to add the component to.
+  -c, --cwd <cwd>    the working directory (default: the current directory)
+  --no-deps          skips adding & installing package dependencies
+  -a, --all          install all components to your project (default: false)
+  -y, --yes          skip confirmation prompt (default: false)
+  -o, --overwrite    overwrite existing files (default: false)
+  --proxy <proxy>    fetch components from registry using a proxy
+  -p, --path <path>  the path to add the component to
   -h, --help         display help for command
 ```
 
@@ -108,9 +108,10 @@ Arguments:
   components       name of components
 
 Options:
-  -a, --all        update all existing components. (default: false)
-  -y, --yes        skip confirmation prompt. (default: false)
-  -c, --cwd <cwd>  the working directory. (default: the current directory)
+  -c, --cwd <cwd>  the working directory (default: the current directory)
+  -a, --all        update all existing components (default: false)
+  -y, --yes        skip confirmation prompt (default: false)
+  --proxy <proxy>  fetch components from registry using a proxy
   -h, --help       display help for command
 ```
 

--- a/apps/www/src/lib/components/docs/manual-install.svelte
+++ b/apps/www/src/lib/components/docs/manual-install.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
 	import * as Accordion from "$lib/registry/new-york/ui/accordion/index.js";
+
+	export let title = "Manual Installation";
+
+	let value = title.replaceAll(" ", "-").toLowerCase();
 </script>
 
 <Accordion.Root>
-	<Accordion.Item value="manual-installation">
-		<Accordion.Trigger>Manual Installation</Accordion.Trigger>
+	<Accordion.Item {value}>
+		<Accordion.Trigger>{title}</Accordion.Trigger>
 		<Accordion.Content>
 			<slot />
 		</Accordion.Content>

--- a/apps/www/src/lib/components/docs/manual-install.svelte
+++ b/apps/www/src/lib/components/docs/manual-install.svelte
@@ -1,14 +1,10 @@
 <script lang="ts">
 	import * as Accordion from "$lib/registry/new-york/ui/accordion/index.js";
-
-	export let title = "Manual Installation";
-
-	let value = title.replaceAll(" ", "-").toLowerCase();
 </script>
 
 <Accordion.Root>
-	<Accordion.Item {value}>
-		<Accordion.Trigger>{title}</Accordion.Trigger>
+	<Accordion.Item value="manual-installation">
+		<Accordion.Trigger>Manual Installation</Accordion.Trigger>
 		<Accordion.Content>
 			<slot />
 		</Accordion.Content>

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -29,7 +29,7 @@ const addOptionsSchema = v.object({
 	overwrite: v.boolean(),
 	cwd: v.string(),
 	path: v.optional(v.string()),
-	nodep: v.boolean(),
+	noDeps: v.boolean(),
 	proxy: v.optional(v.string()),
 });
 
@@ -39,17 +39,13 @@ export const add = new Command()
 	.command("add")
 	.description("add components to your project")
 	.argument("[components...]", "name of components")
-	.option("--nodep", "skips adding & installing package dependencies.", false)
-	.option("-a, --all", "install all components to your project.", false)
-	.option("-y, --yes", "skip confirmation prompt.", false)
-	.option("-o, --overwrite", "overwrite existing files.", false)
-	.option("--proxy <proxy>", "fetch components from registry using a proxy.", getEnvProxy())
-	.option(
-		"-c, --cwd <cwd>",
-		"the working directory. defaults to the current directory.",
-		process.cwd()
-	)
-	.option("-p, --path <path>", "the path to add the component to.")
+	.option("-c, --cwd <cwd>", "the working directory", process.cwd())
+	.option("--no-deps", "skips adding & installing package dependencies", false)
+	.option("-a, --all", "install all components to your project", false)
+	.option("-y, --yes", "skip confirmation prompt", false)
+	.option("-o, --overwrite", "overwrite existing files", false)
+	.option("--proxy <proxy>", "fetch components from registry using a proxy", getEnvProxy())
+	.option("-p, --path <path>", "the path to add the component to")
 	.action(async (components, opts) => {
 		try {
 			intro();
@@ -101,7 +97,7 @@ async function runAdd(cwd: string, config: Config, options: AddOptions) {
 			message: `Which ${highlight("components")} would you like to install?`,
 			maxItems: 10,
 			options: registryIndex.map(({ name, dependencies, registryDependencies }) => {
-				const deps = [...(options.nodep ? [] : dependencies), ...registryDependencies];
+				const deps = [...(options.noDeps ? [] : dependencies), ...registryDependencies];
 				return {
 					label: name,
 					value: name,
@@ -177,7 +173,7 @@ async function runAdd(cwd: string, config: Config, options: AddOptions) {
 
 	if (options.yes === false) {
 		const proceed = await p.confirm({
-			message: `Ready to install ${highlight("components")}${options.nodep ? "?" : ` and ${highlight("dependencies")}?`}`,
+			message: `Ready to install ${highlight("components")}${options.noDeps ? "?" : ` and ${highlight("dependencies")}?`}`,
 			initialValue: true,
 		});
 
@@ -218,7 +214,7 @@ async function runAdd(cwd: string, config: Config, options: AddOptions) {
 		}
 
 		// Add dependencies to the install list
-		if (options.nodep) {
+		if (options.noDeps) {
 			item.dependencies.forEach((dep) => skippedDeps.add(dep));
 		} else {
 			item.dependencies.forEach((dep) => dependencies.add(dep));
@@ -262,7 +258,7 @@ async function runAdd(cwd: string, config: Config, options: AddOptions) {
 
 	await p.tasks(tasks);
 
-	if (options.nodep) {
+	if (options.noDeps) {
 		const prettyList = prettifyList([...skippedDeps], 7);
 		p.log.warn(
 			`Components have been installed ${color.bold.red("without")} the following ${highlight("dependencies")}:\n${color.gray(prettyList)}`

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -44,7 +44,7 @@ export const init = new Command()
 		"the working directory. defaults to the current directory.",
 		process.cwd()
 	)
-	.option("--nodeps", "disable adding & installing dependencies (advanced) (default: false)", false)
+	.option("--nodeps", "disable adding & installing dependencies (advanced)", false)
 	.addOption(
 		new Option("--style <name>", "the style for the components").choices(
 			styles.map((style) => style.name)

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -31,7 +31,7 @@ const initOptionsSchema = v.object({
 	tailwindConfig: v.optional(v.string()),
 	componentsAlias: v.optional(v.string()),
 	utilsAlias: v.optional(v.string()),
-	noDeps: v.boolean(),
+	deps: v.boolean(),
 });
 
 type InitOptions = v.InferOutput<typeof initOptionsSchema>;
@@ -40,7 +40,7 @@ export const init = new Command()
 	.command("init")
 	.description("initialize your project and install dependencies")
 	.option("-c, --cwd <cwd>", "the working directory", process.cwd())
-	.option("--no-deps", "disable adding & installing dependencies", false)
+	.option("--no-deps", "disable adding & installing dependencies")
 	.addOption(
 		new Option("--style <name>", "the style for the components").choices(
 			styles.map((style) => style.name)
@@ -348,7 +348,7 @@ export async function runInit(cwd: string, config: Config, options: InitOptions)
 	});
 
 	// Install dependencies.
-	if (!options.noDeps) {
+	if (options.deps) {
 		tasks.push({
 			title: "Installing dependencies",
 			async task() {
@@ -364,7 +364,7 @@ export async function runInit(cwd: string, config: Config, options: InitOptions)
 
 	await p.tasks(tasks);
 
-	if (options.noDeps) {
+	if (!options.deps) {
 		const prettyList = prettifyList([...PROJECT_DEPENDENCIES], 7);
 		p.log.warn(
 			`shadcn-svelte has been initialized ${color.bold.red("without")} the following ${highlight("dependencies")}:\n${color.gray(prettyList)}`

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -31,7 +31,7 @@ const initOptionsSchema = v.object({
 	tailwindConfig: v.optional(v.string()),
 	componentsAlias: v.optional(v.string()),
 	utilsAlias: v.optional(v.string()),
-	nodeps: v.boolean(),
+	noDeps: v.boolean(),
 });
 
 type InitOptions = v.InferOutput<typeof initOptionsSchema>;
@@ -39,12 +39,8 @@ type InitOptions = v.InferOutput<typeof initOptionsSchema>;
 export const init = new Command()
 	.command("init")
 	.description("initialize your project and install dependencies")
-	.option(
-		"-c, --cwd <cwd>",
-		"the working directory. defaults to the current directory.",
-		process.cwd()
-	)
-	.option("--nodeps", "disable adding & installing dependencies (advanced)", false)
+	.option("-c, --cwd <cwd>", "the working directory", process.cwd())
+	.option("--no-deps", "disable adding & installing dependencies", false)
 	.addOption(
 		new Option("--style <name>", "the style for the components").choices(
 			styles.map((style) => style.name)
@@ -352,7 +348,7 @@ export async function runInit(cwd: string, config: Config, options: InitOptions)
 	});
 
 	// Install dependencies.
-	if (!options.nodeps) {
+	if (!options.noDeps) {
 		tasks.push({
 			title: "Installing dependencies",
 			async task() {
@@ -368,7 +364,7 @@ export async function runInit(cwd: string, config: Config, options: InitOptions)
 
 	await p.tasks(tasks);
 
-	if (options.nodeps) {
+	if (options.noDeps) {
 		const prettyList = prettifyList([...PROJECT_DEPENDENCIES], 7);
 		p.log.warn(
 			`shadcn-svelte has been initialized ${color.bold.red("without")} the following ${highlight("dependencies")}:\n${color.gray(prettyList)}`

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -31,14 +31,10 @@ export const update = new Command()
 	.command("update")
 	.description("update components in your project")
 	.argument("[components...]", "name of components")
-	.option("-a, --all", "update all existing components.", false)
-	.option("-y, --yes", "skip confirmation prompt.", false)
-	.option("--proxy <proxy>", "fetch components from registry using a proxy.", getEnvProxy())
-	.option(
-		"-c, --cwd <cwd>",
-		"the working directory. defaults to the current directory.",
-		process.cwd()
-	)
+	.option("-c, --cwd <cwd>", "the working directory", process.cwd())
+	.option("-a, --all", "update all existing components", false)
+	.option("-y, --yes", "skip confirmation prompt", false)
+	.option("--proxy <proxy>", "fetch components from registry using a proxy", getEnvProxy())
 	.action(async (components, opts) => {
 		intro();
 

--- a/packages/cli/test/commands/init.spec.ts
+++ b/packages/cli/test/commands/init.spec.ts
@@ -37,7 +37,7 @@ it("init (config-full)", async () => {
 	const config = await getConfig(targetDir);
 	if (config === null) throw new Error("config is null");
 
-	await runInit(targetDir, config, { nodeps: false, cwd: targetDir });
+	await runInit(targetDir, config, { deps: true, cwd: targetDir });
 
 	// mkDir mocks
 	expect(mockMkdir).toHaveBeenNthCalledWith(1, expect.stringContaining("src"), expect.anything());

--- a/packages/cli/test/commands/init.spec.ts
+++ b/packages/cli/test/commands/init.spec.ts
@@ -37,7 +37,7 @@ it("init (config-full)", async () => {
 	const config = await getConfig(targetDir);
 	if (config === null) throw new Error("config is null");
 
-	await runInit(targetDir, config);
+	await runInit(targetDir, config, { nodeps: false, cwd: targetDir });
 
 	// mkDir mocks
 	expect(mockMkdir).toHaveBeenNthCalledWith(1, expect.stringContaining("src"), expect.anything());


### PR DESCRIPTION
- fixes #1196
- Updates docs for init command including `Install after --nodeps` instructions

New Init:
```
Usage: shadcn-svelte init [options]

initialize your project and install dependencies

Options:
  -c, --cwd <cwd>            the working directory. defaults to the current directory.
  --nodeps                   disable adding & installing dependencies (advanced) (default: false)
  --style <name>             the style for the components (choices: "default", "new-york")
  --base-color <name>        the base color for the components (choices: "slate", "gray", "zinc", "neutral", "stone")
  --css <path>               path to the global CSS file
  --tailwind-config <path>   path to the tailwind config file
  --components-alias <path>  import alias for components
  --utils-alias <path>       import alias for utils
  -h, --help                 display help for command
```
