### PR TITLE
fix: dropdown-menu-shortcut.svelte to work in rtl layouts

### DIFF
--- a/sites/docs/src/lib/registry/default/ui/dropdown-menu/dropdown-menu-shortcut.svelte
+++ b/sites/docs/src/lib/registry/default/ui/dropdown-menu/dropdown-menu-shortcut.svelte
@@ -8,6 +8,6 @@
 	export { className as class };
 </script>
 
-<span class={cn("ml-auto text-xs tracking-widest opacity-60", className)} {...$$restProps}>
+<span class={cn("ms-auto text-xs tracking-widest opacity-60", className)} {...$$restProps}>
 	<slot />
 </span>


### PR DESCRIPTION
Updated `dropdown-menu-shortcut.svelte` to use margin-inline-start (`ms-auto`) so it works in rtl layouts

Before fix:

![image](https://github.com/user-attachments/assets/beb2671f-4d70-48e3-ba41-0c6e01f4b6ec)


With fix applied:

![image](https://github.com/user-attachments/assets/c8f6b7b3-f40e-4035-bd68-3422d9f72d94)



