### PR TITLE
next(breaking): update bits & adjust checkbox `indeterminate`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 9.12.0
       '@huntabyte/eslint-config':
         specifier: ^0.3.2
-        version: 0.3.2(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.0.4))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.0.4))(svelte@5.0.4)(typescript@5.6.3)(vitest@2.1.3(@types/node@20.16.14)(terser@5.36.0))
+        version: 0.3.2(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.0.4))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.0.4))(svelte@5.0.4)(typescript@5.6.3)(vitest@2.1.3)
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.10.0
         version: 8.10.0(@typescript-eslint/parser@8.10.0(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3)
@@ -172,8 +172,8 @@ importers:
         specifier: ^10.4.19
         version: 10.4.20(postcss@8.4.47)
       bits-ui:
-        specifier: 1.0.0-next.46
-        version: 1.0.0-next.46(svelte@5.0.4)
+        specifier: 1.0.0-next.49
+        version: 1.0.0-next.49(svelte@5.0.4)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -2299,8 +2299,8 @@ packages:
     peerDependencies:
       svelte: ^5.0.0-next.1
 
-  bits-ui@1.0.0-next.46:
-    resolution: {integrity: sha512-ATEyY4z3amOA5C3E7GsiV5H5kPpaNldrclDfDI0iUY6NfNJwNEv44crYlLNEyU8rBkSOGpQfonpwMp/mhtYoDQ==}
+  bits-ui@1.0.0-next.49:
+    resolution: {integrity: sha512-7EoNj7pu9+RVv6MM1kGVvDzH2aA38v07Q+BDSq8yiLIHxZ5dTkDHwoikhtT/+jMU25c0uYvHq44GEQX+027IFw==}
     engines: {node: '>=18', pnpm: '>=8.7.0'}
     peerDependencies:
       svelte: ^5.0.0-next.1
@@ -6035,7 +6035,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@antfu/eslint-config@2.22.0(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.0.4))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.0.4))(svelte@5.0.4)(typescript@5.6.3)(vitest@2.1.3(@types/node@20.16.14)(terser@5.36.0))':
+  '@antfu/eslint-config@2.22.0(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.0.4))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.0.4))(svelte@5.0.4)(typescript@5.6.3)(vitest@2.1.3)':
     dependencies:
       '@antfu/install-pkg': 0.3.3
       '@clack/prompts': 0.7.0
@@ -6060,7 +6060,7 @@ snapshots:
       eslint-plugin-toml: 0.11.1(eslint@9.7.0)
       eslint-plugin-unicorn: 54.0.0(eslint@9.7.0)
       eslint-plugin-unused-imports: 4.0.0(@typescript-eslint/eslint-plugin@8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)
-      eslint-plugin-vitest: 0.5.4(@typescript-eslint/eslint-plugin@8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3)(vitest@2.1.3(@types/node@20.16.14)(terser@5.36.0))
+      eslint-plugin-vitest: 0.5.4(@typescript-eslint/eslint-plugin@8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3)(vitest@2.1.3)
       eslint-plugin-vue: 9.27.0(eslint@9.7.0)
       eslint-plugin-yml: 1.14.0(eslint@9.7.0)
       eslint-processor-vue-blocks: 0.1.2(@vue/compiler-sfc@3.5.12)(eslint@9.7.0)
@@ -6747,9 +6747,9 @@ snapshots:
 
   '@humanwhocodes/retry@0.3.0': {}
 
-  '@huntabyte/eslint-config@0.3.2(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.0.4))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.0.4))(svelte@5.0.4)(typescript@5.6.3)(vitest@2.1.3(@types/node@20.16.14)(terser@5.36.0))':
+  '@huntabyte/eslint-config@0.3.2(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.0.4))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.0.4))(svelte@5.0.4)(typescript@5.6.3)(vitest@2.1.3)':
     dependencies:
