### PR TITLE
docs(next): Add `run dev server once` to SvelteKit installation instruction

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 9.12.0
       '@huntabyte/eslint-config':
         specifier: ^0.3.2
-        version: 0.3.2(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.0.4))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.0.4))(svelte@5.0.4)(typescript@5.6.3)(vitest@2.1.3)
+        version: 0.3.2(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.0.4))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.0.4))(svelte@5.0.4)(typescript@5.6.3)(vitest@2.1.3(@types/node@20.16.14)(terser@5.36.0))
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.10.0
         version: 8.10.0(@typescript-eslint/parser@8.10.0(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3)
@@ -216,6 +216,9 @@ importers:
       mode-watcher:
         specifier: ^0.3.1
         version: 0.3.1(svelte@5.0.4)
+      package-manager-detector:
+        specifier: ^0.2.2
+        version: 0.2.2
       paneforge:
         specifier: 1.0.0-next.1
         version: 1.0.0-next.1(svelte@5.0.4)
@@ -6020,7 +6023,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@antfu/eslint-config@2.22.0(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.0.4))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.0.4))(svelte@5.0.4)(typescript@5.6.3)(vitest@2.1.3)':
+  '@antfu/eslint-config@2.22.0(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.0.4))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.0.4))(svelte@5.0.4)(typescript@5.6.3)(vitest@2.1.3(@types/node@20.16.14)(terser@5.36.0))':
     dependencies:
       '@antfu/install-pkg': 0.3.3
       '@clack/prompts': 0.7.0
@@ -6045,7 +6048,7 @@ snapshots:
       eslint-plugin-toml: 0.11.1(eslint@9.7.0)
       eslint-plugin-unicorn: 54.0.0(eslint@9.7.0)
       eslint-plugin-unused-imports: 4.0.0(@typescript-eslint/eslint-plugin@8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)
-      eslint-plugin-vitest: 0.5.4(@typescript-eslint/eslint-plugin@8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3)(vitest@2.1.3)
+      eslint-plugin-vitest: 0.5.4(@typescript-eslint/eslint-plugin@8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3)(vitest@2.1.3(@types/node@20.16.14)(terser@5.36.0))
       eslint-plugin-vue: 9.27.0(eslint@9.7.0)
       eslint-plugin-yml: 1.14.0(eslint@9.7.0)
       eslint-processor-vue-blocks: 0.1.2(@vue/compiler-sfc@3.5.12)(eslint@9.7.0)
@@ -6732,9 +6735,9 @@ snapshots:
 
   '@humanwhocodes/retry@0.3.0': {}
 
-  '@huntabyte/eslint-config@0.3.2(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.0.4))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.0.4))(svelte@5.0.4)(typescript@5.6.3)(vitest@2.1.3)':
+  '@huntabyte/eslint-config@0.3.2(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.0.4))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.0.4))(svelte@5.0.4)(typescript@5.6.3)(vitest@2.1.3(@types/node@20.16.14)(terser@5.36.0))':
     dependencies:
-      '@antfu/eslint-config': 2.22.0(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.0.4))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.0.4))(svelte@5.0.4)(typescript@5.6.3)(vitest@2.1.3)
+      '@antfu/eslint-config': 2.22.0(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.0.4))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.0.4))(svelte@5.0.4)(typescript@5.6.3)(vitest@2.1.3(@types/node@20.16.14)(terser@5.36.0))
       '@antfu/install-pkg': 0.3.3
       '@clack/prompts': 0.7.0
       '@huntabyte/eslint-plugin': 0.1.0(eslint@9.7.0)
@@ -7792,7 +7795,7 @@ snapshots:
       chai: 5.1.1
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(vite@5.4.9)':
+  '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))':
     dependencies:
       '@vitest/spy': 2.1.3
       estree-walker: 3.0.3
@@ -9078,7 +9081,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3)
 
-  eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3)(vitest@2.1.3):
+  eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3)(vitest@2.1.3(@types/node@20.16.14)(terser@5.36.0)):
     dependencies:
       '@typescript-eslint/utils': 7.16.0(eslint@9.7.0)(typescript@5.6.3)
       eslint: 9.7.0
@@ -12303,7 +12306,7 @@ snapshots:
   vitest@2.1.3(@types/node@20.16.14)(terser@5.36.0):
     dependencies:
       '@vitest/expect': 2.1.3
-      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(vite@5.4.9)
+      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
       '@vitest/pretty-format': 2.1.3
       '@vitest/runner': 2.1.3
       '@vitest/snapshot': 2.1.3

