### PR TITLE
fix: update tabindex attributes to use numbers

### DIFF
--- a/sites/docs/src/lib/components/docs/copy-button.svelte
+++ b/sites/docs/src/lib/components/docs/copy-button.svelte
@@ -76,8 +76,8 @@
 >
 	<span class="sr-only">Copy</span>
 	{#if copied}
-		<Check class="h-3 w-3" tabindex="-1" />
+		<Check class="h-3 w-3" tabindex={-1} />
 	{:else}
-		<Copy class="h-3 w-3" tabindex="-1" />
+		<Copy class="h-3 w-3" tabindex={-1} />
 	{/if}
 </button>

--- a/sites/docs/src/lib/registry/new-york/example/breadcrumb-dropdown.svelte
+++ b/sites/docs/src/lib/registry/new-york/example/breadcrumb-dropdown.svelte
@@ -17,7 +17,7 @@
 			<DropdownMenu.Root>
 				<DropdownMenu.Trigger class="flex items-center gap-1">
 					Components
-					<ChevronDown tabindex="-1" />
+					<ChevronDown tabindex={-1} />
 				</DropdownMenu.Trigger>
 				<DropdownMenu.Content align="start">
 					<DropdownMenu.Item>Documentation</DropdownMenu.Item>
@@ -27,7 +27,7 @@
 			</DropdownMenu.Root>
 		</Breadcrumb.Item>
 		<Breadcrumb.Separator>
-			<Slash tabindex="-1" />
+			<Slash tabindex={-1} />
 		</Breadcrumb.Separator>
 		<Breadcrumb.Item>
 			<Breadcrumb.Page>Breadcrumb</Breadcrumb.Page>

--- a/sites/docs/src/lib/registry/new-york/example/breadcrumb-separator.svelte
+++ b/sites/docs/src/lib/registry/new-york/example/breadcrumb-separator.svelte
@@ -9,13 +9,13 @@
 			<Breadcrumb.Link href="/">Home</Breadcrumb.Link>
 		</Breadcrumb.Item>
 		<Breadcrumb.Separator>
-			<Slash tabindex="-1" />
+			<Slash tabindex={-1} />
 		</Breadcrumb.Separator>
 		<Breadcrumb.Item>
 			<Breadcrumb.Link href="/components">Components</Breadcrumb.Link>
 		</Breadcrumb.Item>
 		<Breadcrumb.Separator>
-			<Slash tabindex="-1" />
+			<Slash tabindex={-1} />
 		</Breadcrumb.Separator>
 		<Breadcrumb.Item>
 			<Breadcrumb.Page>Breadcrumb</Breadcrumb.Page>

--- a/sites/docs/src/lib/registry/new-york/ui/breadcrumb/breadcrumb-ellipsis.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/breadcrumb/breadcrumb-ellipsis.svelte
@@ -18,6 +18,6 @@
 	class={cn("flex size-9 items-center justify-center", className)}
 	{...restProps}
 >
-	<DotsHorizontal class="size-4 outline-none" tabindex="-1" />
+	<DotsHorizontal class="size-4 outline-none" tabindex={-1} />
 	<span class="sr-only">More</span>
 </span>


### PR DESCRIPTION
Not sure why this wasn't errant before, but in a new scaffold, I was getting this error:
```
Type 'string' is not assignable to type 'number'.
```
Happy to close if this leads to unexpected side effects.

P.S. I was using `"svelte-radix": "^2.0.1"` not `"svelte-radix": "2.0.0-next.5"` maybe that's where the mismatch was coming from 🤷 