### PR TITLE
docs: fix renamed lucide icons

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,7 +86,7 @@ importers:
         version: 1.0.5
       tsup:
         specifier: ^8.0.0
-        version: 8.2.4(jiti@1.21.6)(postcss@8.4.41)(typescript@5.5.4)(yaml@2.5.0)
+        version: 8.2.4(jiti@1.21.6)(postcss@8.4.47)(typescript@5.5.4)(yaml@2.5.0)
       type-fest:
         specifier: ^3.13.1
         version: 3.13.1
@@ -109,8 +109,8 @@ importers:
         specifier: 8.0.0-rc19
         version: 8.0.0-rc19(svelte@4.2.18)
       lucide-svelte:
-        specifier: ^0.292.0
-        version: 0.292.0(svelte@4.2.18)
+        specifier: ^0.447.0
+        version: 0.447.0(svelte@4.2.18)
       mode-watcher:
         specifier: ^0.1.2
         version: 0.1.2(svelte@4.2.18)
@@ -243,8 +243,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1(svelte@4.2.18)(sveltekit-superforms@2.16.1(@sveltejs/kit@2.5.20(@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.18)(vite@5.3.5(@types/node@18.19.43)))(svelte@4.2.18)(vite@5.3.5(@types/node@18.19.43)))(svelte@4.2.18))
       lucide-svelte:
-        specifier: ^0.363.0
-        version: 0.363.0(svelte@4.2.18)
+        specifier: ^0.447.0
+        version: 0.447.0(svelte@4.2.18)
       mode-watcher:
         specifier: ^0.2.2
         version: 0.2.2(svelte@4.2.18)
