### PR TITLE
docs: Fixed accordion variable names in migration guide

### DIFF
--- a/sites/docs/src/content/migration/svelte-5/index.md
+++ b/sites/docs/src/content/migration/svelte-5/index.md
@@ -84,10 +84,10 @@ const config: Config = {
 			keyframes: {
 				'accordion-down': {
 					from: { height: '0' },
-					to: { height: 'var(--radix-accordion-content-height)' }
+					to: { height: 'var(--bits-accordion-content-height)' }
 				},
 				'accordion-up': {
-					from: { height: 'var(--radix-accordion-content-height)' },
+					from: { height: 'var(--bits-accordion-content-height)' },
 					to: { height: '0' }
 				},
 				'caret-blink': {


### PR DESCRIPTION
This broke the transition, since the bits-ui variable uses a different prefix.