### PR TITLE
docs: update DatePicker/Popover usage example

### DIFF
--- a/sites/docs/src/content/components/date-picker.md
+++ b/sites/docs/src/content/components/date-picker.md
@@ -44,7 +44,7 @@ See installations instructions for the [Popover](/docs/components/popover#instal
   let value = $state<DateValue>();
 </script>
 
-<Popover.Root openFocus>
+<Popover.Root>
   <Popover.Trigger>
     {#snippet child({ props })}
       <Button
@@ -61,7 +61,7 @@ See installations instructions for the [Popover](/docs/components/popover#instal
     {/snippet}
   </Popover.Trigger>
   <Popover.Content class="w-auto p-0">
-    <Calendar bind:value initialFocus />
+    <Calendar bind:value type="single" />
   </Popover.Content>
 </Popover.Root>
 ```

--- a/sites/docs/src/content/components/date-picker.md
+++ b/sites/docs/src/content/components/date-picker.md
@@ -61,7 +61,7 @@ See installations instructions for the [Popover](/docs/components/popover#instal
     {/snippet}
   </Popover.Trigger>
   <Popover.Content class="w-auto p-0">
-    <Calendar bind:value type="single" />
+    <Calendar bind:value type="single" initialFocus />
   </Popover.Content>
 </Popover.Root>
 ```


### PR DESCRIPTION
For the first;
```
Object literal may only specify known properties, and '"openFocus"' does not exist in type 'PopoverRootPropsWithoutHTML'.ts(2353)
```

The second (because `type` isn't specified);
```
Type 'DateValue | undefined' is not assignable to type 'DateValue[] | undefined'.
  Type 'CalendarDate' is missing the following properties from type 'DateValue[]': length, pop, push, concat, and 35 more.ts(2322)
```