@@ -472,8 +472,16 @@ packages:
     resolution: {integrity: sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.25.7':
+    resolution: {integrity: sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.24.7':
     resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.25.7':
+    resolution: {integrity: sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/highlight@7.24.7':
@@ -482,6 +490,11 @@ packages:
 
   '@babel/parser@7.25.3':
     resolution: {integrity: sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.25.7':
+    resolution: {integrity: sha512-aZn7ETtQsjjGG5HruveUK06cU3Hljuhd9Iojm4M8WWv3wLE6OkE5PWbDUkItmMgegmccaITudyuW5RPYrYlgWw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -499,6 +512,10 @@ packages:
 
   '@babel/types@7.25.2':
     resolution: {integrity: sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.25.7':
+    resolution: {integrity: sha512-vwIVdXG+j+FOpkwqHRcBgHLYNL7XMkufrlaFvL9o6Ai9sJn9+PdyIL5qa0XzTZw084c+u9LOls53eoZWP/W5WQ==}
     engines: {node: '>=6.9.0'}
 
   '@changesets/apply-release-plan@7.0.4':
@@ -3557,13 +3574,8 @@ packages:
   lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
 
-  lucide-svelte@0.292.0:
-    resolution: {integrity: sha512-bnTpg9pbm6pQDc+YiLK2yxtRFk2Cc+hbzwjAPaV85k56x10CJ9LsXjon6wRrlNTSdxJR7GOsRjz0A5ZNu3Z7dg==}
-    peerDependencies:
-      svelte: '>=3 <5'
-
-  lucide-svelte@0.363.0:
-    resolution: {integrity: sha512-zpUBFtMEEOOjILgiDX48ijibUww3JUCLrMo5YDGX/De/m6I+vn+oWIGvdyZtuc8nz/P8xHW9vWLKzIWeMrRYbA==}
+  lucide-svelte@0.447.0:
+    resolution: {integrity: sha512-DDCVy79q9H1IAGmrbGDG4GZmCZK+5elK3Fxzu0RzbHKr2Khg7EMc8S6C12bzWcnfW263raqo3grthEjB5gxAjw==}
     peerDependencies:
       svelte: ^3 || ^4 || ^5.0.0-next.42
 
@@ -4006,6 +4018,9 @@ packages:
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
+  picocolors@1.1.0:
+    resolution: {integrity: sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==}
+
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
@@ -4147,6 +4162,10 @@ packages:
 
   postcss@8.4.41:
     resolution: {integrity: sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.4.47:
+    resolution: {integrity: sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   potpack@1.0.2:
@@ -4480,6 +4499,10 @@ packages:
 
   source-map-js@1.2.0:
     resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
+    engines: {node: '>=0.10.0'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
   source-map-support@0.5.21:
@@ -5269,7 +5292,7 @@ snapshots:
       '@antfu/install-pkg': 0.3.3
       '@clack/prompts': 0.7.0
       '@stylistic/eslint-plugin': 2.6.1(eslint@9.8.0)(typescript@5.5.4)
-      '@typescript-eslint/eslint-plugin': 8.0.1(@typescript-eslint/parser@8.0.1(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)
+      '@typescript-eslint/eslint-plugin': 8.0.1(@typescript-eslint/parser@7.18.0(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)
       '@typescript-eslint/parser': 8.0.1(eslint@9.8.0)(typescript@5.5.4)
       eslint: 9.8.0
       eslint-config-flat-gitignore: 0.1.8
@@ -5288,8 +5311,8 @@ snapshots:
       eslint-plugin-regexp: 2.6.0(eslint@9.8.0)
       eslint-plugin-toml: 0.11.1(eslint@9.8.0)
       eslint-plugin-unicorn: 55.0.0(eslint@9.8.0)
-      eslint-plugin-unused-imports: 4.0.1(@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@7.18.0(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)
-      eslint-plugin-vitest: 0.5.4(@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@7.18.0(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.43))
+      eslint-plugin-unused-imports: 4.0.1(@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@8.0.1(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)
+      eslint-plugin-vitest: 0.5.4(@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@8.0.1(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.43))
       eslint-plugin-vue: 9.27.0(eslint@9.8.0)
       eslint-plugin-yml: 1.14.0(eslint@9.8.0)
       eslint-processor-vue-blocks: 0.1.2(@vue/compiler-sfc@3.4.36)(eslint@9.8.0)
@@ -5347,7 +5370,11 @@ snapshots:
 
   '@babel/helper-string-parser@7.24.8': {}
 
+  '@babel/helper-string-parser@7.25.7': {}
+
   '@babel/helper-validator-identifier@7.24.7': {}
+
+  '@babel/helper-validator-identifier@7.25.7': {}
 
   '@babel/highlight@7.24.7':
     dependencies:
@@ -5359,6 +5386,10 @@ snapshots:
   '@babel/parser@7.25.3':
     dependencies:
       '@babel/types': 7.25.2
+
+  '@babel/parser@7.25.7':
+    dependencies:
+      '@babel/types': 7.25.7
 
   '@babel/runtime@7.21.5':
     dependencies:
@@ -5386,6 +5417,12 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.24.8
       '@babel/helper-validator-identifier': 7.24.7
+      to-fast-properties: 2.0.0
+
+  '@babel/types@7.25.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.25.7
+      '@babel/helper-validator-identifier': 7.25.7
       to-fast-properties: 2.0.0
 
   '@changesets/apply-release-plan@7.0.4':
@@ -6693,10 +6730,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@8.0.1(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)':
+  '@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@7.18.0(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 8.0.1(eslint@9.8.0)(typescript@5.5.4)
+      '@typescript-eslint/parser': 7.18.0(eslint@9.8.0)(typescript@5.5.4)
       '@typescript-eslint/scope-manager': 8.0.1
       '@typescript-eslint/type-utils': 8.0.1(eslint@9.8.0)(typescript@5.5.4)
       '@typescript-eslint/utils': 8.0.1(eslint@9.8.0)(typescript@5.5.4)
@@ -6964,11 +7001,11 @@ snapshots:
 
   '@vue/compiler-core@3.4.36':
     dependencies:
-      '@babel/parser': 7.25.3
+      '@babel/parser': 7.25.7
       '@vue/shared': 3.4.36
       entities: 5.0.0
       estree-walker: 2.0.2
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
 
   '@vue/compiler-dom@3.4.36':
     dependencies:
@@ -6977,15 +7014,15 @@ snapshots:
 
   '@vue/compiler-sfc@3.4.36':
     dependencies:
-      '@babel/parser': 7.25.3
+      '@babel/parser': 7.25.7
       '@vue/compiler-core': 3.4.36
       '@vue/compiler-dom': 3.4.36
       '@vue/compiler-ssr': 3.4.36
       '@vue/shared': 3.4.36
       estree-walker: 2.0.2
       magic-string: 0.30.11
-      postcss: 8.4.41
-      source-map-js: 1.2.0
+      postcss: 8.4.47
+      source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.4.36':
     dependencies:
@@ -7920,19 +7957,19 @@ snapshots:
       semver: 7.6.3
       strip-indent: 3.0.0
 
-  eslint-plugin-unused-imports@4.0.1(@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@7.18.0(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0):
+  eslint-plugin-unused-imports@4.0.1(@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@8.0.1(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0):
     dependencies:
       eslint: 9.8.0
       eslint-rule-composer: 0.3.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.0.1(@typescript-eslint/parser@8.0.1(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)
+      '@typescript-eslint/eslint-plugin': 8.0.1(@typescript-eslint/parser@7.18.0(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)
 
-  eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@7.18.0(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.43)):
+  eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@8.0.1(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.43)):
     dependencies:
       '@typescript-eslint/utils': 7.18.0(eslint@9.8.0)(typescript@5.5.4)
       eslint: 9.8.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.0.1(@typescript-eslint/parser@8.0.1(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)
+      '@typescript-eslint/eslint-plugin': 8.0.1(@typescript-eslint/parser@7.18.0(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)
       vitest: 1.6.0(@types/node@18.19.43)
     transitivePeerDependencies:
       - supports-color
@@ -8706,11 +8743,7 @@ snapshots:
       pseudomap: 1.0.2
       yallist: 2.1.2
 
-  lucide-svelte@0.292.0(svelte@4.2.18):
-    dependencies:
-      svelte: 4.2.18
-
-  lucide-svelte@0.363.0(svelte@4.2.18):
+  lucide-svelte@0.447.0(svelte@4.2.18):
     dependencies:
       svelte: 4.2.18
 
@@ -9345,6 +9378,8 @@ snapshots:
 
   picocolors@1.0.1: {}
 
+  picocolors@1.1.0: {}
+
   picomatch@2.3.1: {}
 
   picomatch@3.0.1: {}
@@ -9411,12 +9446,12 @@ snapshots:
       jiti: 1.21.6
       postcss: 8.4.41
 
-  postcss-load-config@6.0.1(jiti@1.21.6)(postcss@8.4.41)(yaml@2.5.0):
+  postcss-load-config@6.0.1(jiti@1.21.6)(postcss@8.4.47)(yaml@2.5.0):
     dependencies:
       lilconfig: 3.1.2
     optionalDependencies:
       jiti: 1.21.6
-      postcss: 8.4.41
+      postcss: 8.4.47
       yaml: 2.5.0
 
   postcss-nested@6.2.0(postcss@8.4.41):
@@ -9444,6 +9479,12 @@ snapshots:
       nanoid: 3.3.7
       picocolors: 1.0.1
       source-map-js: 1.2.0
+
+  postcss@8.4.47:
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.1.0
+      source-map-js: 1.2.1
 
   potpack@1.0.2: {}
 
@@ -9784,6 +9825,8 @@ snapshots:
       sander: 0.5.1
 
   source-map-js@1.2.0: {}
+
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
     dependencies:
@@ -10222,7 +10265,7 @@ snapshots:
 
   tslib@2.6.3: {}
 
-  tsup@8.2.4(jiti@1.21.6)(postcss@8.4.41)(typescript@5.5.4)(yaml@2.5.0):
+  tsup@8.2.4(jiti@1.21.6)(postcss@8.4.47)(typescript@5.5.4)(yaml@2.5.0):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.23.0)
       cac: 6.7.14
@@ -10234,14 +10277,14 @@ snapshots:
       globby: 11.1.0
       joycon: 3.1.1
       picocolors: 1.0.1
-      postcss-load-config: 6.0.1(jiti@1.21.6)(postcss@8.4.41)(yaml@2.5.0)
+      postcss-load-config: 6.0.1(jiti@1.21.6)(postcss@8.4.47)(yaml@2.5.0)
       resolve-from: 5.0.0
       rollup: 4.20.0
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.4.41
+      postcss: 8.4.47
       typescript: 5.5.4
     transitivePeerDependencies:
       - jiti

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 2.27.7
       '@huntabyte/eslint-config':
         specifier: ^0.3.2
-        version: 0.3.2(@vue/compiler-sfc@3.4.36)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@4.2.18))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@4.2.18))(svelte@4.2.18)(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.43))
+        version: 0.3.2(@vue/compiler-sfc@3.4.36)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@4.2.18))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@4.2.18))(svelte@4.2.18)(typescript@5.5.4)(vitest@1.6.0)
       '@huntabyte/eslint-plugin':
         specifier: ^0.1.0
         version: 0.1.0(eslint@9.8.0)
@@ -109,8 +109,8 @@ importers:
         specifier: 8.0.0-rc19
         version: 8.0.0-rc19(svelte@4.2.18)
       lucide-svelte:
-        specifier: ^0.447.0
-        version: 0.447.0(svelte@4.2.18)
+        specifier: ^0.292.0
+        version: 0.292.0(svelte@4.2.18)
       mode-watcher:
         specifier: ^0.1.2
         version: 0.1.2(svelte@4.2.18)
@@ -3574,6 +3574,11 @@ packages:
   lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
 
+  lucide-svelte@0.292.0:
+    resolution: {integrity: sha512-bnTpg9pbm6pQDc+YiLK2yxtRFk2Cc+hbzwjAPaV85k56x10CJ9LsXjon6wRrlNTSdxJR7GOsRjz0A5ZNu3Z7dg==}
+    peerDependencies:
+      svelte: '>=3 <5'
+
   lucide-svelte@0.447.0:
     resolution: {integrity: sha512-DDCVy79q9H1IAGmrbGDG4GZmCZK+5elK3Fxzu0RzbHKr2Khg7EMc8S6C12bzWcnfW263raqo3grthEjB5gxAjw==}
     peerDependencies:
@@ -5287,7 +5292,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@antfu/eslint-config@2.24.1(@vue/compiler-sfc@3.4.36)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@4.2.18))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@4.2.18))(svelte@4.2.18)(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.43))':
+  '@antfu/eslint-config@2.24.1(@vue/compiler-sfc@3.4.36)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@4.2.18))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@4.2.18))(svelte@4.2.18)(typescript@5.5.4)(vitest@1.6.0)':
     dependencies:
       '@antfu/install-pkg': 0.3.3
       '@clack/prompts': 0.7.0
@@ -5312,7 +5317,7 @@ snapshots:
       eslint-plugin-toml: 0.11.1(eslint@9.8.0)
       eslint-plugin-unicorn: 55.0.0(eslint@9.8.0)
       eslint-plugin-unused-imports: 4.0.1(@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@8.0.1(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)
-      eslint-plugin-vitest: 0.5.4(@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@8.0.1(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.43))
+      eslint-plugin-vitest: 0.5.4(@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@8.0.1(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)(vitest@1.6.0)
       eslint-plugin-vue: 9.27.0(eslint@9.8.0)
       eslint-plugin-yml: 1.14.0(eslint@9.8.0)
       eslint-processor-vue-blocks: 0.1.2(@vue/compiler-sfc@3.4.36)(eslint@9.8.0)
@@ -6012,9 +6017,9 @@ snapshots:
 
   '@humanwhocodes/retry@0.3.0': {}
 
-  '@huntabyte/eslint-config@0.3.2(@vue/compiler-sfc@3.4.36)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@4.2.18))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@4.2.18))(svelte@4.2.18)(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.43))':
+  '@huntabyte/eslint-config@0.3.2(@vue/compiler-sfc@3.4.36)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@4.2.18))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@4.2.18))(svelte@4.2.18)(typescript@5.5.4)(vitest@1.6.0)':
     dependencies:
-      '@antfu/eslint-config': 2.24.1(@vue/compiler-sfc@3.4.36)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@4.2.18))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@4.2.18))(svelte@4.2.18)(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.43))
+      '@antfu/eslint-config': 2.24.1(@vue/compiler-sfc@3.4.36)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@4.2.18))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@4.2.18))(svelte@4.2.18)(typescript@5.5.4)(vitest@1.6.0)
       '@antfu/install-pkg': 0.3.3
       '@clack/prompts': 0.7.0
       '@huntabyte/eslint-plugin': 0.1.0(eslint@9.8.0)
