### PR TITLE
fix: Button roundness is hardcoded by accident

### DIFF
--- a/sites/docs/src/lib/registry/new-york/ui/button/index.ts
+++ b/sites/docs/src/lib/registry/new-york/ui/button/index.ts
@@ -3,7 +3,7 @@ import { type VariantProps, tv } from "tailwind-variants";
 import Root from "./button.svelte";
 
 const buttonVariants = tv({
-	base: "focus-visible:ring-ring inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50",
+	base: "focus-visible:ring-ring inline-flex items-center justify-center whitespace-nowrap text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50",
 	variants: {
 		variant: {
 			default: "bg-primary text-primary-foreground hover:bg-primary/90 shadow",


### PR DESCRIPTION
Roundness was applied in `base`:
```js
const buttonVariants = tv({
	base: 'rounded-md ring-offset-background focus-visible:ring-ring inline-flex items-center justify-center whitespace-nowrap text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
(...)
```
that means that it is applied to all variants, no matter the values of the `size`:
```js
const buttonVariants = tv({
	base: '(...)',
	variants: {
		size: {
			sm: 'h-9 rounded-md px-3',
			lg: 'h-11 rounded-md px-8',
                        // (...)
		},
                // (...)
        },
        // (...)
});
```

I propose removing the `rounded-md` class from the `base` of the `Button` component 