### PR TITLE
fix(next): Update command doesn't update component code

### DIFF
--- a/.changeset/loud-flies-smoke.md
+++ b/.changeset/loud-flies-smoke.md
@@ -1,5 +1,5 @@
 ---
-"shadcn-svelte": minor
+"shadcn-svelte": patch
 ---
 
-fix: Ensure `utils.(js|ts)` is not fetched from the registry on update command.
+fix: Ensure `utils.(js|ts)` is not fetched from the registry on `update` command

--- a/.changeset/loud-flies-smoke.md
+++ b/.changeset/loud-flies-smoke.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": minor
+---
+
+fix: Ensure `utils.(js|ts)` is not fetched from the registry on update command.

--- a/.changeset/tricky-trains-suffer.md
+++ b/.changeset/tricky-trains-suffer.md
@@ -1,5 +1,5 @@
 ---
-"shadcn-svelte": minor
+"shadcn-svelte": patch
 ---
 
-fix: Update command now updates component code.
+fix: `update` command now properly updates components

--- a/.changeset/tricky-trains-suffer.md
+++ b/.changeset/tricky-trains-suffer.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": minor
+---
+
+fix: Update command now updates component code.

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -151,15 +151,11 @@ async function runUpdate(cwd: string, config: cliConfig.Config, options: UpdateO
 
 	const tasks: p.Task[] = [];
 
-	const utilsIndex = selectedComponents.findIndex((item) => item.name === "utils");
-
+	const utils = selectedComponents.find((item) => item.name === "utils");
 	// `update utils` - update the utils.(ts|js) file
-	if (utilsIndex !== -1) {
+	if (utils) {
 		// remove utils so that it isn't fetched from the registry
-		selectedComponents = [
-			...selectedComponents.slice(0, utilsIndex),
-			...selectedComponents.slice(utilsIndex + 1),
-		];
+		selectedComponents = selectedComponents.filter((item) => item !== utils);
 
 		const extension = config.typescript ? ".ts" : ".js";
 		const utilsPath = config.resolvedPaths.utils + extension;

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -149,8 +149,10 @@ async function runUpdate(cwd: string, config: cliConfig.Config, options: UpdateO
 		if (p.isCancel(proceed) || proceed === false) cancel();
 	}
 
+	const utilsIndex = selectedComponents.findIndex((item) => item.name === "utils");
+
 	// `update utils` - update the utils.(ts|js) file
-	if (selectedComponents.find((item) => item.name === "utils")) {
+	if (utilsIndex !== -1) {
 		const extension = config.typescript ? ".ts" : ".js";
 		const utilsPath = config.resolvedPaths.utils + extension;
 
@@ -160,6 +162,12 @@ async function runUpdate(cwd: string, config: cliConfig.Config, options: UpdateO
 
 		// utils.(ts|js) is not in the registry, it is a template, so we'll just overwrite it
 		await fs.writeFile(utilsPath, config.typescript ? UTILS : UTILS_JS);
+
+		// remove utils so that it isn't fetched from the registry
+		selectedComponents = [
+			...selectedComponents.slice(0, utilsIndex),
+			...selectedComponents.slice(utilsIndex + 1),
+		];
 	}
 
 	const tree = await registry.resolveTree({

--- a/packages/cli/src/utils/registry/index.ts
+++ b/packages/cli/src/utils/registry/index.ts
@@ -1,6 +1,5 @@
 import { fetch } from "node-fetch-native";
 import { createProxy } from "node-fetch-native/proxy";
-import path from "node:path";
 import * as v from "valibot";
 import { CLIError, error } from "../errors.js";
 import type { Config } from "../get-config.js";
@@ -136,7 +135,7 @@ export function getItemTargetPath(
 		return null;
 	}
 
-	return path.join(config.resolvedPaths[type as keyof typeof config.resolvedPaths], item.name);
+	return config.resolvedPaths[type as keyof typeof config.resolvedPaths];
 }
 
 async function fetchRegistry(paths: string[]) {

--- a/packages/cli/src/utils/registry/index.ts
+++ b/packages/cli/src/utils/registry/index.ts
@@ -121,7 +121,7 @@ export async function fetchTree(config: Config, tree: RegistryIndex) {
 
 export function getItemTargetPath(
 	config: Config,
-	item: Pick<v.InferOutput<typeof schemas.registryItemWithContentSchema>, "type">,
+	item: v.InferOutput<typeof schemas.registryItemWithContentSchema>,
 	override?: string
 ) {
 	// Allow overrides for all items but ui.
@@ -132,11 +132,11 @@ export function getItemTargetPath(
 	const [parent, type] = item.type.split(":");
 	if (!parent || !type) return null;
 
-	if (!(parent in config.resolvedPaths)) {
+	if (!(type in config.resolvedPaths)) {
 		return null;
 	}
 
-	return path.join(config.resolvedPaths[parent as keyof typeof config.resolvedPaths], type);
+	return path.join(config.resolvedPaths[type as keyof typeof config.resolvedPaths], item.name);
 }
 
 async function fetchRegistry(paths: string[]) {

--- a/packages/cli/src/utils/registry/index.ts
+++ b/packages/cli/src/utils/registry/index.ts
@@ -1,5 +1,6 @@
 import { fetch } from "node-fetch-native";
 import { createProxy } from "node-fetch-native/proxy";
+import path from "node:path";
 import * as v from "valibot";
 import { CLIError, error } from "../errors.js";
 import type { Config } from "../get-config.js";
@@ -135,7 +136,7 @@ export function getItemTargetPath(
 		return null;
 	}
 
-	return config.resolvedPaths[type as keyof typeof config.resolvedPaths];
+	return path.join(config.resolvedPaths[type as keyof typeof config.resolvedPaths]);
 }
 
 async function fetchRegistry(paths: string[]) {

--- a/packages/cli/src/utils/registry/index.ts
+++ b/packages/cli/src/utils/registry/index.ts
@@ -129,12 +129,8 @@ export function getItemTargetPath(
 		return override;
 	}
 
-	const [parent, type] = item.type.split(":");
-	if (!parent || !type) return null;
-
-	if (!(type in config.resolvedPaths)) {
-		return null;
-	}
+	const [, type] = item.type.split(":");
+	if (!type || !(type in config.resolvedPaths)) return null;
 
 	return path.join(config.resolvedPaths[type as keyof typeof config.resolvedPaths]);
 }

--- a/packages/cli/test/utils/registry/index.spec.ts
+++ b/packages/cli/test/utils/registry/index.spec.ts
@@ -75,7 +75,7 @@ describe("getItemTargetPath", () => {
 				},
 				"./override-path"
 			)
-		).toEqual("src\\lib\\components\\ui\\label");
+		).toEqual("src/lib/components/ui/label");
 	});
 
 	it("resolves item target path", async () => {
@@ -89,6 +89,6 @@ describe("getItemTargetPath", () => {
 				],
 				type: "registry:ui",
 			})
-		).toEqual("src\\lib\\components\\ui\\label");
+		).toEqual("src/lib/components/ui/label");
 	});
 });

--- a/packages/cli/test/utils/registry/index.spec.ts
+++ b/packages/cli/test/utils/registry/index.spec.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { getItemTargetPath } from "../../../src/utils/registry/index";
+import { SITE_BASE_URL } from "../../../src/constants";
+
+const config = {
+	style: "new-york",
+	tailwind: {
+		config: "tailwind.config.js",
+		css: "src/app.pcss",
+		baseColor: "zinc",
+	},
+	aliases: {
+		utils: "$lib/utils",
+		components: "$lib/components",
+		hooks: "$lib/hooks",
+		ui: "$lib/components/ui",
+	},
+	// not how they will look in the end but works for the tests
+	resolvedPaths: {
+		components: "./src/lib/components",
+		tailwindConfig: "./tailwind.config.js",
+		tailwindCss: "./src/app.pcss",
+		utils: "./src/lib/utils",
+		cwd: "./",
+		hooks: "./src/lib/hooks",
+		ui: "./src/lib/components/ui",
+	},
+	typescript: true,
+	registry: `${SITE_BASE_URL}/registry`,
+};
+
+describe("getItemTargetPath", () => {
+	it("returns null if invalid type missing `:`", async () => {
+		expect(
+			getItemTargetPath(
+				config,
+				{
+					name: "label",
+					dependencies: ["bits-ui@next"],
+					registryDependencies: [],
+					files: [
+						//... snip this since it doesn't matter
+					],
+					// @ts-expect-error Comes from over the wire in prod
+					type: "registry",
+				}
+			)
+		).toEqual(null);
+	});
+
+	it("returns null if `item.type` has invalid `:<type>`", async () => {
+		expect(
+			getItemTargetPath(
+				config,
+				{
+					name: "label",
+					dependencies: ["bits-ui@next"],
+					registryDependencies: [],
+					files: [
+						//... snip this since it doesn't matter
+					],
+					// @ts-expect-error Comes from over the wire in prod
+					type: "registry:foo",
+				}
+			)
+		).toEqual(null);
+	});
+
+	it("disallow overrides for `registry:ui`", async () => {
+		expect(
+			getItemTargetPath(
+				config,
+				{
+					name: "label",
+					dependencies: ["bits-ui@next"],
+					registryDependencies: [],
+					files: [
+						//... snip this since it doesn't matter
+					],
+					type: "registry:ui",
+				},
+				"./override-path"
+			)
+		).toEqual("src\\lib\\components\\ui\\label");
+	});
+
+	it("resolves itemTargetPath", async () => {
+		expect(
+			getItemTargetPath(config, {
+				name: "label",
+				dependencies: ["bits-ui@next"],
+				registryDependencies: [],
+				files: [
+					//... snip this since it doesn't matter
+				],
+				type: "registry:ui",
+			})
+		).toEqual("src\\lib\\components\\ui\\label");
+	});
+});

--- a/packages/cli/test/utils/registry/index.spec.ts
+++ b/packages/cli/test/utils/registry/index.spec.ts
@@ -75,7 +75,7 @@ describe("getItemTargetPath", () => {
 				},
 				"./override-path"
 			)
-		).toEqual("src/lib/components/ui/label");
+		).toEqual("src/lib/components/ui");
 	});
 
 	it("resolves item target path", async () => {
@@ -89,6 +89,6 @@ describe("getItemTargetPath", () => {
 				],
 				type: "registry:ui",
 			})
-		).toEqual("src/lib/components/ui/label");
+		).toEqual("src/lib/components/ui");
 	});
 });