@@ -7964,7 +7969,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.0.1(@typescript-eslint/parser@7.18.0(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)
 
-  eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@8.0.1(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.43)):
+  eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@8.0.1(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)(vitest@1.6.0):
     dependencies:
       '@typescript-eslint/utils': 7.18.0(eslint@9.8.0)(typescript@5.5.4)
       eslint: 9.8.0
@@ -8742,6 +8747,10 @@ snapshots:
     dependencies:
       pseudomap: 1.0.2
       yallist: 2.1.2
+
+  lucide-svelte@0.292.0(svelte@4.2.18):
+    dependencies:
+      svelte: 4.2.18
 
   lucide-svelte@0.447.0(svelte@4.2.18):
     dependencies:

--- a/sites/docs/package.json
+++ b/sites/docs/package.json
@@ -73,7 +73,7 @@
 		"embla-carousel-autoplay": "8.0.0-rc19",
 		"embla-carousel-svelte": "8.0.0-rc19",
 		"formsnap": "^0.5.1",
-		"lucide-svelte": "^0.363.0",
+		"lucide-svelte": "^0.447.0",
 		"mode-watcher": "^0.2.2",
 		"nanoid": "^5.0.6",
 		"paneforge": "^0.0.2",

--- a/sites/docs/src/lib/registry/default/block/dashboard-02.svelte
+++ b/sites/docs/src/lib/registry/default/block/dashboard-02.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import CircleUser from "lucide-svelte/icons/circle-user";
-	import LineChart from "lucide-svelte/icons/line-chart";
+	import ChartLine from "lucide-svelte/icons/chart-line";
 	import Package from "lucide-svelte/icons/package";
