### PR TITLE
feat ✨: Enhance Copy Button Functionality and UI with Persistent Package Manager Selection

### DIFF
--- a/sites/docs/src/lib/components/docs/copy-button.svelte
+++ b/sites/docs/src/lib/components/docs/copy-button.svelte
@@ -82,10 +82,10 @@
 	{#if $selectedCommand}
 		<Button
 			size="icon"
-			variant="outline"
+			variant="ghost"
 			on:click={() => copyCommand()}
 			class={cn(
-				"pre-copy-btn absolute right-4 top-4 z-10 h-6 w-6 text-zinc-50 hover:bg-zinc-700 hover:text-zinc-50"
+				"pre-copy-btn absolute right-4 top-4 z-10 h-6 w-6  bg-transparent text-zinc-50 hover:bg-zinc-700 hover:text-zinc-50"
 			)}
 			{...$$restProps}
 		>
@@ -104,12 +104,12 @@
 				size="icon"
 				variant="ghost"
 				class={cn(
-					"relative !right-12 h-6 w-fit items-center justify-center rounded-md border border-zinc-50 p-1 text-zinc-50 hover:bg-zinc-700 hover:text-zinc-50 dark:border-zinc-500",
+					"relative !right-12 h-6 w-fit items-center justify-center rounded-md border border-zinc-600 p-1 text-zinc-50 hover:bg-zinc-700 hover:text-zinc-50 dark:border-zinc-700",
 					className
 				)}
 				{...$$restProps}
 			>
-				<span class="sr-only">Copy</span>
+				<span class="sr-only">select package manager</span>
 
 				<span class="flex items-center pl-1"
 					>{$selectedCommand} <CaretSort size="20" />

--- a/sites/docs/src/lib/components/docs/copy-button.svelte
+++ b/sites/docs/src/lib/components/docs/copy-button.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import { clickToCopyAction } from "svelte-legos";
 	import Check from "svelte-radix/Check.svelte";
 	import Copy from "svelte-radix/Copy.svelte";
+	import { CaretSort } from "svelte-radix";
+	import { clickToCopyAction } from "svelte-legos";
 	import { cn, selectedCommand } from "$lib/utils.js";
 	import { Button } from "$lib/registry/new-york/ui/button/index.js";
 	import * as DropdownMenu from "$lib/registry/new-york/ui/dropdown-menu/index.js";
-	import { CaretSort } from "svelte-radix";
 
 	let copied = false;
 	let commands: Record<"npm" | "yarn" | "pnpm" | "bun", string> = {

--- a/sites/docs/src/lib/utils.ts
+++ b/sites/docs/src/lib/utils.ts
@@ -241,3 +241,5 @@ export function getLiftMode(name: string) {
 		toggleLiftMode,
 	};
 }
+
+export let selectedCommand = writable("npm");

--- a/sites/docs/src/lib/utils.ts
+++ b/sites/docs/src/lib/utils.ts
@@ -242,4 +242,4 @@ export function getLiftMode(name: string) {
 	};
 }
 
-export let selectedCommand = writable("npm");
+export const selectedCommand = persisted<string>("package-manager", "npm");


### PR DESCRIPTION
This pull request addresses issue #1059 by introducing a persistent package manager selection feature. The user's chosen package manager is now saved and automatically used across pages within a session, improving user experience and reducing friction.

**Key Improvements:**




* **Dynamic Command Selection:** The component now dynamically updates the `selectedCommand` value when a command is copied.
* **UI Enhancements:** The button's UI has been improved to display the selected command with the `CaretSort` icon, providing a clearer visual indication.
* **Bug Fixes:** The `handleCopyDone` function has been corrected to ensure accurate updating of the `selectedCommand` value.
* **Persistent Package Manager Selection:** User preferences for the package manager are now stored using a writable store for easy retrieval. This eliminates the need for repeated prompts and improves user experience.

**Changes:**

* Integrated `selectedCommand` writable store to manage user preferences.
* Updated `copy-button.svelte` to use the selected package manager and dynamically update `selectedCommand`.
* Enhanced UI to display the selected command with `CaretSort` icon and allow modification of the package manager.
* Fixed `handleCopyDone` function for accurate `selectedCommand` updates.

**Testing:**

* Thoroughly tested the component's functionality to ensure the selected package manager is persisted across pages, and `selectedCommand` is updated correctly.
* Verified that the UI changes are visually appealing and provide a clear indication of the selected command and package manager.


**Showcase**

[Screencast.webm](https://github.com/user-attachments/assets/550a9741-c4d5-4988-94b4-8129b2825372)


