### PR TITLE
fix: wrong icon import for `ScrollDownButton` in `Select`

### DIFF
--- a/sites/docs/src/lib/registry/default/ui/select/select-scroll-down-button.svelte
+++ b/sites/docs/src/lib/registry/default/ui/select/select-scroll-down-button.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import ChevronDown from "lucide-svelte/icons/chevron-up";
+	import ChevronDown from "lucide-svelte/icons/chevron-down";
 	import { Select as SelectPrimitive, type WithoutChildrenOrChild } from "bits-ui";
 	import { cn } from "$lib/utils.js";
 


### PR DESCRIPTION
The `chevron-up` icon was being imported instead of the `chevron-down` icon