### PR TITLE
docs: Update data-table.md to highlight the correct changes

### DIFF
--- a/sites/docs/src/content/components/data-table.md
+++ b/sites/docs/src/content/components/data-table.md
@@ -1198,7 +1198,7 @@ We'll start by creating a new component called `data-table-checkbox.svelte` whic
 
 Next, we'll enable the `addSelectedRows` plugin and import the `<Checkbox />` component we just created.
 
-```svelte showLineNumbers title="routes/payments/data-table.svelte" {13,23,49,55-68,137,143}
+```svelte showLineNumbers title="routes/payments/data-table.svelte" {13,23,50,55-68,138,144}
 <script lang="ts">
   import {
     createTable,


### PR DESCRIPTION
When following the Table component docs, I found a few lines that are wrongly highlighted. The changed lines now highlight the required parts/code for enabling the `addSelectedRows` plugin.