### PR TITLE
fix(next): Fix `<Table.Footer>` foreground color

### DIFF
--- a/sites/docs/src/lib/registry/default/example/table-demo.svelte
+++ b/sites/docs/src/lib/registry/default/example/table-demo.svelte
@@ -67,4 +67,10 @@
 			</Table.Row>
 		{/each}
 	</Table.Body>
+	<Table.Footer>
+		<Table.Row>
+			<Table.Cell colspan={3}>Total</Table.Cell>
+			<Table.Cell class="text-right">$2,500.00</Table.Cell>
+		</Table.Row>
+	</Table.Footer>
 </Table.Root>

--- a/sites/docs/src/lib/registry/default/ui/table/table-footer.svelte
+++ b/sites/docs/src/lib/registry/default/ui/table/table-footer.svelte
@@ -13,7 +13,7 @@
 
 <tfoot
 	bind:this={ref}
-	class={cn("bg-muted/50 text-primary-foreground font-medium", className)}
+	class={cn("bg-muted/50 font-medium", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/sites/docs/src/lib/registry/default/ui/table/table-footer.svelte
+++ b/sites/docs/src/lib/registry/default/ui/table/table-footer.svelte
@@ -11,10 +11,6 @@
 	}: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();
 </script>
 
-<tfoot
-	bind:this={ref}
-	class={cn("bg-muted/50 font-medium", className)}
-	{...restProps}
->
+<tfoot bind:this={ref} class={cn("bg-muted/50 font-medium", className)} {...restProps}>
 	{@render children?.()}
 </tfoot>

--- a/sites/docs/src/lib/registry/new-york/example/table-demo.svelte
+++ b/sites/docs/src/lib/registry/new-york/example/table-demo.svelte
@@ -67,4 +67,10 @@
 			</Table.Row>
 		{/each}
 	</Table.Body>
+	<Table.Footer>
+		<Table.Row>
+			<Table.Cell colspan={3}>Total</Table.Cell>
+			<Table.Cell class="text-right">$2,500.00</Table.Cell>
+		</Table.Row>
+	</Table.Footer>
 </Table.Root>

--- a/sites/docs/src/lib/registry/new-york/ui/table/table-footer.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/table/table-footer.svelte
@@ -13,7 +13,7 @@
 
 <tfoot
 	bind:this={ref}
-	class={cn("bg-muted/50 text-primary-foreground font-medium", className)}
+	class={cn("bg-muted/50 font-medium", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/sites/docs/src/lib/registry/new-york/ui/table/table-footer.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/table/table-footer.svelte
@@ -11,10 +11,6 @@
 	}: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();
 </script>
 
-<tfoot
-	bind:this={ref}
-	class={cn("bg-muted/50 font-medium", className)}
-	{...restProps}
->
+<tfoot bind:this={ref} class={cn("bg-muted/50 font-medium", className)} {...restProps}>
 	{@render children?.()}
 </tfoot>


### PR DESCRIPTION
Fixes #1440 

- Also syncs the table example with the [shadcn-ui](https://ui.shadcn.com/docs/components/table) table example that way we can notice this more easily.
