### PR TITLE
fix(next): parse `<script module>` tags for imports

### DIFF
--- a/sites/docs/scripts/registry.ts
+++ b/sites/docs/scripts/registry.ts
@@ -1,6 +1,6 @@
 import * as acorn from "acorn";
 import tsPlugin from "acorn-typescript";
-import { walk } from "estree-walker";
+import { walk, type Node } from "estree-walker";
 import fs from "node:fs";
 import path from "node:path";
 import { parse, preprocess } from "svelte/compiler";
@@ -287,11 +287,15 @@ async function crawlHook(rootPath: string, style: RegistryStyle) {
 
 async function getFileDependencies(filename: string, sourceCode: string) {
 	let ast: unknown;
+	let moduleAst: unknown;
 
 	if (filename.endsWith(".svelte")) {
 		const { code } = await preprocess(sourceCode, config.preprocess, { filename });
 		const result = parse(code, { filename });
 		ast = result.instance;
+		if (result.module) {
+			moduleAst = result.module;
+		}
 	} else {
 		ast = tsParser.parse(sourceCode, {
 			ecmaVersion: "latest",
@@ -302,35 +306,40 @@ async function getFileDependencies(filename: string, sourceCode: string) {
 	const registryDependencies = new Set<string>();
 	const dependencies = new Set<string>();
 
-	// @ts-expect-error yea, stfu
-	walk(ast, {
-		enter(node) {
-			if (node.type === "ImportDeclaration") {
-				const source = node.source.value as string;
+	const enter = (node: Node) => {
+		if (node.type === "ImportDeclaration") {
+			const source = node.source.value as string;
 
-				const peerDeps = DEPENDENCIES.get(source);
-				if (peerDeps !== undefined) {
-					dependencies.add(source);
-					peerDeps.forEach((dep) => dependencies.add(dep));
-				}
+			const peerDeps = DEPENDENCIES.get(source);
+			if (peerDeps !== undefined) {
+				dependencies.add(source);
+				peerDeps.forEach((dep) => dependencies.add(dep));
+			}
 
-				if (source.startsWith(REGISTRY_DEPENDENCY) && source !== UTILS_PATH) {
-					if (source.includes("ui")) {
-						const component = source.split("/").at(-2)!;
-						registryDependencies.add(component);
-					} else if (source.includes("hook")) {
-						const hook = source.split("/").at(-1)!.split(".")[0];
-						registryDependencies.add(hook);
-					}
-				}
-
-				const iconDep = ICON_DEPENDENCIES.find((dep) => source.startsWith(dep));
-				if (iconDep !== undefined) {
-					dependencies.add(iconDep);
+			if (source.startsWith(REGISTRY_DEPENDENCY) && source !== UTILS_PATH) {
+				if (source.includes("ui")) {
+					const component = source.split("/").at(-2)!;
+					registryDependencies.add(component);
+				} else if (source.includes("hook")) {
+					const hook = source.split("/").at(-1)!.split(".")[0];
+					registryDependencies.add(hook);
 				}
 			}
-		},
-	});
+
+			const iconDep = ICON_DEPENDENCIES.find((dep) => source.startsWith(dep));
+			if (iconDep !== undefined) {
+				dependencies.add(iconDep);
+			}
+		}
+	};
+
+	// @ts-expect-error yea, stfu
+	walk(ast, { enter });
+
+	if (moduleAst) {
+		// @ts-expect-error yea, stfu x2
+		walk(moduleAst, { enter });
+	}
 
 	return { registryDependencies, dependencies };
 }


### PR DESCRIPTION
Fixes #1534 

The root of #1534 was actually that the `index.json` and `button.json` files did not include `bits-ui` as a dependency. With a little (a lot more than I am proud of) digging I figured out that we aren't parsing the `<script module>` tags in `.svelte` files. (I did this same thing in my own project need to go fix that now).

This PR adds second walk of the `<script module>` tag if it exists so that we catch all the imports.