-      '@antfu/eslint-config': 2.22.0(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.0.4))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.0.4))(svelte@5.0.4)(typescript@5.6.3)(vitest@2.1.3(@types/node@20.16.14)(terser@5.36.0))
+      '@antfu/eslint-config': 2.22.0(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.0.4))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.0.4))(svelte@5.0.4)(typescript@5.6.3)(vitest@2.1.3)
       '@antfu/install-pkg': 0.3.3
       '@clack/prompts': 0.7.0
       '@huntabyte/eslint-plugin': 0.1.0(eslint@9.7.0)
@@ -7807,7 +7807,7 @@ snapshots:
       chai: 5.1.1
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))':
+  '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(vite@5.4.9)':
     dependencies:
       '@vitest/spy': 2.1.3
       estree-walker: 3.0.3
@@ -8076,7 +8076,7 @@ snapshots:
       svelte: 5.0.4
       svelte-toolbelt: 0.4.4(svelte@5.0.4)
 
-  bits-ui@1.0.0-next.46(svelte@5.0.4):
+  bits-ui@1.0.0-next.49(svelte@5.0.4):
     dependencies:
       '@floating-ui/core': 1.6.4
       '@floating-ui/dom': 1.6.7
@@ -9103,7 +9103,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3)
 
-  eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3)(vitest@2.1.3(@types/node@20.16.14)(terser@5.36.0)):
+  eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3)(vitest@2.1.3):
     dependencies:
       '@typescript-eslint/utils': 7.16.0(eslint@9.7.0)(typescript@5.6.3)
       eslint: 9.7.0
@@ -12332,7 +12332,7 @@ snapshots:
   vitest@2.1.3(@types/node@20.16.14)(terser@5.36.0):
     dependencies:
       '@vitest/expect': 2.1.3
-      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
+      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(vite@5.4.9)
       '@vitest/pretty-format': 2.1.3
       '@vitest/runner': 2.1.3
       '@vitest/snapshot': 2.1.3

--- a/sites/docs/package.json
+++ b/sites/docs/package.json
@@ -43,7 +43,7 @@
 		"acorn": "^8.13.0",
 		"acorn-typescript": "^1.4.13",
 		"autoprefixer": "^10.4.19",
-		"bits-ui": "1.0.0-next.46",
+		"bits-ui": "1.0.0-next.49",
 		"clsx": "^2.1.1",
 		"concurrently": "^9.0.1",
 		"d3-scale": "^4.0.2",