--- a/sites/docs/package.json
+++ b/sites/docs/package.json
@@ -58,6 +58,7 @@
 		"magic-string": "^0.30.12",
 		"mdsx": "^0.0.6",
 		"mode-watcher": "^0.3.1",
+		"package-manager-detector": "^0.2.2",
 		"paneforge": "1.0.0-next.1",
 		"postcss": "^8.4.39",
 		"postcss-load-config": "^6.0.1",

--- a/sites/docs/src/content/installation/sveltekit.md
+++ b/sites/docs/src/content/installation/sveltekit.md
@@ -44,6 +44,12 @@ const config = {
 };
 ```
 
+If you setup a custom path alias you will need to run the dev server at least once to fix your `tsconfig.json` / `jsconfig.json`.
+
+```bash
+npx
+```
+
 ### Run the CLI
 
 <PMExecute command="shadcn-svelte@next init" />

--- a/sites/docs/src/content/installation/sveltekit.md
+++ b/sites/docs/src/content/installation/sveltekit.md
@@ -5,7 +5,7 @@ description: How to setup shadcn-svelte in a SvelteKit project.
 
 <script>
   import { Alert, AlertDescription } from "$lib/registry/new-york/ui/alert";
-  import { Steps, PMCreate, PMExecute, PMInstall, PMAddComp } from "$lib/components/docs";
+  import { Steps, PMCreate, PMExecute, PMInstall, PMAddComp, PMRun } from "$lib/components/docs";
 </script>
 
 ## Setup your project
@@ -46,9 +46,7 @@ const config = {
 
 If you setup a custom path alias you will need to run the dev server at least once to fix your `tsconfig.json` / `jsconfig.json`.
 
-```bash
-npx
-```
+<PMRun command="dev"/>
 
 ### Run the CLI
 

--- a/sites/docs/src/lib/components/docs/block-toolbar.svelte
+++ b/sites/docs/src/lib/components/docs/block-toolbar.svelte
@@ -5,25 +5,22 @@
 	import Smartphone from "lucide-svelte/icons/smartphone";
 	import Tablet from "lucide-svelte/icons/tablet";
 	import Terminal from "lucide-svelte/icons/terminal";
-	import { getPackageManagerScriptCmd } from "$lib/utils.js";
 	import { Button } from "$lib/registry/new-york/ui/button/index.js";
 	import { Separator } from "$lib/registry/new-york/ui/separator/index.js";
 	import * as ToggleGroup from "$lib/registry/new-york/ui/toggle-group/index.js";
 	import type { Block } from "$lib/registry/schema.js";
 	import type { ResizablePane } from "$lib/registry/new-york/ui/resizable/index.js";
 	import { CopyToClipboard } from "$lib/utils/copy-to-clipboard.svelte.js";
-	import { getPackageManager } from "$lib/stores/package-manager.js";
+	import { getCommand, getPackageManager } from "$lib/stores/package-manager.js";
 
 	let { block, resizablePaneRef }: { block: Block; resizablePaneRef: ResizablePane } = $props();
 
 	const copier = new CopyToClipboard();
 	const selectedPackageManager = getPackageManager();
 
-	const addCommand = $derived.by(() => {
-		const start = getPackageManagerScriptCmd($selectedPackageManager);
-		const end = `shadcn-svelte@next add ${block.name}`;
-		return start + " " + end;
-	});
+	const addCommand = $derived(
+		getCommand($selectedPackageManager, "execute", `shadcn-svelte@next add ${block.name}`)
+	);
 
 	const blockSource = $derived(
 		`https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/new-york/block/${block.name}`
@@ -40,7 +37,7 @@
 			class="bg-muted h-7 rounded-md border shadow-none"
 			size="sm"
 			onclick={() => {
-				copier.copyToClipboard(addCommand);
+				copier.copyToClipboard(addCommand.command + " " + addCommand.args.join(" "));
 			}}
 		>
 			{#if copier.isCopied}

--- a/sites/docs/src/lib/components/docs/copy-button.svelte
+++ b/sites/docs/src/lib/components/docs/copy-button.svelte
@@ -4,7 +4,8 @@
 	import ChevronsUpDown from "lucide-svelte/icons/chevrons-up-down";
 	import { tick } from "svelte";
 	import { cn } from "$lib/utils.js";
-	import { getPackageManager, packageManagers } from "$lib/stores/package-manager.js";
+	import { getPackageManager } from "$lib/stores/package-manager.js";
+	import { AGENTS } from "package-manager-detector";
 	import { Button, type ButtonProps } from "$lib/registry/new-york/ui/button/index.js";
 	import * as DropdownMenu from "$lib/registry/new-york/ui/dropdown-menu/index.js";
 
@@ -51,7 +52,7 @@
 		</DropdownMenu.Trigger>
 
 		<DropdownMenu.Content align="end" preventScroll={false}>
-			{#each packageManagers as pm (pm)}
+			{#each AGENTS.filter((agent) => agent !== "pnpm@6" && agent !== "yarn@berry") as pm (pm)}
 				<DropdownMenu.Item
 					onclick={() => {
 						selectedPackageManager.set(pm);

--- a/sites/docs/src/lib/components/docs/index.ts
+++ b/sites/docs/src/lib/components/docs/index.ts
@@ -9,6 +9,7 @@ export { default as PMAddComp } from "./pm-add-comp.svelte";
 export { default as PMCreate } from "./pm-create.svelte";
 export { default as PMInstall } from "./pm-install.svelte";
 export { default as PMRemove } from "./pm-remove.svelte";
+export { default as PMRun } from "./pm-run.svelte";
 export { default as InstallTabs } from "./install-tabs.svelte";
 
 export * from "./page-header/index.js";

--- a/sites/docs/src/lib/components/docs/pm-block.svelte
+++ b/sites/docs/src/lib/components/docs/pm-block.svelte
@@ -3,9 +3,6 @@
 	import {
 		type PackageManager,
 		getPackageManager,
-		getPackageManagerInstallCmd,
-		getPackageManagerScriptCmd,
-		getPackageManagerUninstallCmd,
 	} from "$lib/stores/package-manager.js";
 
 	type PMBlockType = "execute" | "create" | "install" | "remove";
@@ -26,7 +23,7 @@
 	}
 
 	function getUninstallCommand() {
-		if (command === "") return "install";
+		if (command === "") return "uninstall";
 		return getPackageManagerUninstallCmd($selectedPackageManager);
 	}
 

--- a/sites/docs/src/lib/components/docs/pm-block.svelte
+++ b/sites/docs/src/lib/components/docs/pm-block.svelte
@@ -18,9 +18,6 @@
 	const selectedPackageManager = getPackageManager();
 
 	function getCmd(pm: Agent, type: Props["type"]): ResolvedCommand {
-		// ssr
-		if (pm === undefined) pm = "npm";
-
 		let args = [];
 		if (typeof command === "string") {
 			args = command.split(" ");

--- a/sites/docs/src/lib/components/docs/pm-block.svelte
+++ b/sites/docs/src/lib/components/docs/pm-block.svelte
@@ -1,12 +1,7 @@
 <script lang="ts">
 	import Pre from "./markdown/pre.svelte";
-	import { getPackageManager } from "$lib/stores/package-manager.js";
-	import {
-		resolveCommand,
-		type Agent,
-		type Command,
-		type ResolvedCommand,
-	} from "package-manager-detector";
+	import { getCommand, getPackageManager } from "$lib/stores/package-manager.js";
+	import { type Command } from "package-manager-detector";
 
 	type Props = {
 		type: Command | "create";
@@ -17,26 +12,7 @@
 
 	const selectedPackageManager = getPackageManager();
 
-	function getCmd(pm: Agent, type: Props["type"]): ResolvedCommand {
-		let args = [];
-		if (typeof command === "string") {
-			args = command.split(" ");
-		} else {
-			args = command;
-		}
-
-		// special handling for create
-		if (type === "create") return { command: pm, args: ["create", ...args] };
-
-		const cmd = resolveCommand(pm, type, args);
-
-		// since docs are static any unresolved command is a code error
-		if (cmd === null) throw new Error("Could not resolve command!");
-
-		return cmd;
-	}
-
-	let resolvedCommand = $derived(getCmd($selectedPackageManager, type));
+	let resolvedCommand = $derived(getCommand($selectedPackageManager, type, command));
 </script>
 
 <figure data-rehype-pretty-code-figure>

--- a/sites/docs/src/lib/components/docs/pm-run.svelte
+++ b/sites/docs/src/lib/components/docs/pm-run.svelte
@@ -3,4 +3,4 @@
 	export let command: string;
 </script>
 
-<PMBlock type="uninstall" {command} />
+<PMBlock type="run" {command} />

--- a/sites/docs/src/lib/stores/package-manager.ts
+++ b/sites/docs/src/lib/stores/package-manager.ts
@@ -4,7 +4,7 @@ import type { Agent } from "package-manager-detector";
 
 const PACKAGE_MANAGER = Symbol("packageManager");
 
-export function setPackageManager(initialValue: Agent) {
+export function setPackageManager(initialValue: Agent = "npm") {
 	const packageManager = createPackageManagerStore("packageManager", initialValue);
 	setContext(PACKAGE_MANAGER, packageManager);
 	return packageManager;

--- a/sites/docs/src/lib/stores/package-manager.ts
+++ b/sites/docs/src/lib/stores/package-manager.ts
@@ -1,9 +1,10 @@
 import { getContext, setContext } from "svelte";
 import { persisted } from "svelte-persisted-store";
+import type { Agent } from "package-manager-detector";
 
 const PACKAGE_MANAGER = Symbol("packageManager");
 
-export function setPackageManager(initialValue: PackageManager = "npm") {
+export function setPackageManager(initialValue: Agent) {
 	const packageManager = createPackageManagerStore("packageManager", initialValue);
 	setContext(PACKAGE_MANAGER, packageManager);
 	return packageManager;
@@ -13,48 +14,7 @@ export function getPackageManager(): ReturnType<typeof setPackageManager> {
 	return getContext(PACKAGE_MANAGER);
 }
 
-function createPackageManagerStore(key: string, initialValue: PackageManager) {
+function createPackageManagerStore(key: string, initialValue: Agent) {
 	const store = persisted(key, initialValue);
 	return store;
-}
-
-export const packageManagers = ["pnpm", "bun", "yarn", "npm"] as const;
-export type PackageManager = (typeof packageManagers)[number];
-
-const packageManagerToScriptCmd: Record<PackageManager, string> = {
-	npm: "npx",
-	yarn: "yarn dlx",
-	pnpm: "pnpm dlx",
-	bun: "bunx",
-};
-
-export function getPackageManagerScriptCmd(pm: PackageManager): string {
-	return packageManagerToScriptCmd[pm];
-}
-
-const packageManagerToInstallCmd: Record<PackageManager, string> = {
-	npm: "install",
-	yarn: "add",
-	pnpm: "add",
-	bun: "add",
-};
-
-export function getPackageManagerInstallCmd(pm: PackageManager): string {
-	return packageManagerToInstallCmd[pm];
-}
-
-const packageManagerToUninstallCmd: Record<PackageManager, string> = {
-	npm: "uninstall",
-	yarn: "remove",
-	pnpm: "remove",
-	bun: "remove",
-};
-
-export function getPackageManagerUninstallCmd(pm: PackageManager): string {
-	return packageManagerToUninstallCmd[pm];
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isPackageManager(value: any): value is PackageManager {
-	return packageManagers.includes(value);
 }

--- a/sites/docs/src/lib/utils.ts
+++ b/sites/docs/src/lib/utils.ts
@@ -260,38 +260,6 @@ export function getLiftMode(name: string) {
 	};
 }
 
-export const packageManagers = ["pnpm", "bun", "yarn", "npm"] as const;
-export type PackageManager = (typeof packageManagers)[number];
-
-export const selectedPackageManager = persisted<PackageManager>("package-manager", "npm");
-
-const packageManagerToScriptCmd: Record<PackageManager, string> = {
-	npm: "npx",
-	yarn: "yarn dlx",
-	pnpm: "pnpm dlx",
-	bun: "bunx",
-};
-
-export function getPackageManagerScriptCmd(pm: PackageManager): string {
-	return packageManagerToScriptCmd[pm];
-}
-
-const packageManagerToInstallCmd: Record<PackageManager, string> = {
-	npm: "install",
-	yarn: "add",
-	pnpm: "add",
-	bun: "add",
-};
-
-export function getPackageManagerInstallCmd(pm: PackageManager): string {
-	return packageManagerToInstallCmd[pm];
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isPackageManager(value: any): value is PackageManager {
-	return packageManagers.includes(value);
-}
-
 // Wrappers around svelte's `HTMLAttributes` types to add a `ref` prop can be bound to
 // to get a reference to the underlying DOM element the component is rendering.
 export type PrimitiveDivAttributes = WithElementRef<HTMLAttributes<HTMLDivElement>>;


### PR DESCRIPTION
Fixes #1474 

- Adds `run dev server once` to installation instruction 
- Adds `<PMRun/>` component
- Refactors the pm-block component with `package-manager-detector` so adding new commands is easier.