--- a/packages/cli/test/utils/registry/index.spec.ts
+++ b/packages/cli/test/utils/registry/index.spec.ts
@@ -60,7 +60,7 @@ describe("getItemTargetPath", () => {
 		).toEqual(null);
 	});
 
-	it("disallow overrides for `registry:ui`", async () => {
+	it("disallows overrides for `registry:ui`", async () => {
 		expect(
 			getItemTargetPath(
 				config,
@@ -78,7 +78,7 @@ describe("getItemTargetPath", () => {
 		).toEqual("src\\lib\\components\\ui\\label");
 	});
 
-	it("resolves itemTargetPath", async () => {
+	it("resolves item target path", async () => {
 		expect(
 			getItemTargetPath(config, {
 				name: "label",

--- a/packages/cli/test/utils/registry/index.spec.ts
+++ b/packages/cli/test/utils/registry/index.spec.ts
@@ -32,37 +32,31 @@ const config = {
 describe("getItemTargetPath", () => {
 	it("returns null if invalid type missing `:`", async () => {
 		expect(
-			getItemTargetPath(
-				config,
-				{
-					name: "label",
-					dependencies: ["bits-ui@next"],
-					registryDependencies: [],
-					files: [
-						//... snip this since it doesn't matter
-					],
-					// @ts-expect-error Comes from over the wire in prod
-					type: "registry",
-				}
-			)
+			getItemTargetPath(config, {
+				name: "label",
+				dependencies: ["bits-ui@next"],
+				registryDependencies: [],
+				files: [
+					//... snip this since it doesn't matter
+				],
+				// @ts-expect-error Comes from over the wire in prod
+				type: "registry",
+			})
 		).toEqual(null);
 	});
 
 	it("returns null if `item.type` has invalid `:<type>`", async () => {
 		expect(
-			getItemTargetPath(
-				config,
-				{
-					name: "label",
-					dependencies: ["bits-ui@next"],
-					registryDependencies: [],
-					files: [
-						//... snip this since it doesn't matter
-					],
-					// @ts-expect-error Comes from over the wire in prod
-					type: "registry:foo",
-				}
-			)
+			getItemTargetPath(config, {
+				name: "label",
+				dependencies: ["bits-ui@next"],
+				registryDependencies: [],
+				files: [
+					//... snip this since it doesn't matter
+				],
+				// @ts-expect-error Comes from over the wire in prod
+				type: "registry:foo",
+			})
 		).toEqual(null);
 	});
 


### PR DESCRIPTION
If you ran `npx shadcn-svelte@next update` before you would notice that even though it completes successfully it doesn't actually update the code for any components.

PS: This sounds super rude reading it back but I can't think of a better way to word it so it's really not intentional

+ Also Closes #1368 
