### PR TITLE
docs: Add note to Sonner component

### DIFF
--- a/sites/docs/src/content/components/sonner.md
+++ b/sites/docs/src/content/components/sonner.md
@@ -45,6 +45,8 @@ npx shadcn-svelte@latest add sonner
 	Add the Toaster component
 </Step>
 
+Note: Make sure you are adding the import from the path `"$lib/components/ui/sonner"` not `"svelte-sonner"`.
+
 ```svelte title="+layout.svelte" {2,5}
 <script lang="ts">
   import { Toaster } from "$lib/components/ui/sonner";


### PR DESCRIPTION
Just spent more time than I am proud of trying to figure this one out. But I do think its a pretty easy mistake to make if you are trying to use intellisense imports.

This is an obvious mistake but if you aren't paying attention and could be useful to mention in the installation instructions.

```ts
// incorrect
import { Toaster } from "svelte-sonner";
// correct
import { Toaster } from "$lib/components/ui/sonner"; 
```

Obviously when you do this you miss out on the entire reason of adding the sonner component through shadcn as none of the styles are applied.

I think adding a note would help anyone else who makes this mistake.
