### PR TITLE
next: Fix various elements to use Svelte types vs internal

### DIFF
--- a/sites/docs/src/lib/registry/default/ui/carousel/context.ts
+++ b/sites/docs/src/lib/registry/default/ui/carousel/context.ts
@@ -1,7 +1,8 @@
+import type { WithElementRef } from "bits-ui";
 import type { EmblaCarouselSvelteType } from "embla-carousel-svelte";
 import type emblaCarouselSvelte from "embla-carousel-svelte";
 import { getContext, hasContext, setContext } from "svelte";
-import type { PrimitiveDivAttributes } from "$lib/utils.js";
+import type { HTMLAttributes } from "svelte/elements";
 
 export type CarouselAPI =
 	NonNullable<NonNullable<EmblaCarouselSvelteType["$$_attributes"]>["on:emblaInit"]> extends (
@@ -22,7 +23,7 @@ export type CarouselProps = {
 	plugins?: CarouselPlugins;
 	setApi?: (api: CarouselAPI | undefined) => void;
 	orientation?: "horizontal" | "vertical";
-} & PrimitiveDivAttributes;
+} & WithElementRef<HTMLAttributes<HTMLDivElement>>;
 
 const EMBLA_CAROUSEL_CONTEXT = Symbol("EMBLA_CAROUSEL_CONTEXT");
 

--- a/sites/docs/src/lib/registry/default/ui/drawer/drawer-footer.svelte
+++ b/sites/docs/src/lib/registry/default/ui/drawer/drawer-footer.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
-	import { type PrimitiveDivAttributes, cn } from "$lib/utils.js";
+	import { cn } from "$lib/utils.js";
+	import type { WithElementRef } from "bits-ui";
+	import type { HTMLAttributes } from "svelte/elements";
 
 	let {
 		ref = $bindable(null),
 		class: className,
 		children,
 		...restProps
-	}: PrimitiveDivAttributes = $props();
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
 </script>
 
 <div bind:this={ref} class={cn("mt-auto flex flex-col gap-2 p-4", className)} {...restProps}>

--- a/sites/docs/src/lib/registry/default/ui/form/form-element-field.svelte
+++ b/sites/docs/src/lib/registry/default/ui/form/form-element-field.svelte
@@ -7,7 +7,7 @@
 <script lang="ts" generics="T extends Record<string, unknown>, U extends _FormPathLeaves<T>">
 	import * as FormPrimitive from "formsnap";
 	import type { HTMLAttributes } from "svelte/elements";
-	import type { WithElementRef } from "bits-ui";
+	import type { WithElementRef, WithoutChildren } from "bits-ui";
 	import { cn } from "$lib/utils.js";
 
 	let {
@@ -17,7 +17,7 @@
 		name,
 		children: childrenProp,
 		...restProps
-	}: WithElementRef<HTMLAttributes<HTMLDivElement>> &
+	}: WithoutChildren<WithElementRef<HTMLAttributes<HTMLDivElement>>> &
 		FormPrimitive.ElementFieldProps<T, U> = $props();
 </script>
 

--- a/sites/docs/src/lib/registry/default/ui/form/form-field.svelte
+++ b/sites/docs/src/lib/registry/default/ui/form/form-field.svelte
@@ -6,8 +6,9 @@
 
 <script lang="ts" generics="T extends Record<string, unknown>, U extends _FormPath<T>">
 	import * as FormPrimitive from "formsnap";
-	import type { WithoutChildren } from "bits-ui";
-	import { type PrimitiveDivAttributes, cn } from "$lib/utils.js";
+	import type { WithoutChildren, WithElementRef } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
 
 	let {
 		ref = $bindable(null),
@@ -16,7 +17,8 @@
 		name,
 		children: childrenProp,
 		...restProps
-	}: FormPrimitive.FieldProps<T, U> & WithoutChildren<PrimitiveDivAttributes> = $props();
+	}: FormPrimitive.FieldProps<T, U> &
+		WithoutChildren<WithElementRef<HTMLAttributes<HTMLDivElement>>> = $props();
 </script>
 
 <FormPrimitive.Field {form} {name}>

--- a/sites/docs/src/lib/registry/new-york/ui/carousel/context.ts
+++ b/sites/docs/src/lib/registry/new-york/ui/carousel/context.ts
@@ -1,7 +1,8 @@
 import type { EmblaCarouselSvelteType } from "embla-carousel-svelte";
 import type emblaCarouselSvelte from "embla-carousel-svelte";
 import { getContext, hasContext, setContext } from "svelte";
-import type { PrimitiveDivAttributes } from "$lib/utils.js";
+import type { WithElementRef } from "bits-ui";
+import type { HTMLAttributes } from "svelte/elements";
 
 export type CarouselAPI =
 	NonNullable<NonNullable<EmblaCarouselSvelteType["$$_attributes"]>["on:emblaInit"]> extends (
@@ -22,7 +23,7 @@ export type CarouselProps = {
 	plugins?: CarouselPlugins;
 	setApi?: (api: CarouselAPI | undefined) => void;
 	orientation?: "horizontal" | "vertical";
-} & PrimitiveDivAttributes;
+} & WithElementRef<HTMLAttributes<HTMLDivElement>>;
 
 const EMBLA_CAROUSEL_CONTEXT = Symbol("EMBLA_CAROUSEL_CONTEXT");
 

--- a/sites/docs/src/lib/registry/new-york/ui/drawer/drawer-footer.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/drawer/drawer-footer.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
-	import { type PrimitiveDivAttributes, cn } from "$lib/utils.js";
+	import { cn } from "$lib/utils.js";
+	import type { WithElementRef } from "bits-ui";
+	import type { HTMLAttributes } from "svelte/elements";
 
 	let {
 		ref = $bindable(null),
 		class: className,
 		children,
 		...restProps
-	}: PrimitiveDivAttributes = $props();
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
 
 	export { className as class };
 </script>

--- a/sites/docs/src/lib/registry/new-york/ui/form/form-field.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/form/form-field.svelte
@@ -6,7 +6,9 @@
 
 <script lang="ts" generics="T extends Record<string, unknown>, U extends _FormPath<T>">
 	import * as FormPrimitive from "formsnap";
-	import { type PrimitiveDivAttributes, cn } from "$lib/utils.js";
+	import { cn } from "$lib/utils.js";
+	import type { WithElementRef, WithoutChildren } from "bits-ui";
+	import type { HTMLAttributes } from "svelte/elements";
 
 	let {
 		ref = $bindable(null),
@@ -15,7 +17,8 @@
 		name,
 		children: childrenProp,
 		...restProps
-	}: FormPrimitive.FieldProps<T, U> & PrimitiveDivAttributes = $props();
+	}: FormPrimitive.FieldProps<T, U> &
+		WithoutChildren<WithElementRef<HTMLAttributes<HTMLDivElement>>> = $props();
 </script>
 
 <FormPrimitive.Field {form} {name}>


### PR DESCRIPTION
I was planning to create a bunch of types helpers and add them to the `utils.ts` file, but to avoid blurring the lines too much, I think it's best we just stick to the provided Svelte types everywhere. Perhaps we change our mind later given there is a request for it.

This cleans up some remaining leftovers.