### PR TITLE
docs(next): Fix combobox example text alignment

### DIFF
--- a/sites/docs/src/lib/registry/default/example/combobox-demo.svelte
+++ b/sites/docs/src/lib/registry/default/example/combobox-demo.svelte
@@ -76,12 +76,7 @@
 								closeAndFocusTrigger();
 							}}
 						>
-							<Check
-								class={cn(
-									"ml-auto",
-									value !== framework.value && "text-transparent"
-								)}
-							/>
+							<Check class={cn(value !== framework.value && "text-transparent")} />
 							{framework.label}
 						</Command.Item>
 					{/each}


### PR DESCRIPTION
The current default example:
![image](https://github.com/user-attachments/assets/b3e3dd64-fe53-4ffb-b6d9-b14b7fdda653)

The new york example works fine since it doesn't have the `ml-auto`.

This PR just removes the `ml-auto` class.
