### PR TITLE
feat (`next`):  Added `<ChevronRight />`'s render condition, based on `mainItem.items.length`

### DIFF
--- a/sites/docs/src/lib/registry/new-york/block/sidebar-07/components/nav-main.svelte
+++ b/sites/docs/src/lib/registry/new-york/block/sidebar-07/components/nav-main.svelte
@@ -38,9 +38,11 @@
 										<mainItem.icon />
 									{/if}
 									<span>{mainItem.title}</span>
-									<ChevronRight
-										class="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90"
-									/>
+									{#if mainItem.items && mainItem.items.length > 1}
+										<ChevronRight
+											class="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90"
+										/>
+									{/if}
 								</Sidebar.MenuButton>
 							{/snippet}
 						</Collapsible.Trigger>

--- a/sites/docs/src/lib/registry/new-york/block/sidebar-08/components/nav-main.svelte
+++ b/sites/docs/src/lib/registry/new-york/block/sidebar-08/components/nav-main.svelte
@@ -46,7 +46,9 @@
 										{...props}
 										class="data-[state=open]:rotate-90"
 									>
-										<ChevronRight />
+										{#if mainItem.items && mainItem.items.length > 1}
+											<ChevronRight />
+										{/if}
 										<span class="sr-only">Toggle</span>
 									</Sidebar.MenuAction>
 								{/snippet}


### PR DESCRIPTION
### Modified:

File: `nav-main.svelte`
> 
> ↳ (sites/docs/src/lib/registry/new-york/block/sidebar-07/components/nav-main.svelte)
>
 - Added `<ChevronRight />`'s render condition, based on `mainItem.items.length`


File: `nav-main.svelte`
> 
> ↳ (sites/docs/src/lib/registry/new-york/block/sidebar-08/components/nav-main.svelte)
> 
 - Added `<ChevronRight />`'s render condition, based on `mainItem.items.length`

___

### Explanation:

[`app-sidebar.svelte`]
> ↳ (sites/docs/src/lib/registry/new-york/block/sidebar-07/components/app-sidebar.svelte)
```ts
// This is sample data.
const data = {
  user: {
    name: 'shadcn',
    email: 'm@example.com',
    avatar: '/avatars/shadcn.jpg'
  },
  teams: [
    { name: 'Acme Inc', logo: GalleryVerticalEnd, plan: 'Enterprise' },
    { name: 'Acme Corp.', logo: AudioWaveform, plan: 'Startup' },
    { name: 'Evil Corp.', logo: Command, plan: 'Free' }
  ],
  navMain: [
    {
      title: 'Playground',
      url: '#',
      icon: SquareTerminal,
      isActive: true,
      items: [
        { title: 'History', url: '#' },
	{ title: 'Starred', url: '#' },
	{ title: 'Settings', url: '#' }
      ]
    },
    {
      title: 'Models',
      url: '#',
      icon: Bot,
      items: [
        { title: 'Genesis', url: '#' },
        { title: 'Explorer', url: '#' },
        { title: 'Quantum', url: '#' }
      ]
    },
    {
      title: 'Documentation',
      url: '#',
      icon: BookOpen,
      items: [
        { title: 'Introduction', url: '#' },
        { title: 'Get Started', url: '#' },
        { title: 'Tutorials', url: '#' },
        { title: 'Changelog', url: '#' }
      ]
    },
    {
      title: 'Settings',
      url: '#',
      icon: Settings2,
      items: [
        { title: 'General', url: '#' },
        { title: 'Team', url: '#' },
        { title: 'Billing', url: '#' },
        { title: 'Limits', url: '#' }
      ]
    }
    ],
  projects: [
    { name: 'Design Engineering', url: '#', icon: Frame },
    { name: 'Sales & Marketing', url: '#', icon: ChartPie },
    { name: 'Travel', url: '#', icon: Map }
  ]
};
```

Referring to the `app-sidebar.svelte` above, the current`<ChevronRight />` in the `nav-main.svelte` is being functional as expected.

___

However, for the case where there is no `items: [...]`:

```ts
{
  title: 'Playground',
  url: '#',
  icon: SquareTerminal,
  isActive: true,
},
```

The current `<ChevronRight />` in the `nav-main.svelte` will always be rendered and clickable, regardless of the data existence of the item:

```svelte
<Sidebar.MenuButton {...props}>
  {#snippet tooltipContent()}
    {mainItem.title}
  {/snippet}
    {#if mainItem.icon}
      <mainItem.icon />
    {/if}
  <span>{mainItem.title}</span>
  <ChevronRight
    class="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90"
  />
</Sidebar.MenuButton>
```

> ↑ Current version
___

This change is to encapsulate `<ChevronRight />` in the condition to check whether to render `<ChevronRight />`, based on the existence and the amount of item more than 1 from `mainItem.items`:

```svelte
<Sidebar.MenuButton {...props}>
  {#snippet tooltipContent()}
    {mainItem.title}
  {/snippet}
    {#if mainItem.icon}
      <mainItem.icon />
    {/if}
  <span>{mainItem.title}</span>
  {#if mainItem.items && mainItem.items.length > 1}
    <ChevronRight
      class="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90"
    />
  {/if}
</Sidebar.MenuButton>
```

> ↑ Updated version
