### PR TITLE
fix: Errors when importing Radio Group

### DIFF
--- a/sites/docs/src/lib/registry/new-york/ui/radio-group/radio-group.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/radio-group/radio-group.svelte
@@ -8,8 +8,6 @@
 		value = $bindable(),
 		...restProps
 	}: RadioGroupPrimitive.RootProps = $props();
-
-	export { className as class };
 </script>
 
 <RadioGroupPrimitive.Root bind:value class={cn("grid gap-2", className)} {...restProps} bind:ref />


### PR DESCRIPTION
Fixes `TypeError: Cannot redefine property: class` when imported

### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
