### PR TITLE
fix: Vertical separator height

### DIFF
--- a/sites/docs/src/lib/registry/default/ui/separator/separator.svelte
+++ b/sites/docs/src/lib/registry/default/ui/separator/separator.svelte
@@ -13,7 +13,7 @@
 <SeparatorPrimitive.Root
 	class={cn(
 		"bg-border shrink-0",
-		orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+		orientation === "horizontal" ? "h-[1px] w-full" : "min-h-full w-[1px]",
 		className
 	)}
 	{orientation}

--- a/sites/docs/src/lib/registry/new-york/ui/separator/separator.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/separator/separator.svelte
@@ -13,7 +13,7 @@
 <SeparatorPrimitive.Root
 	class={cn(
 		"bg-border shrink-0",
-		orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+		orientation === "horizontal" ? "h-[1px] w-full" : "min-h-full w-[1px]",
 		className
 	)}
 	{orientation}


### PR DESCRIPTION
Fixes height of vertical separator when parent container doesn't have a defined height. Closes https://github.com/huntabyte/shadcn-svelte/issues/1149. 