-	import Home from "lucide-svelte/icons/home";
+	import House from "lucide-svelte/icons/house";
 	import ShoppingCart from "lucide-svelte/icons/shopping-cart";
 	import Bell from "lucide-svelte/icons/bell";
 	import Menu from "lucide-svelte/icons/menu";
@@ -37,7 +37,7 @@
 						href="##"
 						class="text-muted-foreground hover:text-primary flex items-center gap-3 rounded-lg px-3 py-2 transition-all"
 					>
-						<Home class="h-4 w-4" />
+						<House class="h-4 w-4" />
 						Dashboard
 					</a>
 					<a
@@ -70,7 +70,7 @@
 						href="##"
 						class="text-muted-foreground hover:text-primary flex items-center gap-3 rounded-lg px-3 py-2 transition-all"
 					>
-						<LineChart class="h-4 w-4" />
+						<ChartLine class="h-4 w-4" />
 						Analytics
 					</a>
 				</nav>
@@ -117,7 +117,7 @@
 							href="##"
 							class="text-muted-foreground hover:text-foreground mx-[-0.65rem] flex items-center gap-4 rounded-xl px-3 py-2"
 						>
-							<Home class="h-5 w-5" />
+							<House class="h-5 w-5" />
 							Dashboard
 						</a>
 						<a
