### PR TITLE
docs: daisyui integration

### DIFF
--- a/sites/docs/src/content/theming.md
+++ b/sites/docs/src/content/theming.md
@@ -152,24 +152,24 @@ It's recommended to use [HSL colors](https://www.smashingmagazine.com/2021/07/hs
 
 See the [Tailwind CSS documentation](https://tailwindcss.com/docs/customizing-colors#using-css-variables) for more information on using `rgb`, `rgba` or `hsl` colors.
 
-
-
 ## Integrating with other theming libraries
 
 ### Daisy UI
 
-To use Shadcn components with daisy ui you just need to change the variables in the tailwind config to match daisyui ones, note that daisy ui uses *oklch*
+To use Shadcn components with daisy ui you just need to change the variables in the tailwind config to match daisyui ones, note that daisy ui uses _oklch_
 
 You should be able to delete the entire postcss file and just change the variables in your tailwind config
 
 #### Usefull Links
- - [Theme Default Variables](https://github.com/saadeghi/daisyui/blob/master/src/theming/themeDefaults.js)
- - [Color Variables](https://github.com/saadeghi/daisyui/blob/master/src/theming/colorNames.js)
- - [Official Docs](https://daisyui.com/)
 
- - [Check the Demo](https://shad-daisy.vercel.app/)
+- [Theme Default Variables](https://github.com/saadeghi/daisyui/blob/master/src/theming/themeDefaults.js)
+- [Color Variables](https://github.com/saadeghi/daisyui/blob/master/src/theming/colorNames.js)
+- [Official Docs](https://daisyui.com/)
+
+- [Check the Demo](https://shad-daisy.vercel.app/)
 
 Example
+
 ```js title="tailwind.config.js"
 import type { Config } from 'tailwindcss';
 import daisyui from 'daisyui';

--- a/sites/docs/src/content/theming.md
+++ b/sites/docs/src/content/theming.md
@@ -151,3 +151,148 @@ You can now use the `warning` utility class in your components.
 It's recommended to use [HSL colors](https://www.smashingmagazine.com/2021/07/hsl-colors-css/) for theming but you can also use other color formats if you prefer.
 
 See the [Tailwind CSS documentation](https://tailwindcss.com/docs/customizing-colors#using-css-variables) for more information on using `rgb`, `rgba` or `hsl` colors.
+
+
+
+## Integrating with other theming libraries
+
+### Daisy UI
+
+To use Shadcn components with daisy ui you just need to change the variables in the tailwind config to match daisyui ones, note that daisy ui uses *oklch*
+
+You should be able to delete the entire postcss file and just change the variables in your tailwind config
+
+#### Usefull Links
+ - [Theme Default Variables](https://github.com/saadeghi/daisyui/blob/master/src/theming/themeDefaults.js)
+ - [Color Variables](https://github.com/saadeghi/daisyui/blob/master/src/theming/colorNames.js)
+ - [Official Docs](https://daisyui.com/)
+
+ - [Check the Demo](https://shad-daisy.vercel.app/)
+
+Example
+```js title="tailwind.config.js"
+import type { Config } from 'tailwindcss';
+import daisyui from 'daisyui';
+import tailwindcssAnimate from 'tailwindcss-animate';
+
+export default {
+	content: ['./src/**/*.{html,js,svelte,ts}'],
+	theme: {
+		container: {
+			center: true,
+			padding: '2rem'
+		},
+		extend: {
+			colors: {
+				border: 'oklch(var(--p) / <alpha-value>)',
+				input: 'oklch(var(--s) / <alpha-value>)',
+				ring: 'oklch(var(--in) / <alpha-value>)',
+				background: 'oklch(var(--b1) / <alpha-value>)',
+				foreground: 'oklch(var(--bc) / <alpha-value>)',
+				primary: {
+					DEFAULT: 'oklch(var(--p) / <alpha-value>)',
+					foreground: 'oklch(var(--pc) / <alpha-value>)'
+				},
+				secondary: {
+					DEFAULT: 'oklch(var(--s) / <alpha-value>)',
+					foreground: 'oklch(var(--sc) / <alpha-value>)'
+				},
+				destructive: {
+					DEFAULT: 'oklch(var(--er) / <alpha-value>)',
+					foreground: 'oklch(var(--erc) / <alpha-value>)'
+				},
+				muted: {
+					DEFAULT: 'oklch(var(--n) / <alpha-value>)',
+					foreground: 'oklch(var(--nc) / <alpha-value>)'
+				},
+				accent: {
+					DEFAULT: 'oklch(var(--a) / <alpha-value>)',
+					foreground: 'oklch(var(--ac) / <alpha-value>)'
+				},
+				popover: {
+					DEFAULT: 'oklch(var(--b2) / <alpha-value>)',
+					foreground: 'oklch(var(--bc) / <alpha-value>)'
+				},
+				card: {
+					DEFAULT: 'oklch(var(--n) / <alpha-value>)',
+					foreground: 'oklch(var(--nc) / <alpha-value>)'
+				},
+				sidebar: {
+					DEFAULT: 'oklch(var(--b2) / <alpha-value>)',
+					foreground: 'oklch(var(--bc) / <alpha-value>)',
+					primary: 'oklch(var(--p) / <alpha-value>)',
+					'primary-foreground': 'oklch(var(--pc) / <alpha-value>)',
+					accent: 'oklch(var(--p) / <alpha-value>)',
+					'accent-foreground': 'oklch(var(--pc) / <alpha-value>)',
+					border: 'oklch(var(--bc) / <alpha-value>)',
+					ring: 'oklch(var(--bc) / <alpha-value>)'
+				}
+			},
+			borderRadius: {
+				xl: 'calc(var(--rounded-btn) + 4px)',
+				lg: 'var(--rounded-btn)',
+				md: 'calc(var(--rounded-btn) - 2px)',
+				sm: 'calc(var(--rounded-btn) - 4px)'
+			},
+			keyframes: {
+				'accordion-down': {
+					from: { height: '0' },
+					to: { height: 'var(--bits-accordion-content-height)' }
+				},
+				'accordion-up': {
+					from: { height: 'var(--bits-accordion-content-height)' },
+					to: { height: '0' }
+				},
+				'caret-blink': {
+					'0%,70%,100%': { opacity: '1' },
+					'20%,50%': { opacity: '0' }
+				}
+			},
+			animation: {
+				'accordion-down': 'accordion-down 0.2s ease-out',
+				'accordion-up': 'accordion-up 0.2s ease-out',
+				'caret-blink': 'caret-blink 1.25s ease-out infinite'
+			}
+		}
+	},
+
+	plugins: [daisyui, tailwindcssAnimate],
+	daisyui: {
+		themes: [
+			'bumblebee',
+			'light',
+			'dark',
+			'cupcake',
+			'emerald',
+			'corporate',
+			'synthwave',
+			'retro',
+			'cyberpunk',
+			'valentine',
+			'halloween',
+			'garden',
+			'forest',
+			'aqua',
+			'lofi',
+			'pastel',
+			'fantasy',
+			'wireframe',
+			'black',
+			'luxury',
+			'dracula',
+			'cmyk',
+			'autumn',
+			'business',
+			'acid',
+			'lemonade',
+			'night',
+			'coffee',
+			'winter',
+			'dim',
+			'nord',
+			'sunset'
+		]
+	}
+} satisfies Config;
+
+```


### PR DESCRIPTION
hey, i love shadcn, it was the first library I used when learning svelte, I kinda moved away from it because I love just having the utility classes daisyui provides without importing anything, but I still kinda missed some of the components from shadcn, so i took some time and integrated both of than, just wrote some documentation to help the next person that is trying to do the same

also have an exemple of how it looks with the music exemple and a theme changer on the top right

https://shad-daisy.vercel.app/
https://github.com/andre-brandao/shad-daisy