### PR TITLE
fix(next): resolve command for sveltekit sync as `execute-local`

### DIFF
--- a/.changeset/ten-spiders-do.md
+++ b/.changeset/ten-spiders-do.md
@@ -2,4 +2,4 @@
 "shadcn-svelte": patch
 ---
 
-ensure sync executes local binary
+fix: Ensure `svelte-kit sync` executes locally

--- a/.changeset/ten-spiders-do.md
+++ b/.changeset/ten-spiders-do.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": patch
+---
+
+ensure sync executes local binary

--- a/packages/cli/src/utils/sveltekit.ts
+++ b/packages/cli/src/utils/sveltekit.ts
@@ -15,7 +15,7 @@ export async function syncSvelteKit(cwd: string) {
 
 		agent ??= { agent: "npm", name: "npm" };
 
-		const cmd = resolveCommand(agent.agent, "execute", ["svelte-kit", "sync"]);
+		const cmd = resolveCommand(agent.agent, "execute-local", ["svelte-kit", "sync"]);
 		if (cmd) {
 			await execa(cmd.command, cmd.args, {
 				cwd,


### PR DESCRIPTION
Fixes #1486. 

Sorry about the misunderstanding I skipped like 2 words reading the issue and totally threw me off.