@@ -150,7 +150,7 @@
 							href="##"
 							class="text-muted-foreground hover:text-foreground mx-[-0.65rem] flex items-center gap-4 rounded-xl px-3 py-2"
 						>
-							<LineChart class="h-5 w-5" />
+							<ChartLine class="h-5 w-5" />
 							Analytics
 						</a>
 					</nav>

--- a/sites/docs/src/lib/registry/default/block/dashboard-05.svelte
+++ b/sites/docs/src/lib/registry/default/block/dashboard-05.svelte
@@ -4,8 +4,8 @@
 	import Copy from "lucide-svelte/icons/copy";
 	import CreditCard from "lucide-svelte/icons/credit-card";
 	import File from "lucide-svelte/icons/file";
-	import Home from "lucide-svelte/icons/home";
-	import LineChart from "lucide-svelte/icons/line-chart";
+	import House from "lucide-svelte/icons/house";
+	import ChartLine from "lucide-svelte/icons/chart-line";
 	import ListFilter from "lucide-svelte/icons/list-filter";
 	import EllipsisVertical from "lucide-svelte/icons/ellipsis-vertical";
 	import Package from "lucide-svelte/icons/package";
@@ -50,7 +50,7 @@
 						use:builder.action
 						{...builder}
 					>
-						<Home class="h-5 w-5" />
+						<House class="h-5 w-5" />
 						<span class="sr-only">Dashboard</span>
 					</a>
 				</Tooltip.Trigger>
