### PR TITLE
Typo: docs-migration-svelte-5,  replaced \\ with /

### DIFF
--- a/sites/docs/src/content/migration/svelte-5/index.md
+++ b/sites/docs/src/content/migration/svelte-5/index.md
@@ -37,7 +37,7 @@ Add the `registry` to the root object, and add `hooks` and `ui` keys under `alia
   "style": "default",
   "tailwind": {
     "config": "tailwind.config.js",
-    "css": "src\\app.pcss",
+    "css": "src/app.pcss",
     "baseColor": "zinc"
   },
   "aliases": {


### PR DESCRIPTION
# Summary

* replaced `\\` with `/` in code example under `components.json`. (see screenshot)

* on `https://next.shadcn-svelte.com/docs/migration/svelte-5`
* Shown on website as: `"css": "src\app.pcss",` (should be '/')

<img width="774" alt="Screenshot 2024-12-19 at 5 05 51 PM" src="https://github.com/user-attachments/assets/b6185252-b92f-427c-acbf-5769ed95c5d9" />
