### PR TITLE
chore: ignore JetBrains IDE config in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ packages/cli/dist
 dist/
 dist
 generated-assets
+
+# JetBrains IDEs
+.idea/


### PR DESCRIPTION
Quick change to ignore any config files generated by JetBrains IDEs