### PR TITLE
fix: Pin svelte-radix version for Svelte 4 support

### DIFF
--- a/sites/docs/scripts/registry.ts
+++ b/sites/docs/scripts/registry.ts
@@ -14,7 +14,7 @@ const DEPENDENCIES = new Map<string, string[]>([
 	["embla-carousel-svelte", []],
 	["paneforge", []],
 ]);
-const ICON_DEPENDENCIES = ["lucide-svelte", "svelte-radix"];
+const ICON_DEPENDENCIES = ["lucide-svelte", "svelte-radix@1.1.1"];
 // these are required dependencies for particular components
 // where the dependencies are not specified in the import declarations of the component file
 const REQUIRED_COMPONENT_DEPS = new Map<string, string[]>([


### PR DESCRIPTION
Looks like [1.1.1](https://github.com/shinokada/svelte-radix/releases/tag/v1.1.1) is the latest version of radix for svelte 4.

P.S. I think the registry needs to be built but the build is broken on windows (I only have access to a windows machine rn) so you may need to build and commit.