### PR TITLE
feat: Make card header optional

### DIFF
--- a/sites/docs/src/lib/registry/default/ui/card/card-content.svelte
+++ b/sites/docs/src/lib/registry/default/ui/card/card-content.svelte
@@ -8,6 +8,6 @@
 	export { className as class };
 </script>
 
-<div class={cn("p-6 pt-0", className)} {...$$restProps}>
+<div class={cn("p-6", className)} {...$$restProps}>
 	<slot />
 </div>

--- a/sites/docs/src/lib/registry/default/ui/card/card-header.svelte
+++ b/sites/docs/src/lib/registry/default/ui/card/card-header.svelte
@@ -8,6 +8,6 @@
 	export { className as class };
 </script>
 
-<div class={cn("flex flex-col space-y-1.5 p-6", className)} {...$$restProps}>
+<div class={cn("flex flex-col space-y-1.5 p-6 pb-0", className)} {...$$restProps}>
 	<slot />
 </div>

--- a/sites/docs/src/lib/registry/new-york/ui/card/card-content.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/card/card-content.svelte
@@ -8,6 +8,6 @@
 	export { className as class };
 </script>
 
-<div class={cn("p-6 pt-0", className)} {...$$restProps}>
+<div class={cn("p-6", className)} {...$$restProps}>
 	<slot />
 </div>

--- a/sites/docs/src/lib/registry/new-york/ui/card/card-header.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/card/card-header.svelte
@@ -8,6 +8,6 @@
 	export { className as class };
 </script>
 
-<div class={cn("flex flex-col space-y-1.5 p-6", className)} {...$$restProps}>
+<div class={cn("flex flex-col space-y-1.5 p-6 pb-0", className)} {...$$restProps}>
 	<slot />
 </div>


### PR DESCRIPTION
This PR removes bottom padding from the card header instead of removing top padding from the card content. This way, the card content has consistent padding regardless of the presence of a header.

This is symmetrical to how it is done in the card footer.