### PR TITLE
docs: fix card select showing [object object]

### DIFF
--- a/sites/docs/src/lib/registry/default/example/card-with-form.svelte
+++ b/sites/docs/src/lib/registry/default/example/card-with-form.svelte
@@ -27,7 +27,7 @@
 	let framework = $state("");
 
 	const selectedFramework = $derived(
-		frameworks.find((f) => f.value === framework) ?? "Select a framework"
+		frameworks.find((f) => f.value === framework)?.label ?? "Select a framework"
 	);
 </script>
 


### PR DESCRIPTION
solves issue #1424 

- fixes selected showing `[object object]` instead of the actual name of the selected framework when using the `Default` style

Before:
![image](https://github.com/user-attachments/assets/ab403706-729e-4ab2-9a95-b90b0a68c06c)

After:
![image](https://github.com/user-attachments/assets/492e216a-9ed6-437d-b8b7-ecd4e463dd79)

