### PR TITLE
fix: make `isActive` prop optional

### DIFF
--- a/sites/docs/src/lib/registry/default/ui/pagination/pagination-link.svelte
+++ b/sites/docs/src/lib/registry/default/ui/pagination/pagination-link.svelte
@@ -5,7 +5,7 @@
 
 	type $$Props = PaginationPrimitive.PageProps &
 		Props & {
-			isActive: boolean;
+			isActive?: boolean;
 		};
 
 	type $$Events = PaginationPrimitive.PageEvents;


### PR DESCRIPTION
Currently the `isActive` prop is required:
```ts
type $$Props = PaginationPrimitive.PageProps &
  Props & {
    isActive: boolean;
  };
```
where it should've been optional. This PR addresses that issue by changing the `isActive` to be optional.
