### PR TITLE
docs: fix nav link overlapping issues

### DIFF
--- a/sites/docs/src/lib/components/docs/nav/main-nav.svelte
+++ b/sites/docs/src/lib/components/docs/nav/main-nav.svelte
@@ -8,7 +8,7 @@
 <div class="mr-4 hidden md:flex">
 	<a href="/" class="mr-6 flex items-center space-x-2">
 		<Icons.logo class="h-6 w-6" />
-		<span class="hidden font-bold sm:inline-block">
+		<span class="hidden font-bold xl:inline-block">
 			{siteConfig.name}
 		</span>
 	</a>
@@ -71,16 +71,6 @@
 			)}
 		>
 			Colors
-		</a>
-		<a
-			href={siteConfig.links.github}
-			target="_blank"
-			rel="noopener noreferrer"
-			class={cn(
-				"text-foreground/60 hover:text-foreground/80 hidden transition-colors lg:block"
-			)}
-		>
-			GitHub
 		</a>
 	</nav>
 </div>


### PR DESCRIPTION
My previous contribution (tailwind colors page) introduced a new link "colors" to the navbar. This causes the search bar to cover nav links on md-lg viewport widths.

<img width="830" alt="Screenshot 2024-08-17 at 1 26 20 PM" src="https://github.com/user-attachments/assets/b58bbb36-4aa5-4b3c-aae9-a7ec4cc54eaa">

You can also see in this photo that "shadcn-svelte" gets wrapped when squished. Also, the github link is being covered by the search bar.

I opted to remove the "GitHub" link, as it could be considered redundant, being that there is a github icon to the right of the search bar. 

I also mimicked the navbar behavior of the shadcn-ui site, to make things line up a little better.

Here is the result after (md):
<img width="814" alt="Screenshot 2024-08-17 at 1 46 41 PM" src="https://github.com/user-attachments/assets/a69751d3-f355-49ea-be39-02c61e4caba2">

And (lg):
<img width="1305" alt="Screenshot 2024-08-17 at 1 47 00 PM" src="https://github.com/user-attachments/assets/6cdb50d2-7d91-4556-b5ec-bcafbef1a7e2">


