### PR TITLE
fix(next): add newline to end of components.json

### DIFF
--- a/.changeset/young-wombats-prove.md
+++ b/.changeset/young-wombats-prove.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": patch
+---
+
+fix(next): add newline to end of `components.json`

--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -176,5 +176,5 @@ export async function getRawConfig(cwd: string): Promise<RawConfig | null> {
 export function writeConfig(cwd: string, config: any): void {
 	const targetPath = path.resolve(cwd, "components.json");
 	const conf = v.parse(rawConfigSchema, config); // inefficient, but it'll do
-	fs.writeFileSync(targetPath, JSON.stringify(conf, null, "\t"), "utf8");
+	fs.writeFileSync(targetPath, JSON.stringify(conf, null, "\t") + "\n", "utf8");
 }


### PR DESCRIPTION
All files generated from `templates.ts` end with a newline. `components.json` should, too.