### PR TITLE
docs: make album artwork same size on music example

### DIFF
--- a/sites/docs/src/routes/(app)/examples/music/(components)/album-artwork.svelte
+++ b/sites/docs/src/routes/(app)/examples/music/(components)/album-artwork.svelte
@@ -20,12 +20,12 @@
 				<img
 					class={cn(
 						"h-auto w-auto object-cover transition-all hover:scale-105",
+						`w-[${width}px]`,
+						`h-[${height}px]`,
 						aspectRatio === "portrait" ? "aspect-[3/4]" : "aspect-square"
 					)}
 					src={album.cover}
 					alt={album.name}
-					{width}
-					{height}
 				/>
 			</div>
 		</ContextMenu.Trigger>


### PR DESCRIPTION
before:

<img width="1090" alt="imagen" src="https://github.com/user-attachments/assets/22b7f927-972a-4c26-875f-3986d6c4c18d">

after:

<img width="1072" alt="imagen" src="https://github.com/user-attachments/assets/1e6969ec-9f59-4886-8768-b42673b2b121">
