### PR TITLE
fix: Next Button Component with href

### DIFF
--- a/sites/docs/src/lib/registry/default/ui/button/button.svelte
+++ b/sites/docs/src/lib/registry/default/ui/button/button.svelte
@@ -15,7 +15,7 @@
 </script>
 
 {#if href}
-	<a 
+	<a
 		bind:this={ref}
 		class={cn(buttonVariants({ variant, size, className }))}
 		{href}

--- a/sites/docs/src/lib/registry/default/ui/button/button.svelte
+++ b/sites/docs/src/lib/registry/default/ui/button/button.svelte
@@ -15,7 +15,12 @@
 </script>
 
 {#if href}
-	<a bind:this={ref} class={cn(buttonVariants({ variant, size, className }))} {...restProps}>
+	<a 
+		bind:this={ref}
+		class={cn(buttonVariants({ variant, size, className }))}
+		{href}
+		{...restProps}
+	>
 		{@render children?.()}
 	</a>
 {:else}

--- a/sites/docs/src/lib/registry/new-york/ui/button/button.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/button/button.svelte
@@ -15,9 +15,9 @@
 </script>
 
 {#if href}
-	<a 
+	<a
 		bind:this={ref}
-		class={cn(buttonVariants({ variant, size, className }))} 
+		class={cn(buttonVariants({ variant, size, className }))}
 		{href}
 		{...restProps}
 	>

--- a/sites/docs/src/lib/registry/new-york/ui/button/button.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/button/button.svelte
@@ -15,7 +15,12 @@
 </script>
 
 {#if href}
-	<a bind:this={ref} class={cn(buttonVariants({ variant, size, className }))} {...restProps}>
+	<a 
+		bind:this={ref}
+		class={cn(buttonVariants({ variant, size, className }))} 
+		{href}
+		{...restProps}
+	>
 		{@render children?.()}
 	</a>
 {:else}


### PR DESCRIPTION
When passing an href to the Button Component, the button does not redirect to the href on click. It appears that {...restProps} doesn't contain the href passed. 

Manually passed the href variable onto the a tag and links work as expected.