### PR TITLE
fix(next): Fix inset sidebar with UnoCSS

### DIFF
--- a/sites/docs/src/lib/registry/default/ui/sidebar/sidebar-inset.svelte
+++ b/sites/docs/src/lib/registry/default/ui/sidebar/sidebar-inset.svelte
@@ -15,7 +15,7 @@
 	bind:this={ref}
 	class={cn(
 		"bg-background relative flex min-h-svh flex-1 flex-col",
-		"peer-data-[variant=inset]:min-h-[calc(100svh-theme(spacing.4))] md:peer-data-[variant=inset]:m-2 md:peer-[[data-state=collapsed][data-variant=inset]]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
+		"peer-data-[variant=inset]:min-h-[calc(100svh-theme(spacing.4))] md:peer-[[data-state=collapsed][data-variant=inset]]:ml-2 md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
 		className
 	)}
 	{...restProps}

--- a/sites/docs/src/lib/registry/new-york/ui/sidebar/sidebar-inset.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/sidebar/sidebar-inset.svelte
@@ -15,7 +15,7 @@
 	bind:this={ref}
 	class={cn(
 		"bg-background relative flex min-h-svh flex-1 flex-col",
-		"peer-data-[variant=inset]:min-h-[calc(100svh-theme(spacing.4))] md:peer-data-[variant=inset]:m-2 md:peer-[[data-state=collapsed][data-variant=inset]]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
+		"peer-data-[variant=inset]:min-h-[calc(100svh-theme(spacing.4))] md:peer-[[data-state=collapsed][data-variant=inset]]:ml-2 md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
 		className
 	)}
 	{...restProps}


### PR DESCRIPTION
The TailwindCSS classes to add a margin to the `inset` variant of sidebars were not being recognized properly by UnoCSS. This may be a bug in UnoCSS, but this fix still works fine in both TailwindCSS and UnoCSS.

Before fix:
![CleanShot 2024-11-04 at 20 10 54@2x](https://github.com/user-attachments/assets/0c84668b-0105-4f9f-a450-07ff874fdec0)

After fix:
![CleanShot 2024-11-04 at 20 11 16@2x](https://github.com/user-attachments/assets/2a9026c7-5707-4492-818f-d5c0a384f215)
