### PR TITLE
fix: remove slots from drawer overlays

### DIFF
--- a/sites/docs/src/lib/registry/default/ui/drawer/drawer-overlay.svelte
+++ b/sites/docs/src/lib/registry/default/ui/drawer/drawer-overlay.svelte
@@ -13,6 +13,4 @@
 	bind:el
 	class={cn("fixed inset-0 z-50 bg-black/80", className)}
 	{...$$restProps}
->
-	<slot />
-</DrawerPrimitive.Overlay>
+/>

--- a/sites/docs/src/lib/registry/new-york/ui/drawer/drawer-overlay.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/drawer/drawer-overlay.svelte
@@ -13,6 +13,4 @@
 	bind:el
 	class={cn("fixed inset-0 z-50 bg-black/80", className)}
 	{...$$restProps}
->
-	<slot />
-</DrawerPrimitive.Overlay>
+/>


### PR DESCRIPTION
Fixes #1215 

Removes slots from the default/ny drawer overlay components in order to prevent console warnings described in issue.
