### PR TITLE
registry: pin deps

### DIFF
--- a/sites/docs/scripts/registry.ts
+++ b/sites/docs/scripts/registry.ts
@@ -156,8 +156,8 @@ async function getDependencies(filename: string, source: string) {
 	const registryDependencies = new Set<string>();
 	const dependencies = new Set<string>();
 
+	// @ts-expect-error annoying
 	walk(ast.instance, {
-		// @ts-expect-error annoying
 		enter(node) {
 			if (node.type === "ImportDeclaration") {
 				const source = node.source.value as string;

--- a/sites/docs/scripts/registry.ts
+++ b/sites/docs/scripts/registry.ts
@@ -51,10 +51,10 @@ export async function buildRegistry() {
 
 function getDepsWithPinned(deps: Set<string>) {
 	return Array.from(deps).map((dep) => {
-		const pinnedDep = TMP_PINNED_DEPS.get(dep)
-		if (pinnedDep) return pinnedDep
-		return dep
-	})
+		const pinnedDep = TMP_PINNED_DEPS.get(dep);
+		if (pinnedDep) return pinnedDep;
+		return dep;
+	});
 }
 
 async function crawlUI(rootPath: string, style: string) {

--- a/sites/docs/scripts/registry.ts
+++ b/sites/docs/scripts/registry.ts
@@ -50,11 +50,7 @@ export async function buildRegistry() {
 }
 
 function getDepsWithPinned(deps: Set<string>) {
-	return Array.from(deps).map((dep) => {
-		const pinnedDep = TMP_PINNED_DEPS.get(dep);
-		if (pinnedDep) return pinnedDep;
-		return dep;
-	});
+	return Array.from(deps).map((dep) => TMP_PINNED_DEPS.get(dep) ?? dep);
 }
 
 async function crawlUI(rootPath: string, style: string) {

--- a/sites/docs/scripts/registry.ts
+++ b/sites/docs/scripts/registry.ts
@@ -49,10 +49,6 @@ export async function buildRegistry() {
 	return registry;
 }
 
-function getDepsWithPinned(deps: Set<string>) {
-	return Array.from(deps).map((dep) => TMP_PINNED_DEPS.get(dep) ?? dep);
-}
-
 async function crawlUI(rootPath: string, style: string) {
 	const dir = fs.readdirSync(rootPath, {
 		recursive: true,
@@ -107,7 +103,7 @@ async function buildUIRegistry(componentPath: string, componentName: string, sty
 		files,
 		name: componentName,
 		registryDependencies: Array.from(registryDependencies),
-		dependencies: getDepsWithPinned(dependencies),
+		dependencies: Array.from(dependencies).map((dep) => TMP_PINNED_DEPS.get(dep) ?? dep),
 	} satisfies RegistryItem;
 }
 
@@ -138,7 +134,7 @@ async function crawlDemo(rootPath: string, style: string, demoType: "example" | 
 			style,
 			files: [file],
 			registryDependencies: Array.from(registryDependencies),
-			dependencies: getDepsWithPinned(dependencies),
+			dependencies: Array.from(dependencies).map((dep) => TMP_PINNED_DEPS.get(dep) ?? dep),
 		});
 	}
 

--- a/sites/docs/scripts/tmp.ts
+++ b/sites/docs/scripts/tmp.ts
@@ -1,1 +1,1 @@
-export const TMP_PINNED_DEPS = new Map<string, string>([["formsnap", "formsnap@0.1.1"]]);
+export const TMP_PINNED_DEPS = new Map<string, string>([["formsnap", "formsnap@1.0.1"]]);

--- a/sites/docs/scripts/tmp.ts
+++ b/sites/docs/scripts/tmp.ts
@@ -1,0 +1,3 @@
+export const TMP_PINNED_DEPS = new Map<string, string>([[
+	"formsnap", "formsnap@0.1.1"
+]])

--- a/sites/docs/scripts/tmp.ts
+++ b/sites/docs/scripts/tmp.ts
@@ -1,3 +1,1 @@
-export const TMP_PINNED_DEPS = new Map<string, string>([[
-	"formsnap", "formsnap@0.1.1"
-]])
+export const TMP_PINNED_DEPS = new Map<string, string>([["formsnap", "formsnap@0.1.1"]]);


### PR DESCRIPTION
As we release new majors for dependencies that only support Svelte 5, we'll pin those dependencies to their latest Svelte 4-supported version.