@@ -106,7 +106,7 @@
 						use:builder.action
 						{...builder}
 					>
-						<LineChart class="h-5 w-5" />
+						<ChartLine class="h-5 w-5" />
 						<span class="sr-only">Analytics</span>
 					</a>
 				</Tooltip.Trigger>
@@ -154,7 +154,7 @@
 							href="##"
 							class="text-muted-foreground hover:text-foreground flex items-center gap-4 px-2.5"
 						>
-							<Home class="h-5 w-5" />
+							<House class="h-5 w-5" />
 							Dashboard
 						</a>
 						<a href="##" class="text-foreground flex items-center gap-4 px-2.5">
@@ -179,7 +179,7 @@
 							href="##"
 							class="text-muted-foreground hover:text-foreground flex items-center gap-4 px-2.5"
 						>
-							<LineChart class="h-5 w-5" />
+							<ChartLine class="h-5 w-5" />
 							Settings
 						</a>
 					</nav>

--- a/sites/docs/src/lib/registry/default/block/dashboard-06.svelte
+++ b/sites/docs/src/lib/registry/default/block/dashboard-06.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import File from "lucide-svelte/icons/file";
-	import Home from "lucide-svelte/icons/home";
-	import LineChart from "lucide-svelte/icons/line-chart";
+	import House from "lucide-svelte/icons/house";
+	import ChartLine from "lucide-svelte/icons/chart-line";
 	import ListFilter from "lucide-svelte/icons/list-filter";
 	import Ellipsis from "lucide-svelte/icons/ellipsis";
 	import Package from "lucide-svelte/icons/package";
@@ -43,7 +43,7 @@
 						use:builder.action
 						{...builder}
 					>
-						<Home class="h-5 w-5" />
+						<House class="h-5 w-5" />
 						<span class="sr-only">Dashboard</span>
 					</a>
 				</Tooltip.Trigger>
@@ -99,7 +99,7 @@
 						use:builder.action
 						{...builder}
 					>
-						<LineChart class="h-5 w-5" />
+						<ChartLine class="h-5 w-5" />
 						<span class="sr-only">Analytics</span>
 					</a>
 				</Tooltip.Trigger>
@@ -147,7 +147,7 @@
 							href="##"
 							class="text-muted-foreground hover:text-foreground flex items-center gap-4 px-2.5"
 						>
-							<Home class="h-5 w-5" />
+							<House class="h-5 w-5" />
 							Dashboard
 						</a>
 						<a
@@ -172,7 +172,7 @@
 							href="##"
 							class="text-muted-foreground hover:text-foreground flex items-center gap-4 px-2.5"
 						>
-							<LineChart class="h-5 w-5" />
+							<ChartLine class="h-5 w-5" />
 							Settings
 						</a>
 					</nav>

--- a/sites/docs/src/lib/registry/default/block/dashboard-07.svelte
+++ b/sites/docs/src/lib/registry/default/block/dashboard-07.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import ChevronLeft from "lucide-svelte/icons/chevron-left";
-	import Home from "lucide-svelte/icons/home";
-	import LineChart from "lucide-svelte/icons/line-chart";
+	import House from "lucide-svelte/icons/house";
+	import ChartLine from "lucide-svelte/icons/chart-line";
 	import Package from "lucide-svelte/icons/package";
 	import Package2 from "lucide-svelte/icons/package-2";
 	import PanelLeft from "lucide-svelte/icons/panel-left";
@@ -45,7 +45,7 @@
 						use:builder.action
 						{...builder}
 					>
-						<Home class="h-5 w-5" />
+						<House class="h-5 w-5" />
 						<span class="sr-only">Dashboard</span>
 					</a>
 				</Tooltip.Trigger>
@@ -101,7 +101,7 @@
 						use:builder.action
 						{...builder}
 					>
-						<LineChart class="h-5 w-5" />
+						<ChartLine class="h-5 w-5" />
 						<span class="sr-only">Analytics</span>
 					</a>
 				</Tooltip.Trigger>
@@ -149,7 +149,7 @@
 							href="##"
 							class="text-muted-foreground hover:text-foreground flex items-center gap-4 px-2.5"
 						>
