### PR TITLE
next(chore): update `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ generated-assets
 .idea/
 
 .velite
+sites/docs/static/registry


### PR DESCRIPTION
Ignoring registry because it unnecessarily bogs down PRs. We build the registry during the site build and CI, so no reason to have its history cluttering our diffs.