### PR TITLE
fix: Issue #1307 [Sheet] transition

### DIFF
--- a/sites/docs/src/lib/registry/default/ui/sheet/sheet-content.svelte
+++ b/sites/docs/src/lib/registry/default/ui/sheet/sheet-content.svelte
@@ -26,7 +26,7 @@
 	delete $$restProps.inTransitionConfig;
 	export let outTransition: $$Props["outTransition"] = fly;
 	let outTransitionConfig: $$Props["outTransitionConfig"] = {
-		...sheetTransitions[side ? side : "right"].out,
+		...sheetTransitions[side || "right"].out,
 		...$$props.outTransitionConfig,
 	};
 	delete $$restProps.outTransitionConfig;

--- a/sites/docs/src/lib/registry/default/ui/sheet/sheet-content.svelte
+++ b/sites/docs/src/lib/registry/default/ui/sheet/sheet-content.svelte
@@ -19,11 +19,17 @@
 	export let side: $$Props["side"] = "right";
 	export { className as class };
 	export let inTransition: $$Props["inTransition"] = fly;
-	export let inTransitionConfig: $$Props["inTransitionConfig"] =
-		sheetTransitions[side ?? "right"].in;
+	let inTransitionConfig: $$Props["inTransitionConfig"] = {
+		...sheetTransitions[side ?? "right"].in,
+		...$$props.inTransitionConfig,
+	};
+	delete $$restProps.inTransitionConfig;
 	export let outTransition: $$Props["outTransition"] = fly;
-	export let outTransitionConfig: $$Props["outTransitionConfig"] =
-		sheetTransitions[side ?? "right"].out;
+	let outTransitionConfig: $$Props["outTransitionConfig"] = {
+		...sheetTransitions[side ? side : "right"].out,
+		...$$props.outTransitionConfig,
+	};
+	delete $$restProps.outTransitionConfig;
 </script>
 
 <SheetPortal>

--- a/sites/docs/src/lib/registry/new-york/ui/sheet/sheet-content.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/sheet/sheet-content.svelte
@@ -26,7 +26,7 @@
 	delete $$restProps.inTransitionConfig;
 	export let outTransition: $$Props["outTransition"] = fly;
 	let outTransitionConfig: $$Props["outTransitionConfig"] = {
-		...sheetTransitions[side ? side : "right"].out,
+		...sheetTransitions[side || "right"].out,
 		...$$props.outTransitionConfig,
 	};
 	delete $$restProps.outTransitionConfig;

--- a/sites/docs/src/lib/registry/new-york/ui/sheet/sheet-content.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/sheet/sheet-content.svelte
@@ -19,11 +19,17 @@
 	export let side: $$Props["side"] = "right";
 	export { className as class };
 	export let inTransition: $$Props["inTransition"] = fly;
-	export let inTransitionConfig: $$Props["inTransitionConfig"] =
-		sheetTransitions[side ?? "right"].in;
+	let inTransitionConfig: $$Props["inTransitionConfig"] = {
+		...sheetTransitions[side ?? "right"].in,
+		...$$props.inTransitionConfig,
+	};
+	delete $$restProps.inTransitionConfig;
 	export let outTransition: $$Props["outTransition"] = fly;
-	export let outTransitionConfig: $$Props["outTransitionConfig"] =
-		sheetTransitions[side ?? "right"].out;
+	let outTransitionConfig: $$Props["outTransitionConfig"] = {
+		...sheetTransitions[side ? side : "right"].out,
+		...$$props.outTransitionConfig,
+	};
+	delete $$restProps.outTransitionConfig;
 </script>
 
 <SheetPortal>


### PR DESCRIPTION
This pull request fixes the issue talked in #1307.

The proposed changes creates a fallback in case out/in configs are not specified. 
outTransitionConfig imports the default values and then overwrites them with the provided props if present.

Please let me know if you have any questions or a better way to solve the problem, thanks!