### PR TITLE
docs: replace `svelte-add` with svelte cli

### DIFF
--- a/sites/docs/src/content/installation/manual.md
+++ b/sites/docs/src/content/installation/manual.md
@@ -13,9 +13,9 @@ description: How to setup shadcn-svelte manually.
 
 ### Add Tailwind
 
-Use the `svelte-add` CLI to add Tailwind CSS to your project.
+Use the Svelte CLI to add Tailwind CSS to your project.
 
-<PMExecute command="svelte-add@latest tailwindcss" />
+<PMExecute command="sv add tailwindcss" />
 
 ### Add dependencies
 

--- a/sites/docs/src/content/installation/sveltekit.md
+++ b/sites/docs/src/content/installation/sveltekit.md
@@ -20,9 +20,9 @@ Use the SvelteKit CLI to create a new project.
 
 ### Add TailwindCSS
 
-Use the `svelte-add` CLI to add Tailwind CSS to your project.
+Use the Svelte CLI to add Tailwind CSS to your project.
 
-<PMExecute command="svelte-add@latest tailwindcss" />
+<PMExecute command="sv add tailwindcss" />
 
 ### Install dependencies
 

--- a/sites/docs/src/content/installation/vite.md
+++ b/sites/docs/src/content/installation/vite.md
@@ -14,9 +14,9 @@ description: How to setup shadcn-svelte in a Vite project.
 
 ### Add TailwindCSS
 
-Use the `svelte-add` CLI to add Tailwind CSS to your project.
+Use the Svelte CLI to add Tailwind CSS to your project.
 
-<PMExecute command="svelte-add@latest tailwindcss" />
+<PMExecute command="sv add tailwindcss" />
 
 ### Install dependencies
 


### PR DESCRIPTION
Reason: `svelte-add` is now [deprecated](https://github.com/svelte-add/svelte-add/pull/559) and merged with [svelte cli](https://github.com/sveltejs/cli) (`sv`)