### PR TITLE
next: use `formsnap@latest`

### DIFF
--- a/sites/docs/scripts/tmp.ts
+++ b/sites/docs/scripts/tmp.ts
@@ -1,2 +1,2 @@
 // will be removed once moving from `next` to `latest`
-export const TMP_NEXT_DEPS = ["bits-ui", "formsnap", "paneforge", "vaul-svelte"];
+export const TMP_NEXT_DEPS = ["bits-ui", "paneforge", "vaul-svelte"];


### PR DESCRIPTION
Formsnap v2 has been released so we no longer need to install the `@next` release and can just rely on `latest` for Svelte 5 😃