-							<Home class="h-5 w-5" />
+							<House class="h-5 w-5" />
 							Dashboard
 						</a>
 						<a
@@ -174,7 +174,7 @@
 							href="##"
 							class="text-muted-foreground hover:text-foreground flex items-center gap-4 px-2.5"
 						>
-							<LineChart class="h-5 w-5" />
+							<ChartLine class="h-5 w-5" />
 							Settings
 						</a>
 					</nav>

--- a/sites/docs/src/lib/registry/new-york/block/dashboard-02.svelte
+++ b/sites/docs/src/lib/registry/new-york/block/dashboard-02.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import CircleUser from "lucide-svelte/icons/circle-user";
-	import LineChart from "lucide-svelte/icons/line-chart";
+	import ChartLine from "lucide-svelte/icons/chart-line";
 	import Package from "lucide-svelte/icons/package";
-	import Home from "lucide-svelte/icons/home";
+	import House from "lucide-svelte/icons/house";
 	import ShoppingCart from "lucide-svelte/icons/shopping-cart";
 	import Bell from "lucide-svelte/icons/bell";
 	import Menu from "lucide-svelte/icons/menu";
@@ -37,7 +37,7 @@
 						href="##"
 						class="text-muted-foreground hover:text-primary flex items-center gap-3 rounded-lg px-3 py-2 transition-all"
 					>
-						<Home class="h-4 w-4" />
+						<House class="h-4 w-4" />
 						Dashboard
 					</a>
 					<a
@@ -70,7 +70,7 @@
 						href="##"
 						class="text-muted-foreground hover:text-primary flex items-center gap-3 rounded-lg px-3 py-2 transition-all"
 					>
-						<LineChart class="h-4 w-4" />
+						<ChartLine class="h-4 w-4" />
 						Analytics
 					</a>
 				</nav>
@@ -117,7 +117,7 @@
 							href="##"
 							class="text-muted-foreground hover:text-foreground mx-[-0.65rem] flex items-center gap-4 rounded-xl px-3 py-2"
 						>
-							<Home class="h-5 w-5" />
+							<House class="h-5 w-5" />
 							Dashboard
 						</a>
 						<a
@@ -150,7 +150,7 @@
 							href="##"
 							class="text-muted-foreground hover:text-foreground mx-[-0.65rem] flex items-center gap-4 rounded-xl px-3 py-2"
 						>
-							<LineChart class="h-5 w-5" />
+							<ChartLine class="h-5 w-5" />
 							Analytics
 						</a>
 					</nav>

--- a/sites/docs/src/lib/registry/new-york/block/dashboard-05.svelte
+++ b/sites/docs/src/lib/registry/new-york/block/dashboard-05.svelte
@@ -4,8 +4,8 @@
 	import Copy from "lucide-svelte/icons/copy";
 	import CreditCard from "lucide-svelte/icons/credit-card";
 	import File from "lucide-svelte/icons/file";
-	import Home from "lucide-svelte/icons/home";
-	import LineChart from "lucide-svelte/icons/line-chart";
+	import House from "lucide-svelte/icons/house";
+	import ChartLine from "lucide-svelte/icons/chart-line";
 	import ListFilter from "lucide-svelte/icons/list-filter";
 	import EllipsisVertical from "lucide-svelte/icons/ellipsis-vertical";
 	import Package from "lucide-svelte/icons/package";
@@ -50,7 +50,7 @@
 						use:builder.action
 						{...builder}
 					>
-						<Home class="h-5 w-5" />
+						<House class="h-5 w-5" />
 						<span class="sr-only">Dashboard</span>
 					</a>
 				</Tooltip.Trigger>
@@ -106,7 +106,7 @@
 						use:builder.action
 						{...builder}
 					>
-						<LineChart class="h-5 w-5" />
+						<ChartLine class="h-5 w-5" />
 						<span class="sr-only">Analytics</span>
 					</a>
 				</Tooltip.Trigger>
@@ -154,7 +154,7 @@
 							href="##"
 							class="text-muted-foreground hover:text-foreground flex items-center gap-4 px-2.5"
 						>
-							<Home class="h-5 w-5" />
+							<House class="h-5 w-5" />
 							Dashboard
 						</a>
 						<a href="##" class="text-foreground flex items-center gap-4 px-2.5">
