### PR TITLE
feat: highlight the correct line for addSelectedRows

### DIFF
--- a/sites/docs/src/content/components/data-table.md
+++ b/sites/docs/src/content/components/data-table.md
@@ -1202,7 +1202,7 @@ We'll start by creating a new component called `data-table-checkbox.svelte` whic
 
 Next, we'll enable the `addSelectedRows` plugin and import the `<Checkbox />` component we just created.
 
-```svelte showLineNumbers title="routes/payments/data-table.svelte" {13,23,49,55-68,137,143}
+```svelte showLineNumbers title="routes/payments/data-table.svelte" {13,23,50,55-68,137,143}
 <script lang="ts">
   import {
     createTable,


### PR DESCRIPTION
Fixes #1207 

- This message body should clearly illustrate what problems it solves.

Highlights the correct line in the "Enable addSelectedRows plugin" section of "Data Tables".

<img width="750" alt="image" src="https://github.com/user-attachments/assets/850854e8-7927-429c-ae4a-8b517daabb99">