--- a/sites/docs/src/content/components/data-table.md
+++ b/sites/docs/src/content/components/data-table.md
@@ -856,9 +856,10 @@ export const columns: ColumnDef<Payment>[] = [
     id: "select",
     header: ({ table }) =>
       renderComponent(Checkbox, {
-        checked:
-          table.getIsAllPageRowsSelected() ||
-          (table.getIsSomePageRowsSelected() && "indeterminate"),
+        checked: table.getIsAllPageRowsSelected(),
+        indeterminate:
+          table.getIsSomePageRowsSelected() &&
+          !table.getIsAllPageRowsSelected(),
         onCheckedChange: (value) => table.toggleAllPageRowsSelected(!!value),
         controlledChecked: true,
         "aria-label": "Select all",

--- a/sites/docs/src/lib/registry/default/example/cards/data-table.svelte
+++ b/sites/docs/src/lib/registry/default/example/cards/data-table.svelte
@@ -72,9 +72,9 @@
 			id: "select",
 			header: ({ table }) =>
 				renderComponent(DataTableCheckbox, {
-					checked:
-						table.getIsAllPageRowsSelected() ||
-						(table.getIsSomePageRowsSelected() && "indeterminate"),
+					checked: table.getIsAllPageRowsSelected(),
+					indeterminate:
+						table.getIsSomePageRowsSelected() && !table.getIsAllPageRowsSelected(),
 					onCheckedChange: (value) => table.toggleAllPageRowsSelected(!!value),
 					"aria-label": "Select all",
 				}),

--- a/sites/docs/src/lib/registry/default/example/data-table-demo.svelte
+++ b/sites/docs/src/lib/registry/default/example/data-table-demo.svelte
@@ -72,9 +72,9 @@
 			id: "select",
 			header: ({ table }) =>
 				renderComponent(DataTableCheckbox, {
-					checked:
-						table.getIsAllPageRowsSelected() ||
-						(table.getIsSomePageRowsSelected() && "indeterminate"),
+					checked: table.getIsAllPageRowsSelected(),
+					indeterminate:
+						table.getIsSomePageRowsSelected() && !table.getIsAllPageRowsSelected(),
 					onCheckedChange: (value) => table.toggleAllPageRowsSelected(!!value),
 					"aria-label": "Select all",
 				}),

--- a/sites/docs/src/lib/registry/default/ui/checkbox/checkbox.svelte
+++ b/sites/docs/src/lib/registry/default/ui/checkbox/checkbox.svelte
@@ -7,6 +7,7 @@
 	let {
 		ref = $bindable(null),
 		checked = $bindable(false),
+		indeterminate = $bindable(false),
 		class: className,
 		...restProps
 	}: WithoutChildrenOrChild<CheckboxPrimitive.RootProps> = $props();
@@ -19,11 +20,12 @@
 		className
 	)}
 	bind:checked
+	bind:indeterminate
 	{...restProps}
 >
-	{#snippet children({ checked })}
+	{#snippet children({ checked, indeterminate })}
 		<div class="flex size-4 items-center justify-center text-current">
-			{#if checked === "indeterminate"}
+			{#if indeterminate}
 				<Minus class="size-3.5" />
 			{:else}
 				<Check class={cn("size-3.5", !checked && "text-transparent")} />

--- a/sites/docs/src/lib/registry/default/ui/context-menu/context-menu-checkbox-item.svelte
+++ b/sites/docs/src/lib/registry/default/ui/context-menu/context-menu-checkbox-item.svelte
@@ -1,35 +1,40 @@
 <script lang="ts">
-	import { ContextMenu as ContextMenuPrimitive, type WithoutChild } from "bits-ui";
+	import { ContextMenu as ContextMenuPrimitive, type WithoutChildrenOrChild } from "bits-ui";
 	import Check from "lucide-svelte/icons/check";
 	import Minus from "lucide-svelte/icons/minus";
 	import { cn } from "$lib/utils.js";
+	import type { Snippet } from "svelte";
 
 	let {
 		ref = $bindable(null),
 		checked = $bindable(false),
+		indeterminate = $bindable(false),
 		class: className,
 		children: childrenProp,
 		...restProps
-	}: WithoutChild<ContextMenuPrimitive.CheckboxItemProps> = $props();
+	}: WithoutChildrenOrChild<ContextMenuPrimitive.CheckboxItemProps> & {
+		children?: Snippet;
+	} = $props();
 </script>
 
 <ContextMenuPrimitive.CheckboxItem
 	bind:ref
 	bind:checked
+	bind:indeterminate
 	class={cn(
 		"data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
 		className
 	)}
 	{...restProps}
 >
-	{#snippet children({ checked })}
+	{#snippet children({ checked, indeterminate })}
 		<span class="absolute left-2 flex size-3.5 items-center justify-center">
-			{#if checked === "indeterminate"}
+			{#if indeterminate}
 				<Minus class="size-3.5" />
 			{:else}
 				<Check class={cn("size-3.5", !checked && "text-transparent")} />
 			{/if}
 		</span>
-		{@render childrenProp?.({ checked })}
+		{@render childrenProp?.()}
 	{/snippet}
 </ContextMenuPrimitive.CheckboxItem>

--- a/sites/docs/src/lib/registry/default/ui/dropdown-menu/dropdown-menu-checkbox-item.svelte
+++ b/sites/docs/src/lib/registry/default/ui/dropdown-menu/dropdown-menu-checkbox-item.svelte
@@ -1,35 +1,40 @@
 <script lang="ts">
-	import { DropdownMenu as DropdownMenuPrimitive, type WithoutChild } from "bits-ui";
+	import { DropdownMenu as DropdownMenuPrimitive, type WithoutChildrenOrChild } from "bits-ui";
 	import Check from "lucide-svelte/icons/check";
 	import Minus from "lucide-svelte/icons/minus";
 	import { cn } from "$lib/utils.js";
+	import type { Snippet } from "svelte";
 
 	let {
 		ref = $bindable(null),
 		checked = $bindable(false),
+		indeterminate = $bindable(false),
 		class: className,
 		children: childrenProp,
 		...restProps
-	}: WithoutChild<DropdownMenuPrimitive.CheckboxItemProps> = $props();
+	}: WithoutChildrenOrChild<DropdownMenuPrimitive.CheckboxItemProps> & {
+		children?: Snippet;
+	} = $props();
 </script>
 
 <DropdownMenuPrimitive.CheckboxItem
 	bind:ref
 	bind:checked
+	bind:indeterminate
 	class={cn(
 		"data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
 		className
 	)}
 	{...restProps}
 >
-	{#snippet children({ checked })}
+	{#snippet children({ checked, indeterminate })}
 		<span class="absolute left-2 flex size-3.5 items-center justify-center">
-			{#if checked === "indeterminate"}
+			{#if indeterminate}
 				<Minus class="size-4" />
 			{:else}
 				<Check class={cn("size-4", !checked && "text-transparent")} />
 			{/if}
 		</span>
-		{@render childrenProp?.({ checked })}
+		{@render childrenProp?.()}
 	{/snippet}
 </DropdownMenuPrimitive.CheckboxItem>

--- a/sites/docs/src/lib/registry/default/ui/menubar/menubar-checkbox-item.svelte
+++ b/sites/docs/src/lib/registry/default/ui/menubar/menubar-checkbox-item.svelte
@@ -1,35 +1,40 @@
 <script lang="ts">
-	import { Menubar as MenubarPrimitive, type WithoutChild } from "bits-ui";
+	import { Menubar as MenubarPrimitive, type WithoutChildrenOrChild } from "bits-ui";
 	import Check from "lucide-svelte/icons/check";
 	import Minus from "lucide-svelte/icons/minus";
 	import { cn } from "$lib/utils.js";
+	import type { Snippet } from "svelte";
 
 	let {
 		ref = $bindable(null),
 		class: className,
 		checked = $bindable(false),
+		indeterminate = $bindable(false),
 		children: childrenProp,
 		...restProps
-	}: WithoutChild<MenubarPrimitive.CheckboxItemProps> = $props();
+	}: WithoutChildrenOrChild<MenubarPrimitive.CheckboxItemProps> & {
+		children?: Snippet;
+	} = $props();
 </script>
 
 <MenubarPrimitive.CheckboxItem
 	bind:ref
 	bind:checked
+	bind:indeterminate
 	class={cn(
 		"data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
 		className
 	)}
 	{...restProps}
 >
-	{#snippet children({ checked })}
+	{#snippet children({ checked, indeterminate })}
 		<span class="absolute left-2 flex size-3.5 items-center justify-center">
-			{#if checked === "indeterminate"}
+			{#if indeterminate}
 				<Minus class="size-4" />
 			{:else}
 				<Check class={cn("size-4", !checked && "text-transparent")} />
 			{/if}
 		</span>
-		{@render childrenProp?.({ checked })}
+		{@render childrenProp?.()}
 	{/snippet}
 </MenubarPrimitive.CheckboxItem>

--- a/sites/docs/src/lib/registry/new-york/example/cards/data-table.svelte
+++ b/sites/docs/src/lib/registry/new-york/example/cards/data-table.svelte
@@ -72,9 +72,9 @@
 			id: "select",
 			header: ({ table }) =>
 				renderComponent(DataTableCheckbox, {
-					checked:
-						table.getIsAllPageRowsSelected() ||
-						(table.getIsSomePageRowsSelected() && "indeterminate"),
+					checked: table.getIsAllPageRowsSelected(),
+					indeterminate:
+						table.getIsSomePageRowsSelected() && !table.getIsAllPageRowsSelected(),
 					onCheckedChange: (value) => table.toggleAllPageRowsSelected(!!value),
 					"aria-label": "Select all",
 				}),

--- a/sites/docs/src/lib/registry/new-york/example/data-table-demo.svelte
+++ b/sites/docs/src/lib/registry/new-york/example/data-table-demo.svelte
@@ -72,9 +72,9 @@
 			id: "select",
 			header: ({ table }) =>
 				renderComponent(DataTableCheckbox, {
-					checked:
-						table.getIsAllPageRowsSelected() ||
-						(table.getIsSomePageRowsSelected() && "indeterminate"),
+					checked: table.getIsAllPageRowsSelected(),
+					indeterminate:
+						table.getIsSomePageRowsSelected() && !table.getIsAllPageRowsSelected(),
 					onCheckedChange: (value) => table.toggleAllPageRowsSelected(!!value),
 					"aria-label": "Select all",
 				}),

--- a/sites/docs/src/lib/registry/new-york/ui/checkbox/checkbox.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/checkbox/checkbox.svelte
@@ -8,6 +8,7 @@
 		ref = $bindable(null),
 		class: className,
 		checked = $bindable(false),
+		indeterminate = $bindable(false),
 		...restProps
 	}: WithoutChildrenOrChild<CheckboxPrimitive.RootProps> = $props();
 </script>
@@ -19,11 +20,12 @@
 	)}
 	bind:checked
 	bind:ref
+	bind:indeterminate
 	{...restProps}
 >
-	{#snippet children({ checked })}
+	{#snippet children({ checked, indeterminate })}
 		<span class="flex size-4 items-center justify-center text-current">
-			{#if checked === "indeterminate"}
+			{#if indeterminate}
 				<Minus class="size-3.5" />
 			{:else}
 				<Check class={cn("size-3.5", !checked && "text-transparent")} />

--- a/sites/docs/src/lib/registry/new-york/ui/context-menu/context-menu-checkbox-item.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/context-menu/context-menu-checkbox-item.svelte
@@ -8,8 +8,9 @@
 	let {
 		ref = $bindable(null),
 		class: className,
-		checked = $bindable(),
-		children,
+		checked = $bindable(false),
+		indeterminate = $bindable(false),
+		children: childrenProp,
 		...restProps
 	}: WithoutChildrenOrChild<ContextMenuPrimitive.CheckboxItemProps> & {
 		children?: Snippet;
@@ -17,20 +18,23 @@
 </script>
 
 <ContextMenuPrimitive.CheckboxItem
-	bind:checked
 	bind:ref
+	bind:checked
+	bind:indeterminate
 	class={cn(
 		"data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
 		className
 	)}
 	{...restProps}
 >
-	<span class="absolute left-2 flex size-3.5 items-center justify-center">
-		{#if checked === "indeterminate"}
-			<Minus class="size-4" />
-		{:else}
-			<Check class={cn("size-4", !checked && "text-transparent")} />
-		{/if}
-	</span>
-	{@render children?.()}
+	{#snippet children({ checked, indeterminate })}
+		<span class="absolute left-2 flex size-3.5 items-center justify-center">
+			{#if indeterminate}
+				<Minus class="size-4" />
+			{:else}
+				<Check class={cn("size-4", !checked && "text-transparent")} />
+			{/if}
+		</span>
+		{@render childrenProp?.()}
+	{/snippet}
 </ContextMenuPrimitive.CheckboxItem>

--- a/sites/docs/src/lib/registry/new-york/ui/dropdown-menu/dropdown-menu-checkbox-item.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/dropdown-menu/dropdown-menu-checkbox-item.svelte
@@ -1,37 +1,40 @@
 <script lang="ts">
-	import { DropdownMenu as DropdownMenuPrimitive, type WithoutChild } from "bits-ui";
+	import { DropdownMenu as DropdownMenuPrimitive, type WithoutChildrenOrChild } from "bits-ui";
 	import Check from "svelte-radix/Check.svelte";
 	import Minus from "svelte-radix/Minus.svelte";
 	import { cn } from "$lib/utils.js";
+	import type { Snippet } from "svelte";
 
 	let {
 		ref = $bindable(null),
 		class: className,
 		children: childrenProp,
 		checked = $bindable(false),
+		indeterminate = $bindable(false),
 		...restProps
-	}: WithoutChild<DropdownMenuPrimitive.CheckboxItemProps> = $props();
-
-	export { className as class };
+	}: WithoutChildrenOrChild<DropdownMenuPrimitive.CheckboxItemProps> & {
+		children?: Snippet;
+	} = $props();
 </script>
 
 <DropdownMenuPrimitive.CheckboxItem
 	bind:ref
 	bind:checked
+	bind:indeterminate
 	class={cn(
 		"data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
 		className
 	)}
 	{...restProps}
 >
-	{#snippet children({ checked })}
+	{#snippet children({ checked, indeterminate })}
 		<span class="absolute left-2 flex size-3.5 items-center justify-center">
-			{#if checked === "indeterminate"}
+			{#if indeterminate}
 				<Minus class="size-3.5" />
 			{:else}
 				<Check class={cn("size-3.5", !checked && "text-transparent")} />
 			{/if}
 		</span>
-		{@render childrenProp?.({ checked })}
+		{@render childrenProp?.()}
 	{/snippet}
 </DropdownMenuPrimitive.CheckboxItem>

--- a/sites/docs/src/lib/registry/new-york/ui/menubar/menubar-checkbox-item.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/menubar/menubar-checkbox-item.svelte
@@ -1,35 +1,40 @@
 <script lang="ts">
-	import { Menubar as MenubarPrimitive, type WithoutChild } from "bits-ui";
+	import { Menubar as MenubarPrimitive, type WithoutChildrenOrChild } from "bits-ui";
 	import Check from "svelte-radix/Check.svelte";
 	import Minus from "svelte-radix/Minus.svelte";
 	import { cn } from "$lib/utils.js";
+	import type { Snippet } from "svelte";
 
 	let {
 		ref = $bindable(null),
 		checked = $bindable(false),
+		indeterminate = $bindable(false),
 		class: className,
 		children: childrenProp,
 		...restProps
-	}: WithoutChild<MenubarPrimitive.CheckboxItemProps> = $props();
+	}: WithoutChildrenOrChild<MenubarPrimitive.CheckboxItemProps> & {
+		children?: Snippet;
+	} = $props();
 </script>
 
 <MenubarPrimitive.CheckboxItem
 	bind:ref
 	bind:checked
+	bind:indeterminate
 	class={cn(
 		"data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
 		className
 	)}
 	{...restProps}
 >
-	{#snippet children({ checked })}
+	{#snippet children({ checked, indeterminate })}
 		<span class="absolute left-2 flex size-3.5 items-center justify-center">
-			{#if checked === "indeterminate"}
+			{#if indeterminate}
 				<Minus class="size-4" />
 			{:else}
 				<Check class={cn("size-4", !checked && "text-transparent")} />
 			{/if}
 		</span>
-		{@render childrenProp?.({ checked })}
+		{@render childrenProp?.()}
 	{/snippet}
 </MenubarPrimitive.CheckboxItem>


### PR DESCRIPTION
Adjusts various `Checkbox` components to handle `indeterminate` state in the new way introduced by Bits UI (reference: https://github.com/huntabyte/bits-ui/pull/898)