@@ -179,7 +179,7 @@
 							href="##"
 							class="text-muted-foreground hover:text-foreground flex items-center gap-4 px-2.5"
 						>
-							<LineChart class="h-5 w-5" />
+							<ChartLine class="h-5 w-5" />
 							Settings
 						</a>
 					</nav>

--- a/sites/docs/src/lib/registry/new-york/block/dashboard-06.svelte
+++ b/sites/docs/src/lib/registry/new-york/block/dashboard-06.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import File from "lucide-svelte/icons/file";
-	import Home from "lucide-svelte/icons/home";
-	import LineChart from "lucide-svelte/icons/line-chart";
+	import House from "lucide-svelte/icons/house";
+	import ChartLine from "lucide-svelte/icons/chart-line";
 	import ListFilter from "lucide-svelte/icons/list-filter";
 	import Ellipsis from "lucide-svelte/icons/ellipsis";
 	import Package from "lucide-svelte/icons/package";
@@ -43,7 +43,7 @@
 						use:builder.action
 						{...builder}
 					>
-						<Home class="h-5 w-5" />
+						<House class="h-5 w-5" />
 						<span class="sr-only">Dashboard</span>
 					</a>
 				</Tooltip.Trigger>
@@ -99,7 +99,7 @@
 						use:builder.action
 						{...builder}
 					>
-						<LineChart class="h-5 w-5" />
+						<ChartLine class="h-5 w-5" />
 						<span class="sr-only">Analytics</span>
 					</a>
 				</Tooltip.Trigger>
@@ -147,7 +147,7 @@
 							href="##"
 							class="text-muted-foreground hover:text-foreground flex items-center gap-4 px-2.5"
 						>
-							<Home class="h-5 w-5" />
+							<House class="h-5 w-5" />
 							Dashboard
 						</a>
 						<a
@@ -172,7 +172,7 @@
 							href="##"
 							class="text-muted-foreground hover:text-foreground flex items-center gap-4 px-2.5"
 						>
-							<LineChart class="h-5 w-5" />
+							<ChartLine class="h-5 w-5" />
 							Settings
 						</a>
 					</nav>

--- a/sites/docs/src/lib/registry/new-york/block/dashboard-07.svelte
+++ b/sites/docs/src/lib/registry/new-york/block/dashboard-07.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import ChevronLeft from "lucide-svelte/icons/chevron-left";
-	import Home from "lucide-svelte/icons/home";
-	import LineChart from "lucide-svelte/icons/line-chart";
+	import House from "lucide-svelte/icons/house";
+	import ChartLine from "lucide-svelte/icons/chart-line";
 	import Package from "lucide-svelte/icons/package";
 	import Package2 from "lucide-svelte/icons/package-2";
 	import PanelLeft from "lucide-svelte/icons/panel-left";
@@ -45,7 +45,7 @@
 						use:builder.action
 						{...builder}
 					>
-						<Home class="h-5 w-5" />
+						<House class="h-5 w-5" />
 						<span class="sr-only">Dashboard</span>
 					</a>
 				</Tooltip.Trigger>
@@ -101,7 +101,7 @@
 						use:builder.action
 						{...builder}
 					>
-						<LineChart class="h-5 w-5" />
+						<ChartLine class="h-5 w-5" />
 						<span class="sr-only">Analytics</span>
 					</a>
 				</Tooltip.Trigger>
@@ -149,7 +149,7 @@
 							href="##"
 							class="text-muted-foreground hover:text-foreground flex items-center gap-4 px-2.5"
 						>
-							<Home class="h-5 w-5" />
+							<House class="h-5 w-5" />
 							Dashboard
 						</a>
 						<a
@@ -174,7 +174,7 @@
 							href="##"
 							class="text-muted-foreground hover:text-foreground flex items-center gap-4 px-2.5"
 						>
-							<LineChart class="h-5 w-5" />
+							<ChartLine class="h-5 w-5" />
 							Settings
 						</a>
 					</nav>


### PR DESCRIPTION
Updates `lucide-svelte` to the latest version. Fixes #1212.

I only updated the `docs` package. I'm not sure how the `playground-*` packages are used, if at all - the `playground-js` package uses an even more outdated version while the `playground-ts` package doesn't use it at all.