### PR TITLE
fix(next): misplaced `className` in `cn` functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"prettier-plugin-svelte": "^3.2.7",
 		"prettier-plugin-tailwindcss": "^0.6.8",
 		"pretty-quick": "^4.0.0",
-		"svelte": "^5.15.0",
+		"svelte": "^5.16.0",
 		"svelte-eslint-parser": "^0.42.0",
 		"typescript": "^5.6.3",
 		"typescript-eslint": "^8.10.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,13 +128,13 @@ importers:
         version: 0.3.0(prettier@3.3.3)
       '@sveltejs/adapter-cloudflare':
         specifier: 4.6.1
-        version: 4.6.1(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(wrangler@3.81.0)
+        version: 4.6.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(wrangler@3.81.0)
       '@sveltejs/enhanced-img':
         specifier: ^0.3.9
         version: 0.3.9(rollup@4.24.0)(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
       '@sveltejs/kit':
-        specifier: ^2.5.28
-        version: 2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
+        specifier: ^2.12.0
+        version: 2.15.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^4.0.0
         version: 4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
@@ -194,7 +194,7 @@ importers:
         version: 3.0.3
       formsnap:
         specifier: 2.0.0-next.1
-        version: 2.0.0-next.1(svelte@5.16.0)(sveltekit-superforms@2.19.1(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(@types/json-schema@7.0.15)(svelte@5.16.0))
+        version: 2.0.0-next.1(svelte@5.16.0)(sveltekit-superforms@2.19.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(@types/json-schema@7.0.15)(svelte@5.16.0))
       hast-util-to-html:
         specifier: ^9.0.1
         version: 9.0.1
@@ -263,13 +263,13 @@ importers:
         version: 0.11.0(svelte@5.16.0)
       svelte-sonner:
         specifier: ^0.3.25
-        version: 0.3.25(svelte@5.16.0)
+        version: 0.3.28(svelte@5.16.0)
       sveltekit-superforms:
         specifier: ^2.19.1
-        version: 2.19.1(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(@types/json-schema@7.0.15)(svelte@5.16.0)
+        version: 2.19.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(@types/json-schema@7.0.15)(svelte@5.16.0)
       tailwind-merge:
         specifier: ^2.4.0
-        version: 2.5.4
+        version: 2.6.0
       tailwind-variants:
         specifier: ^0.2.1
         version: 0.2.1(tailwindcss@3.4.14)
@@ -1574,14 +1574,14 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       vite: '>= 5.0.0'
 
-  '@sveltejs/kit@2.7.2':
-    resolution: {integrity: sha512-bFwrl+0bNr0/DHQZM0INwwSPNYqDjfsKRhUoa6rj9d8tDZzszBrJ3La6/HVFxWGONEigtG+SzHXa1BEa1BLdwA==}
+  '@sveltejs/kit@2.15.1':
+    resolution: {integrity: sha512-8t7D3hQHbUDMiaQ2RVnjJJ/+Ur4Fn/tkeySJCsHtX346Q9cp3LAnav8xXdfuqYNJwpUGX0x3BqF1uvbmXQw93A==}
     engines: {node: '>=18.13'}
     hasBin: true
     peerDependencies:
-      '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1
+      '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1 || ^5.0.0
       svelte: ^4.0.0 || ^5.0.0-next.0
-      vite: ^5.0.3
+      vite: ^5.0.3 || ^6.0.0
 
   '@sveltejs/vite-plugin-svelte-inspector@3.0.0-next.3':
     resolution: {integrity: sha512-kuGJ2CZ5lAw3gKF8Kw0AfKtUJWbwdlDHY14K413B0MCyrzvQvsKTorwmwZcky0+QqY6RnVIZ/5FttB9bQmkLXg==}
@@ -3180,9 +3180,6 @@ packages:
     resolution: {integrity: sha512-FzJ9D/0nGiCGBf8UXO/IGLTgLVzIxze1zpfA8Ton2mjLovXdAPlYDv+MQDcqj3TmrhAGYfOpz9RfR+ent0AgAw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
-
-  esm-env@1.0.0:
-    resolution: {integrity: sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==}
 
   esm-env@1.2.1:
     resolution: {integrity: sha512-U9JedYYjCnadUlXk7e1Kr+aENQhtUaoaV9+gZm1T8LC/YBAPJx3NSPIAurFOC0U5vrdSevnUJS2/wUVxGwPhng==}
@@ -5304,8 +5301,8 @@ packages:
     peerDependencies:
       svelte: ^3.48.0 || ^4.0.0 || ^5.0.0-next.0
 
-  svelte-sonner@0.3.25:
-    resolution: {integrity: sha512-jYAHqDc1fBAotI+9g9SW2Pc6sKJ8oVl7aXB/EhQsxiVADAZ9AX4w7dxDI1oyskD6pG8mhYIKXi+5WqFmCRqFyw==}
+  svelte-sonner@0.3.28:
+    resolution: {integrity: sha512-K3AmlySeFifF/cKgsYNv5uXqMVNln0NBAacOYgmkQStLa/UoU0LhfAACU6Gr+YYC8bOCHdVmFNoKuDbMEsppJg==}
     peerDependencies:
       svelte: ^3.0.0 || ^4.0.0 || ^5.0.0-next.1
 
@@ -5333,8 +5330,8 @@ packages:
     resolution: {integrity: sha512-7RnqIMq572L8PeEzKeBINYEJDDxpcH8JEgLwUqBd3TkofhFRbkq4QLR0u+36avGAhCRbk2nnmjcW9SE531hPDg==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  tailwind-merge@2.5.4:
-    resolution: {integrity: sha512-0q8cfZHMu9nuYP/b5Shb7Y7Sh1B7Nnl5GqNr1U+n2p6+mybvRtayrQ+0042Z5byvTA8ihjlP8Odo8/VnHbZu4Q==}
+  tailwind-merge@2.6.0:
+    resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
 
   tailwind-variants@0.2.1:
     resolution: {integrity: sha512-2xmhAf4UIc3PijOUcJPA1LP4AbxhpcHuHM2C26xM0k81r0maAO6uoUSHl3APmvHZcY5cZCY/bYuJdfFa4eGoaw==}
@@ -7129,10 +7126,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@sveltejs/adapter-cloudflare@4.6.1(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(wrangler@3.81.0)':
+  '@sveltejs/adapter-cloudflare@4.6.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(wrangler@3.81.0)':
     dependencies:
       '@cloudflare/workers-types': 4.20240222.0
-      '@sveltejs/kit': 2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
+      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
       esbuild: 0.21.5
       worktop: 0.8.0-next.18
       wrangler: 3.81.0
@@ -7147,13 +7144,13 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  '@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))':
+  '@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
-      esm-env: 1.0.0
+      esm-env: 1.2.1
       import-meta-resolve: 4.1.0
       kleur: 4.1.5
       magic-string: 0.30.12
@@ -9180,8 +9177,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  esm-env@1.0.0: {}
-
   esm-env@1.2.1: {}
 
   espree@10.2.0:
@@ -9372,11 +9367,11 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
-  formsnap@2.0.0-next.1(svelte@5.16.0)(sveltekit-superforms@2.19.1(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(@types/json-schema@7.0.15)(svelte@5.16.0)):
+  formsnap@2.0.0-next.1(svelte@5.16.0)(sveltekit-superforms@2.19.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(@types/json-schema@7.0.15)(svelte@5.16.0)):
     dependencies:
       svelte: 5.16.0
       svelte-toolbelt: 0.4.4(svelte@5.16.0)
-      sveltekit-superforms: 2.19.1(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(@types/json-schema@7.0.15)(svelte@5.16.0)
+      sveltekit-superforms: 2.19.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(@types/json-schema@7.0.15)(svelte@5.16.0)
 
   fraction.js@4.3.7: {}
 
@@ -11709,7 +11704,7 @@ snapshots:
     dependencies:
       svelte: 5.16.0
 
-  svelte-sonner@0.3.25(svelte@5.16.0):
+  svelte-sonner@0.3.28(svelte@5.16.0):
     dependencies:
       svelte: 5.16.0
 
@@ -11736,9 +11731,9 @@ snapshots:
       magic-string: 0.30.12
       zimmerframe: 1.1.2
 
-  sveltekit-superforms@2.19.1(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(@types/json-schema@7.0.15)(svelte@5.16.0):
+  sveltekit-superforms@2.19.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(@types/json-schema@7.0.15)(svelte@5.16.0):
     dependencies:
-      '@sveltejs/kit': 2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
+      '@sveltejs/kit': 2.15.1(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
       devalue: 5.1.1
       just-clone: 6.2.0
       memoize-weak: 1.0.2
@@ -11771,11 +11766,11 @@ snapshots:
       '@pkgr/core': 0.1.1
       tslib: 2.8.0
 
-  tailwind-merge@2.5.4: {}
+  tailwind-merge@2.6.0: {}
 
   tailwind-variants@0.2.1(tailwindcss@3.4.14):
     dependencies:
-      tailwind-merge: 2.5.4
+      tailwind-merge: 2.6.0
       tailwindcss: 3.4.14
 
   tailwindcss-animate@1.0.7(tailwindcss@3.4.14):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 9.12.0
       '@huntabyte/eslint-config':
         specifier: ^0.3.2
-        version: 0.3.2(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.15.0))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.15.0))(svelte@5.15.0)(typescript@5.6.3)(vitest@2.1.3)
+        version: 0.3.2(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.16.0))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.16.0))(svelte@5.16.0)(typescript@5.6.3)(vitest@2.1.3(@types/node@20.16.14)(terser@5.36.0))
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.10.0
         version: 8.10.0(@typescript-eslint/parser@8.10.0(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3)
@@ -34,7 +34,7 @@ importers:
         version: 9.1.0(eslint@9.7.0)
       eslint-plugin-svelte:
         specifier: ^2.44.1
-        version: 2.44.1(eslint@9.7.0)(svelte@5.15.0)
+        version: 2.44.1(eslint@9.7.0)(svelte@5.16.0)
       globals:
         specifier: ^15.11.0
         version: 15.11.0
@@ -43,19 +43,19 @@ importers:
         version: 3.3.3
       prettier-plugin-svelte:
         specifier: ^3.2.7
-        version: 3.2.7(prettier@3.3.3)(svelte@5.15.0)
+        version: 3.2.7(prettier@3.3.3)(svelte@5.16.0)
       prettier-plugin-tailwindcss:
         specifier: ^0.6.8
-        version: 0.6.8(prettier-plugin-svelte@3.2.7(prettier@3.3.3)(svelte@5.15.0))(prettier@3.3.3)
+        version: 0.6.8(prettier-plugin-svelte@3.2.7(prettier@3.3.3)(svelte@5.16.0))(prettier@3.3.3)
       pretty-quick:
         specifier: ^4.0.0
         version: 4.0.0(prettier@3.3.3)
       svelte:
-        specifier: ^5.15.0
-        version: 5.15.0
+        specifier: ^5.16.0
+        version: 5.16.0
       svelte-eslint-parser:
         specifier: ^0.42.0
-        version: 0.42.0(svelte@5.15.0)
+        version: 0.42.0(svelte@5.16.0)
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -128,16 +128,16 @@ importers:
         version: 0.3.0(prettier@3.3.3)
       '@sveltejs/adapter-cloudflare':
         specifier: 4.6.1
-        version: 4.6.1(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(wrangler@3.81.0)
+        version: 4.6.1(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(wrangler@3.81.0)
       '@sveltejs/enhanced-img':
         specifier: ^0.3.9
-        version: 0.3.9(rollup@4.24.0)(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
+        version: 0.3.9(rollup@4.24.0)(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
       '@sveltejs/kit':
         specifier: ^2.5.28
-        version: 2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
+        version: 2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^4.0.0
-        version: 4.0.0(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
+        version: 4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
       '@tanstack/table-core':
         specifier: ^8.20.5
         version: 8.20.5
@@ -158,7 +158,7 @@ importers:
         version: 20.16.14
       '@unovis/svelte':
         specifier: 1.4.3
-        version: 1.4.3(@unovis/ts@1.4.3)(svelte@5.15.0)
+        version: 1.4.3(@unovis/ts@1.4.3)(svelte@5.16.0)
       '@unovis/ts':
         specifier: 1.4.3
         version: 1.4.3
@@ -173,7 +173,7 @@ importers:
         version: 10.4.20(postcss@8.4.47)
       bits-ui:
         specifier: 1.0.0-next.71
-        version: 1.0.0-next.71(svelte@5.15.0)
+        version: 1.0.0-next.71(svelte@5.16.0)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -188,13 +188,13 @@ importers:
         version: 8.1.6(embla-carousel@8.1.6)
       embla-carousel-svelte:
         specifier: 8.1.6
-        version: 8.1.6(svelte@5.15.0)
+        version: 8.1.6(svelte@5.16.0)
       estree-walker:
         specifier: ^3.0.3
         version: 3.0.3
       formsnap:
         specifier: 2.0.0-next.1
-        version: 2.0.0-next.1(svelte@5.15.0)(sveltekit-superforms@2.19.1(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(@types/json-schema@7.0.15)(svelte@5.15.0))
+        version: 2.0.0-next.1(svelte@5.16.0)(sveltekit-superforms@2.19.1(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(@types/json-schema@7.0.15)(svelte@5.16.0))
       hast-util-to-html:
         specifier: ^9.0.1
         version: 9.0.1
@@ -206,22 +206,22 @@ importers:
         version: 4.5.0
       lucide-svelte:
         specifier: ^0.447.0
-        version: 0.447.0(svelte@5.15.0)
+        version: 0.447.0(svelte@5.16.0)
       magic-string:
         specifier: ^0.30.12
         version: 0.30.12
       mdsx:
         specifier: ^0.0.6
-        version: 0.0.6(svelte@5.15.0)
+        version: 0.0.6(svelte@5.16.0)
       mode-watcher:
         specifier: ^0.3.1
-        version: 0.3.1(svelte@5.15.0)
+        version: 0.3.1(svelte@5.16.0)
       package-manager-detector:
         specifier: ^0.2.2
         version: 0.2.2
       paneforge:
         specifier: 1.0.0-next.1
-        version: 1.0.0-next.1(svelte@5.15.0)
+        version: 1.0.0-next.1(svelte@5.16.0)
       postcss:
         specifier: ^8.4.39
         version: 8.4.47
@@ -250,23 +250,23 @@ importers:
         specifier: ^1.2.1
         version: 1.2.1
       svelte:
-        specifier: ^5.15.0
-        version: 5.15.0
+        specifier: ^5.16.0
+        version: 5.16.0
       svelte-check:
         specifier: ^4.0.5
-        version: 4.0.5(picomatch@4.0.2)(svelte@5.15.0)(typescript@5.5.3)
+        version: 4.0.5(picomatch@4.0.2)(svelte@5.16.0)(typescript@5.5.3)
       svelte-local-storage-store:
         specifier: ^0.6.4
-        version: 0.6.4(svelte@5.15.0)
+        version: 0.6.4(svelte@5.16.0)
       svelte-persisted-store:
         specifier: ^0.11.0
-        version: 0.11.0(svelte@5.15.0)
+        version: 0.11.0(svelte@5.16.0)
       svelte-sonner:
         specifier: ^0.3.25
-        version: 0.3.25(svelte@5.15.0)
+        version: 0.3.25(svelte@5.16.0)
       sveltekit-superforms:
         specifier: ^2.19.1
-        version: 2.19.1(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(@types/json-schema@7.0.15)(svelte@5.15.0)
+        version: 2.19.1(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(@types/json-schema@7.0.15)(svelte@5.16.0)
       tailwind-merge:
         specifier: ^2.4.0
         version: 2.5.4
@@ -302,7 +302,7 @@ importers:
         version: 5.0.0
       vaul-svelte:
         specifier: ^1.0.0-next.2
-        version: 1.0.0-next.2(svelte@5.15.0)
+        version: 1.0.0-next.2(svelte@5.16.0)
       velite:
         specifier: ^0.2.0
         version: 0.2.0
@@ -5315,8 +5315,8 @@ packages:
     peerDependencies:
       svelte: ^5.0.0-next.126
 
-  svelte@5.15.0:
-    resolution: {integrity: sha512-YWl8rAd4hSjERLtLvP6h2pflGtmrJwv+L12BgrOtHYJCpvLS9WKp/YNAdyolw3FymXtcYZqhSWvWlu5O1X7tgQ==}
+  svelte@5.16.0:
+    resolution: {integrity: sha512-Ygqsiac6UogVED2ruKclU+pOeMThxWtp9LG+li7BXeDKC2paVIsRTMkNmcON4Zejerd1s5sZHWx6ZtU85xklVg==}
     engines: {node: '>=18'}
 
   sveltekit-superforms@2.19.1:
@@ -6026,7 +6026,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@antfu/eslint-config@2.22.0(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.15.0))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.15.0))(svelte@5.15.0)(typescript@5.6.3)(vitest@2.1.3)':
+  '@antfu/eslint-config@2.22.0(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.16.0))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.16.0))(svelte@5.16.0)(typescript@5.6.3)(vitest@2.1.3(@types/node@20.16.14)(terser@5.36.0))':
     dependencies:
       '@antfu/install-pkg': 0.3.3
       '@clack/prompts': 0.7.0
@@ -6046,12 +6046,12 @@ snapshots:
       eslint-plugin-markdown: 5.1.0(eslint@9.7.0)
       eslint-plugin-n: 17.9.0(eslint@9.7.0)
       eslint-plugin-no-only-tests: 3.1.0
-      eslint-plugin-perfectionist: 2.11.0(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.15.0))(svelte@5.15.0)(typescript@5.6.3)(vue-eslint-parser@9.4.3(eslint@9.7.0))
+      eslint-plugin-perfectionist: 2.11.0(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.16.0))(svelte@5.16.0)(typescript@5.6.3)(vue-eslint-parser@9.4.3(eslint@9.7.0))
       eslint-plugin-regexp: 2.6.0(eslint@9.7.0)
       eslint-plugin-toml: 0.11.1(eslint@9.7.0)
       eslint-plugin-unicorn: 54.0.0(eslint@9.7.0)
       eslint-plugin-unused-imports: 4.0.0(@typescript-eslint/eslint-plugin@8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)
-      eslint-plugin-vitest: 0.5.4(@typescript-eslint/eslint-plugin@8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3)(vitest@2.1.3)
+      eslint-plugin-vitest: 0.5.4(@typescript-eslint/eslint-plugin@8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3)(vitest@2.1.3(@types/node@20.16.14)(terser@5.36.0))
       eslint-plugin-vue: 9.27.0(eslint@9.7.0)
       eslint-plugin-yml: 1.14.0(eslint@9.7.0)
       eslint-processor-vue-blocks: 0.1.2(@vue/compiler-sfc@3.5.12)(eslint@9.7.0)
@@ -6065,8 +6065,8 @@ snapshots:
       yaml-eslint-parser: 1.2.3
       yargs: 17.7.2
     optionalDependencies:
-      eslint-plugin-svelte: 2.44.1(eslint@9.7.0)(svelte@5.15.0)
-      svelte-eslint-parser: 0.42.0(svelte@5.15.0)
+      eslint-plugin-svelte: 2.44.1(eslint@9.7.0)(svelte@5.16.0)
+      svelte-eslint-parser: 0.42.0(svelte@5.16.0)
     transitivePeerDependencies:
       - '@vue/compiler-sfc'
       - supports-color
@@ -6738,9 +6738,9 @@ snapshots:
 
   '@humanwhocodes/retry@0.3.0': {}
 
-  '@huntabyte/eslint-config@0.3.2(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.15.0))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.15.0))(svelte@5.15.0)(typescript@5.6.3)(vitest@2.1.3)':
+  '@huntabyte/eslint-config@0.3.2(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.16.0))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.16.0))(svelte@5.16.0)(typescript@5.6.3)(vitest@2.1.3(@types/node@20.16.14)(terser@5.36.0))':
     dependencies:
-      '@antfu/eslint-config': 2.22.0(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.15.0))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.15.0))(svelte@5.15.0)(typescript@5.6.3)(vitest@2.1.3)
+      '@antfu/eslint-config': 2.22.0(@vue/compiler-sfc@3.5.12)(eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.16.0))(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.16.0))(svelte@5.16.0)(typescript@5.6.3)(vitest@2.1.3(@types/node@20.16.14)(terser@5.36.0))
       '@antfu/install-pkg': 0.3.3
       '@clack/prompts': 0.7.0
       '@huntabyte/eslint-plugin': 0.1.0(eslint@9.7.0)
@@ -6749,10 +6749,10 @@ snapshots:
       chalk: 5.3.0
       eslint: 9.7.0
       eslint-flat-config-utils: 0.2.5
-      eslint-plugin-svelte: 2.44.1(eslint@9.7.0)(svelte@5.15.0)
+      eslint-plugin-svelte: 2.44.1(eslint@9.7.0)(svelte@5.16.0)
       local-pkg: 0.5.0
       parse-gitignore: 2.0.0
-      svelte-eslint-parser: 0.42.0(svelte@5.15.0)
+      svelte-eslint-parser: 0.42.0(svelte@5.16.0)
       yargs: 17.7.2
     transitivePeerDependencies:
       - '@eslint-react/eslint-plugin'
@@ -7129,27 +7129,27 @@ snapshots:
       - supports-color
       - typescript
 
-  '@sveltejs/adapter-cloudflare@4.6.1(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(wrangler@3.81.0)':
+  '@sveltejs/adapter-cloudflare@4.6.1(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(wrangler@3.81.0)':
     dependencies:
       '@cloudflare/workers-types': 4.20240222.0
-      '@sveltejs/kit': 2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
+      '@sveltejs/kit': 2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
       esbuild: 0.21.5
       worktop: 0.8.0-next.18
       wrangler: 3.81.0
 
-  '@sveltejs/enhanced-img@0.3.9(rollup@4.24.0)(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))':
+  '@sveltejs/enhanced-img@0.3.9(rollup@4.24.0)(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))':
     dependencies:
       magic-string: 0.30.12
-      svelte: 5.15.0
-      svelte-parse-markup: 0.1.5(svelte@5.15.0)
+      svelte: 5.16.0
+      svelte-parse-markup: 0.1.5(svelte@5.16.0)
       vite: 5.4.9(@types/node@20.16.14)(terser@5.36.0)
       vite-imagetools: 7.0.2(rollup@4.24.0)
     transitivePeerDependencies:
       - rollup
 
-  '@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))':
+  '@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.0(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
+      '@sveltejs/vite-plugin-svelte': 4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
@@ -7161,27 +7161,27 @@ snapshots:
       sade: 1.8.1
       set-cookie-parser: 2.6.0
       sirv: 3.0.0
-      svelte: 5.15.0
+      svelte: 5.16.0
       tiny-glob: 0.2.9
       vite: 5.4.9(@types/node@20.16.14)(terser@5.36.0)
 
-  '@sveltejs/vite-plugin-svelte-inspector@3.0.0-next.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.0-next.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.0(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
+      '@sveltejs/vite-plugin-svelte': 4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
       debug: 4.3.7
-      svelte: 5.15.0
+      svelte: 5.16.0
       vite: 5.4.9(@types/node@20.16.14)(terser@5.36.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))':
+  '@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 3.0.0-next.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 3.0.0-next.3(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
       debug: 4.3.7
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.12
-      svelte: 5.15.0
+      svelte: 5.16.0
       vite: 5.4.9(@types/node@20.16.14)(terser@5.36.0)
       vitefu: 1.0.3(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
     transitivePeerDependencies:
@@ -7730,10 +7730,10 @@ snapshots:
     dependencies:
       lodash-es: 4.17.21
 
-  '@unovis/svelte@1.4.3(@unovis/ts@1.4.3)(svelte@5.15.0)':
+  '@unovis/svelte@1.4.3(@unovis/ts@1.4.3)(svelte@5.16.0)':
     dependencies:
       '@unovis/ts': 1.4.3
-      svelte: 5.15.0
+      svelte: 5.16.0
 
   '@unovis/ts@1.4.3':
     dependencies:
@@ -7798,7 +7798,7 @@ snapshots:
       chai: 5.1.1
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(vite@5.4.9)':
+  '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))':
     dependencies:
       '@vitest/spy': 2.1.3
       estree-walker: 3.0.3
@@ -8057,15 +8057,15 @@ snapshots:
 
   binary-extensions@2.2.0: {}
 
-  bits-ui@1.0.0-next.71(svelte@5.15.0):
+  bits-ui@1.0.0-next.71(svelte@5.16.0):
     dependencies:
       '@floating-ui/core': 1.6.4
       '@floating-ui/dom': 1.6.7
       '@internationalized/date': 3.5.6
       esm-env: 1.2.1
-      runed: 0.15.2(svelte@5.15.0)
-      svelte: 5.15.0
-      svelte-toolbelt: 0.4.4(svelte@5.15.0)
+      runed: 0.15.2(svelte@5.16.0)
+      svelte: 5.16.0
+      svelte-toolbelt: 0.4.4(svelte@5.16.0)
 
   blake3-wasm@2.1.5: {}
 
@@ -8653,11 +8653,11 @@ snapshots:
     dependencies:
       embla-carousel: 8.1.6
 
-  embla-carousel-svelte@8.1.6(svelte@5.15.0):
+  embla-carousel-svelte@8.1.6(svelte@5.16.0):
     dependencies:
       embla-carousel: 8.1.6
       embla-carousel-reactive-utils: 8.1.6(embla-carousel@8.1.6)
-      svelte: 5.15.0
+      svelte: 5.16.0
 
   embla-carousel@8.1.6: {}
 
@@ -9001,15 +9001,15 @@ snapshots:
 
   eslint-plugin-no-only-tests@3.1.0: {}
 
-  eslint-plugin-perfectionist@2.11.0(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.15.0))(svelte@5.15.0)(typescript@5.6.3)(vue-eslint-parser@9.4.3(eslint@9.7.0)):
+  eslint-plugin-perfectionist@2.11.0(eslint@9.7.0)(svelte-eslint-parser@0.42.0(svelte@5.16.0))(svelte@5.16.0)(typescript@5.6.3)(vue-eslint-parser@9.4.3(eslint@9.7.0)):
     dependencies:
       '@typescript-eslint/utils': 7.16.0(eslint@9.7.0)(typescript@5.6.3)
       eslint: 9.7.0
       minimatch: 9.0.5
       natural-compare-lite: 1.4.0
     optionalDependencies:
-      svelte: 5.15.0
-      svelte-eslint-parser: 0.42.0(svelte@5.15.0)
+      svelte: 5.16.0
+      svelte-eslint-parser: 0.42.0(svelte@5.16.0)
       vue-eslint-parser: 9.4.3(eslint@9.7.0)
     transitivePeerDependencies:
       - supports-color
@@ -9026,7 +9026,7 @@ snapshots:
       regexp-ast-analysis: 0.7.1
       scslre: 0.3.0
 
-  eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.15.0):
+  eslint-plugin-svelte@2.44.1(eslint@9.7.0)(svelte@5.16.0):
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.7.0)
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -9039,9 +9039,9 @@ snapshots:
       postcss-safe-parser: 6.0.0(postcss@8.4.47)
       postcss-selector-parser: 6.1.1
       semver: 7.6.3
-      svelte-eslint-parser: 0.41.1(svelte@5.15.0)
+      svelte-eslint-parser: 0.41.1(svelte@5.16.0)
     optionalDependencies:
-      svelte: 5.15.0
+      svelte: 5.16.0
     transitivePeerDependencies:
       - ts-node
 
@@ -9084,7 +9084,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3)
 
-  eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3)(vitest@2.1.3):
+  eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3))(eslint@9.7.0)(typescript@5.6.3)(vitest@2.1.3(@types/node@20.16.14)(terser@5.36.0)):
     dependencies:
       '@typescript-eslint/utils': 7.16.0(eslint@9.7.0)(typescript@5.6.3)
       eslint: 9.7.0
@@ -9372,11 +9372,11 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
-  formsnap@2.0.0-next.1(svelte@5.15.0)(sveltekit-superforms@2.19.1(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(@types/json-schema@7.0.15)(svelte@5.15.0)):
+  formsnap@2.0.0-next.1(svelte@5.16.0)(sveltekit-superforms@2.19.1(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(@types/json-schema@7.0.15)(svelte@5.16.0)):
     dependencies:
-      svelte: 5.15.0
-      svelte-toolbelt: 0.4.4(svelte@5.15.0)
-      sveltekit-superforms: 2.19.1(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(@types/json-schema@7.0.15)(svelte@5.15.0)
+      svelte: 5.16.0
+      svelte-toolbelt: 0.4.4(svelte@5.16.0)
+      sveltekit-superforms: 2.19.1(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(@types/json-schema@7.0.15)(svelte@5.16.0)
 
   fraction.js@4.3.7: {}
 
@@ -10058,9 +10058,9 @@ snapshots:
 
   lru-cache@7.18.3: {}
 
-  lucide-svelte@0.447.0(svelte@5.15.0):
+  lucide-svelte@0.447.0(svelte@5.16.0):
     dependencies:
-      svelte: 5.15.0
+      svelte: 5.16.0
 
   magic-string@0.25.9:
     dependencies:
@@ -10279,7 +10279,7 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
-  mdsx@0.0.6(svelte@5.15.0):
+  mdsx@0.0.6(svelte@5.16.0):
     dependencies:
       esrap: 1.2.2
       hast-util-to-html: 9.0.1
@@ -10288,7 +10288,7 @@ snapshots:
       rehype-stringify: 10.0.0
       remark-parse: 11.0.0
       remark-rehype: 11.1.0
-      svelte: 5.15.0
+      svelte: 5.16.0
       unified: 11.0.5
       unist-util-visit: 5.0.0
       vfile: 6.0.1
@@ -10657,9 +10657,9 @@ snapshots:
       pkg-types: 1.0.3
       ufo: 1.5.4
 
-  mode-watcher@0.3.1(svelte@5.15.0):
+  mode-watcher@0.3.1(svelte@5.16.0):
     dependencies:
-      svelte: 5.15.0
+      svelte: 5.16.0
 
   mri@1.2.0: {}
 
@@ -10811,10 +10811,10 @@ snapshots:
 
   package-manager-detector@0.2.2: {}
 
-  paneforge@1.0.0-next.1(svelte@5.15.0):
+  paneforge@1.0.0-next.1(svelte@5.16.0):
     dependencies:
-      svelte: 5.15.0
-      svelte-toolbelt: 0.4.4(svelte@5.15.0)
+      svelte: 5.16.0
+      svelte-toolbelt: 0.4.4(svelte@5.16.0)
 
   parent-module@1.0.1:
     dependencies:
@@ -11009,16 +11009,16 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-svelte@3.2.7(prettier@3.3.3)(svelte@5.15.0):
+  prettier-plugin-svelte@3.2.7(prettier@3.3.3)(svelte@5.16.0):
     dependencies:
       prettier: 3.3.3
-      svelte: 5.15.0
+      svelte: 5.16.0
 
-  prettier-plugin-tailwindcss@0.6.8(prettier-plugin-svelte@3.2.7(prettier@3.3.3)(svelte@5.15.0))(prettier@3.3.3):
+  prettier-plugin-tailwindcss@0.6.8(prettier-plugin-svelte@3.2.7(prettier@3.3.3)(svelte@5.16.0))(prettier@3.3.3):
     dependencies:
       prettier: 3.3.3
     optionalDependencies:
-      prettier-plugin-svelte: 3.2.7(prettier@3.3.3)(svelte@5.15.0)
+      prettier-plugin-svelte: 3.2.7(prettier@3.3.3)(svelte@5.16.0)
 
   prettier@2.8.8: {}
 
@@ -11321,10 +11321,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  runed@0.15.2(svelte@5.15.0):
+  runed@0.15.2(svelte@5.16.0):
     dependencies:
       esm-env: 1.2.1
-      svelte: 5.15.0
+      svelte: 5.16.0
 
   rw@1.3.3: {}
 
@@ -11665,19 +11665,19 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.0.5(picomatch@4.0.2)(svelte@5.15.0)(typescript@5.5.3):
+  svelte-check@4.0.5(picomatch@4.0.2)(svelte@5.16.0)(typescript@5.5.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 4.0.1
       fdir: 6.3.0(picomatch@4.0.2)
       picocolors: 1.1.0
       sade: 1.8.1
-      svelte: 5.15.0
+      svelte: 5.16.0
       typescript: 5.5.3
     transitivePeerDependencies:
       - picomatch
 
-  svelte-eslint-parser@0.41.1(svelte@5.15.0):
+  svelte-eslint-parser@0.41.1(svelte@5.16.0):
     dependencies:
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -11685,9 +11685,9 @@ snapshots:
       postcss: 8.4.47
       postcss-scss: 4.0.9(postcss@8.4.47)
     optionalDependencies:
-      svelte: 5.15.0
+      svelte: 5.16.0
 
-  svelte-eslint-parser@0.42.0(svelte@5.15.0):
+  svelte-eslint-parser@0.42.0(svelte@5.16.0):
     dependencies:
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -11695,31 +11695,31 @@ snapshots:
       postcss: 8.4.47
       postcss-scss: 4.0.9(postcss@8.4.47)
     optionalDependencies:
-      svelte: 5.15.0
+      svelte: 5.16.0
 
-  svelte-local-storage-store@0.6.4(svelte@5.15.0):
+  svelte-local-storage-store@0.6.4(svelte@5.16.0):
     dependencies:
-      svelte: 5.15.0
+      svelte: 5.16.0
 
-  svelte-parse-markup@0.1.5(svelte@5.15.0):
+  svelte-parse-markup@0.1.5(svelte@5.16.0):
     dependencies:
-      svelte: 5.15.0
+      svelte: 5.16.0
 
-  svelte-persisted-store@0.11.0(svelte@5.15.0):
+  svelte-persisted-store@0.11.0(svelte@5.16.0):
     dependencies:
-      svelte: 5.15.0
+      svelte: 5.16.0
 
-  svelte-sonner@0.3.25(svelte@5.15.0):
+  svelte-sonner@0.3.25(svelte@5.16.0):
     dependencies:
-      svelte: 5.15.0
+      svelte: 5.16.0
 
-  svelte-toolbelt@0.4.4(svelte@5.15.0):
+  svelte-toolbelt@0.4.4(svelte@5.16.0):
     dependencies:
       clsx: 2.1.1
       style-to-object: 1.0.8
-      svelte: 5.15.0
+      svelte: 5.16.0
 
-  svelte@5.15.0:
+  svelte@5.16.0:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -11728,6 +11728,7 @@ snapshots:
       acorn-typescript: 1.4.13(acorn@8.13.0)
       aria-query: 5.3.2
       axobject-query: 4.1.0
+      clsx: 2.1.1
       esm-env: 1.2.1
       esrap: 1.3.2
       is-reference: 3.0.3
@@ -11735,13 +11736,13 @@ snapshots:
       magic-string: 0.30.12
       zimmerframe: 1.1.2
 
-  sveltekit-superforms@2.19.1(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(@types/json-schema@7.0.15)(svelte@5.15.0):
+  sveltekit-superforms@2.19.1(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(@types/json-schema@7.0.15)(svelte@5.16.0):
     dependencies:
-      '@sveltejs/kit': 2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.15.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
+      '@sveltejs/kit': 2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0)))(svelte@5.16.0)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
       devalue: 5.1.1
       just-clone: 6.2.0
       memoize-weak: 1.0.2
-      svelte: 5.15.0
+      svelte: 5.16.0
       ts-deepmerge: 7.0.1
     optionalDependencies:
       '@exodus/schemasafe': 1.3.0
@@ -12176,11 +12177,11 @@ snapshots:
   validator@13.11.0:
     optional: true
 
-  vaul-svelte@1.0.0-next.2(svelte@5.15.0):
+  vaul-svelte@1.0.0-next.2(svelte@5.16.0):
     dependencies:
-      bits-ui: 1.0.0-next.71(svelte@5.15.0)
-      svelte: 5.15.0
-      svelte-toolbelt: 0.4.4(svelte@5.15.0)
+      bits-ui: 1.0.0-next.71(svelte@5.16.0)
+      svelte: 5.16.0
+      svelte-toolbelt: 0.4.4(svelte@5.16.0)
 
   velite@0.2.0:
     dependencies:
@@ -12317,7 +12318,7 @@ snapshots:
   vitest@2.1.3(@types/node@20.16.14)(terser@5.36.0):
     dependencies:
       '@vitest/expect': 2.1.3
-      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(vite@5.4.9)
+      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(vite@5.4.9(@types/node@20.16.14)(terser@5.36.0))
       '@vitest/pretty-format': 2.1.3
       '@vitest/runner': 2.1.3
       '@vitest/snapshot': 2.1.3

--- a/sites/docs/package.json
+++ b/sites/docs/package.json
@@ -69,7 +69,7 @@
 		"remark-gfm": "^4.0.0",
 		"rimraf": "^4.4.1",
 		"shiki": "^1.2.1",
-		"svelte": "^5.15.0",
+		"svelte": "^5.16.0",
 		"svelte-check": "^4.0.5",
 		"svelte-local-storage-store": "^0.6.4",
 		"svelte-persisted-store": "^0.11.0",

--- a/sites/docs/package.json
+++ b/sites/docs/package.json
@@ -30,7 +30,7 @@
 		"@prettier/sync": "0.3.0",
 		"@sveltejs/adapter-cloudflare": "4.6.1",
 		"@sveltejs/enhanced-img": "^0.3.9",
-		"@sveltejs/kit": "^2.5.28",
+		"@sveltejs/kit": "^2.12.0",
 		"@sveltejs/vite-plugin-svelte": "^4.0.0",
 		"@tanstack/table-core": "^8.20.5",
 		"@types/d3-scale": "^4.0.8",

--- a/sites/docs/src/lib/components/docs/docs-pager.svelte
+++ b/sites/docs/src/lib/components/docs/docs-pager.svelte
@@ -2,7 +2,7 @@
 	import ChevronLeft from "lucide-svelte/icons/chevron-left";
 	import ChevronRight from "lucide-svelte/icons/chevron-right";
 	import type { NavItem, NavItemWithChildren } from "$lib/types/nav.js";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import { Button } from "$lib/registry/new-york/ui/button/index.js";
 	import { docsConfig } from "$lib/config/docs.js";
 
@@ -32,7 +32,7 @@
 			.filter((link) => !link?.disabled);
 	}
 
-	const pager = $derived(getPagerForDoc($page.params.slug));
+	const pager = $derived(getPagerForDoc(page.params.slug));
 </script>
 
 <div class="flex flex-row items-center justify-between">

--- a/sites/docs/src/lib/components/docs/examples-nav/example-code-link.svelte
+++ b/sites/docs/src/lib/components/docs/examples-nav/example-code-link.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import ArrowRight from "lucide-svelte/icons/arrow-right";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import { examples } from "$lib/config/docs.js";
 
 	const example = $derived(
-		examples.find((example) => $page.url.pathname.startsWith(example.href))
+		examples.find((example) => page.url.pathname.startsWith(example.href))
 	);
 </script>
 

--- a/sites/docs/src/lib/components/docs/examples-nav/examples-nav.svelte
+++ b/sites/docs/src/lib/components/docs/examples-nav/examples-nav.svelte
@@ -2,7 +2,7 @@
 	import { cubicInOut } from "svelte/easing";
 	import { crossfade } from "svelte/transition";
 	import ExampleCodeLink from "./example-code-link.svelte";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import { examples } from "$lib/config/docs.js";
 	import { type PrimitiveElementAttributes, cn } from "$lib/utils.js";
 	import { ScrollArea } from "$lib/registry/new-york/ui/scroll-area/index.js";
@@ -24,8 +24,8 @@
 			>
 				{#each examples as example, index (index)}
 					{@const isActive =
-						$page.url.pathname.startsWith(example.href) ||
-						($page.url.pathname === "/" && index === 0)}
+						page.url.pathname.startsWith(example.href) ||
+						(page.url.pathname === "/" && index === 0)}
 
 					<a
 						href={example.href}

--- a/sites/docs/src/lib/components/docs/metadata.svelte
+++ b/sites/docs/src/lib/components/docs/metadata.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import { dev } from "$app/environment";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import { siteConfig } from "$lib/config/site.js";
 
 	const title = $derived(
-		$page.data?.title ? `${$page.data.title} - ${siteConfig.name}` : siteConfig.name
+		page.data?.title ? `${page.data.title} - ${siteConfig.name}` : siteConfig.name
 	);
 </script>
 
@@ -22,7 +22,7 @@
 	<meta name="twitter:creator" content="huntabyte" />
 	<meta property="og:title" content={title} />
 	<meta property="og:type" content="article" />
-	<meta property="og:url" content={siteConfig.url + $page.url.pathname} />
+	<meta property="og:url" content={siteConfig.url + page.url.pathname} />
 	<meta property="og:image" content={siteConfig.ogImage} />
 	<meta property="og:image:alt" content={siteConfig.name} />
 	<meta property="og:image:width" content="1200" />

--- a/sites/docs/src/lib/components/docs/nav/docs-sidebar-nav-items.svelte
+++ b/sites/docs/src/lib/components/docs/nav/docs-sidebar-nav-items.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { SidebarNavItem } from "$lib/types/nav.js";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import { cn } from "$lib/utils.js";
 
 	let { items }: { items: SidebarNavItem[] } = $props();
@@ -15,7 +15,7 @@
 					class={cn(
 						"group flex w-full items-center rounded-md border border-transparent px-2 py-1 hover:underline",
 						item.disabled && "cursor-not-allowed opacity-60",
-						$page.url.pathname === item.href
+						page.url.pathname === item.href
 							? "text-foreground font-medium"
 							: "text-muted-foreground"
 					)}

--- a/sites/docs/src/lib/components/docs/nav/main-nav.svelte
+++ b/sites/docs/src/lib/components/docs/nav/main-nav.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import * as Icon from "../icons/index.js";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import { siteConfig } from "$lib/config/site.js";
 	import { cn } from "$lib/utils.js";
 </script>
@@ -17,7 +17,7 @@
 			href="/docs"
 			class={cn(
 				"hover:text-foreground/80 transition-colors",
-				$page.url.pathname === "/docs" ? "text-foreground" : "text-foreground/60"
+				page.url.pathname === "/docs" ? "text-foreground" : "text-foreground/60"
 			)}
 		>
 			Docs
@@ -26,7 +26,7 @@
 			href="/docs/components"
 			class={cn(
 				"hover:text-foreground/80 transition-colors",
-				$page.url.pathname.startsWith("/docs/components")
+				page.url.pathname.startsWith("/docs/components")
 					? "text-foreground"
 					: "text-foreground/60"
 			)}
@@ -37,7 +37,7 @@
 			href="/blocks"
 			class={cn(
 				"hover:text-foreground/80 transition-colors",
-				$page.url.pathname.startsWith("/blocks") ? "text-foreground" : "text-foreground/60"
+				page.url.pathname.startsWith("/blocks") ? "text-foreground" : "text-foreground/60"
 			)}
 		>
 			Blocks
@@ -46,7 +46,7 @@
 			href="/themes"
 			class={cn(
 				"hover:text-foreground/80 transition-colors",
-				$page.url.pathname.startsWith("/themes") ? "text-foreground" : "text-foreground/60"
+				page.url.pathname.startsWith("/themes") ? "text-foreground" : "text-foreground/60"
 			)}
 		>
 			Themes
@@ -55,7 +55,7 @@
 			href="/examples"
 			class={cn(
 				"hover:text-foreground/80 transition-colors",
-				$page.url.pathname.startsWith("/examples")
+				page.url.pathname.startsWith("/examples")
 					? "text-foreground"
 					: "text-foreground/60"
 			)}
@@ -67,7 +67,7 @@
 			href="/colors"
 			class={cn(
 				"hover:text-foreground/80 transition-colors",
-				$page.url.pathname.startsWith("/colors") ? "text-foreground" : "text-foreground/60"
+				page.url.pathname.startsWith("/colors") ? "text-foreground" : "text-foreground/60"
 			)}
 		>
 			Colors

--- a/sites/docs/src/lib/components/docs/nav/main-nav.svelte
+++ b/sites/docs/src/lib/components/docs/nav/main-nav.svelte
@@ -55,9 +55,7 @@
 			href="/examples"
 			class={cn(
 				"hover:text-foreground/80 transition-colors",
-				page.url.pathname.startsWith("/examples")
-					? "text-foreground"
-					: "text-foreground/60"
+				page.url.pathname.startsWith("/examples") ? "text-foreground" : "text-foreground/60"
 			)}
 		>
 			Examples

--- a/sites/docs/src/lib/components/docs/nav/mobile-link.svelte
+++ b/sites/docs/src/lib/components/docs/nav/mobile-link.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import { type PrimitiveAnchorAttributes, cn } from "$lib/utils.js";
 
 	let {
@@ -17,7 +17,7 @@
 
 <a
 	{href}
-	class={cn($page.url.pathname === href ? "text-foreground" : "text-foreground/60", className)}
+	class={cn(page.url.pathname === href ? "text-foreground" : "text-foreground/60", className)}
 	onclick={handleClick}
 	{...restProps}
 >

--- a/sites/docs/src/lib/registry/default/example/checkbox-form-multiple.svelte
+++ b/sites/docs/src/lib/registry/default/example/checkbox-form-multiple.svelte
@@ -41,11 +41,11 @@
 	import { zodClient } from "sveltekit-superforms/adapters";
 	import { toast } from "svelte-sonner";
 	import { browser } from "$app/environment";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import * as Form from "$lib/registry/default/ui/form/index.js";
 	import { Checkbox } from "$lib/registry/default/ui/checkbox/index.js";
 
-	let { form: data = $page.data.checkboxMultiple }: { form: SuperValidated<Infer<FormSchema>> } =
+	let { form: data = page.data.checkboxMultiple }: { form: SuperValidated<Infer<FormSchema>> } =
 		$props();
 
 	const form = superForm(data, {

--- a/sites/docs/src/lib/registry/default/example/combobox-form.svelte
+++ b/sites/docs/src/lib/registry/default/example/combobox-form.svelte
@@ -33,13 +33,13 @@
 	import { toast } from "svelte-sonner";
 	import { useId } from "bits-ui";
 	import { browser } from "$app/environment";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import * as Form from "$lib/registry/default/ui/form/index.js";
 	import * as Popover from "$lib/registry/default/ui/popover/index.js";
 	import * as Command from "$lib/registry/default/ui/command/index.js";
 	import { cn } from "$lib/utils.js";
 	import { buttonVariants } from "$lib/registry/default/ui/button/index.js";
-	let data: SuperValidated<Infer<FormSchema>> = $page.data.combobox;
+	let data: SuperValidated<Infer<FormSchema>> = page.data.combobox;
 	export { data as form };
 
 	const form = superForm(data, {

--- a/sites/docs/src/lib/registry/default/example/date-picker-form.svelte
+++ b/sites/docs/src/lib/registry/default/example/date-picker-form.svelte
@@ -23,13 +23,13 @@
 	import { zodClient } from "sveltekit-superforms/adapters";
 	import { toast } from "svelte-sonner";
 	import { browser } from "$app/environment";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import { cn } from "$lib/utils.js";
 	import { Button, buttonVariants } from "$lib/registry/default/ui/button/index.js";
 	import { Calendar } from "$lib/registry/default/ui/calendar/index.js";
 	import * as Popover from "$lib/registry/default/ui/popover/index.js";
 	import * as Form from "$lib/registry/default/ui/form/index.js";
-	let data: SuperValidated<Infer<FormSchema>> = $page.data.datePicker;
+	let data: SuperValidated<Infer<FormSchema>> = page.data.datePicker;
 	export { data as form };
 
 	const form = superForm(data, {

--- a/sites/docs/src/lib/registry/default/example/form-demo.svelte
+++ b/sites/docs/src/lib/registry/default/example/form-demo.svelte
@@ -14,9 +14,9 @@
 	import { browser } from "$app/environment";
 	import * as Form from "$lib/registry/default/ui/form/index.js";
 	import { Input } from "$lib/registry/default/ui/input/index.js";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 
-	let { form: data = $page.data.username }: { form: SuperValidated<Infer<FormSchema>> } =
+	let { form: data = page.data.username }: { form: SuperValidated<Infer<FormSchema>> } =
 		$props();
 
 	const form = superForm(data, {

--- a/sites/docs/src/lib/registry/default/example/form-demo.svelte
+++ b/sites/docs/src/lib/registry/default/example/form-demo.svelte
@@ -16,8 +16,7 @@
 	import { Input } from "$lib/registry/default/ui/input/index.js";
 	import { page } from "$app/state";
 
-	let { form: data = page.data.username }: { form: SuperValidated<Infer<FormSchema>> } =
-		$props();
+	let { form: data = page.data.username }: { form: SuperValidated<Infer<FormSchema>> } = $props();
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/sites/docs/src/lib/registry/default/example/input-otp-form.svelte
+++ b/sites/docs/src/lib/registry/default/example/input-otp-form.svelte
@@ -15,9 +15,9 @@
 	import { browser } from "$app/environment";
 	import * as InputOTP from "$lib/registry/default/ui/input-otp/index.js";
 	import * as Form from "$lib/registry/default/ui/form/index.js";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 
-	let { form: data = $page.data.inputOtp }: { form: SuperValidated<Infer<FormSchema>> } =
+	let { form: data = page.data.inputOtp }: { form: SuperValidated<Infer<FormSchema>> } =
 		$props();
 
 	const form = superForm(data, {

--- a/sites/docs/src/lib/registry/default/example/input-otp-form.svelte
+++ b/sites/docs/src/lib/registry/default/example/input-otp-form.svelte
@@ -17,8 +17,7 @@
 	import * as Form from "$lib/registry/default/ui/form/index.js";
 	import { page } from "$app/state";
 
-	let { form: data = page.data.inputOtp }: { form: SuperValidated<Infer<FormSchema>> } =
-		$props();
+	let { form: data = page.data.inputOtp }: { form: SuperValidated<Infer<FormSchema>> } = $props();
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/sites/docs/src/lib/registry/default/example/radio-group-form.svelte
+++ b/sites/docs/src/lib/registry/default/example/radio-group-form.svelte
@@ -14,11 +14,11 @@
 	import { zodClient } from "sveltekit-superforms/adapters";
 	import { toast } from "svelte-sonner";
 	import { browser } from "$app/environment";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import * as Form from "$lib/registry/default/ui/form/index.js";
 	import * as RadioGroup from "$lib/registry/default/ui/radio-group/index.js";
 
-	let { form: data = $page.data.radioGroup }: { form: SuperValidated<Infer<FormSchema>> } =
+	let { form: data = page.data.radioGroup }: { form: SuperValidated<Infer<FormSchema>> } =
 		$props();
 
 	const form = superForm(data, {

--- a/sites/docs/src/lib/registry/default/example/select-form.svelte
+++ b/sites/docs/src/lib/registry/default/example/select-form.svelte
@@ -13,11 +13,11 @@
 	import { zodClient } from "sveltekit-superforms/adapters";
 	import { toast } from "svelte-sonner";
 	import { browser } from "$app/environment";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import * as Form from "$lib/registry/default/ui/form/index.js";
 	import * as Select from "$lib/registry/default/ui/select/index.js";
 
-	let { form: data = $page.data.select }: { form: SuperValidated<Infer<FormSchema>> } = $props();
+	let { form: data = page.data.select }: { form: SuperValidated<Infer<FormSchema>> } = $props();
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/sites/docs/src/lib/registry/default/example/switch-form.svelte
+++ b/sites/docs/src/lib/registry/default/example/switch-form.svelte
@@ -12,11 +12,11 @@
 	import { zodClient } from "sveltekit-superforms/adapters";
 	import { toast } from "svelte-sonner";
 	import { browser } from "$app/environment";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import * as Form from "$lib/registry/default/ui/form/index.js";
 	import { Switch } from "$lib/registry/default/ui/switch/index.js";
 
-	let { form: data = $page.data.switch }: { form: SuperValidated<Infer<FormSchema>> } = $props();
+	let { form: data = page.data.switch }: { form: SuperValidated<Infer<FormSchema>> } = $props();
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/sites/docs/src/lib/registry/default/example/textarea-form.svelte
+++ b/sites/docs/src/lib/registry/default/example/textarea-form.svelte
@@ -18,8 +18,7 @@
 	import * as Form from "$lib/registry/default/ui/form/index.js";
 	import { Textarea } from "$lib/registry/default/ui/textarea/index.js";
 
-	let { form: data = page.data.textarea }: { form: SuperValidated<Infer<FormSchema>> } =
-		$props();
+	let { form: data = page.data.textarea }: { form: SuperValidated<Infer<FormSchema>> } = $props();
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/sites/docs/src/lib/registry/default/example/textarea-form.svelte
+++ b/sites/docs/src/lib/registry/default/example/textarea-form.svelte
@@ -14,11 +14,11 @@
 	import { zodClient } from "sveltekit-superforms/adapters";
 	import { toast } from "svelte-sonner";
 	import { browser } from "$app/environment";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import * as Form from "$lib/registry/default/ui/form/index.js";
 	import { Textarea } from "$lib/registry/default/ui/textarea/index.js";
 
-	let { form: data = $page.data.textarea }: { form: SuperValidated<Infer<FormSchema>> } =
+	let { form: data = page.data.textarea }: { form: SuperValidated<Infer<FormSchema>> } =
 		$props();
 
 	const form = superForm(data, {

--- a/sites/docs/src/lib/registry/default/ui/badge/badge.svelte
+++ b/sites/docs/src/lib/registry/default/ui/badge/badge.svelte
@@ -43,7 +43,7 @@
 	this={href ? "a" : "span"}
 	bind:this={ref}
 	{href}
-	class={cn(badgeVariants({ variant, className }))}
+	class={cn(badgeVariants({ variant }), className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/sites/docs/src/lib/registry/default/ui/button/button.svelte
+++ b/sites/docs/src/lib/registry/default/ui/button/button.svelte
@@ -56,7 +56,7 @@
 {#if href}
 	<a
 		bind:this={ref}
-		class={cn(buttonVariants({ variant, size, className }))}
+		class={cn(buttonVariants({ variant, size }), className)}
 		{href}
 		{...restProps}
 	>
@@ -65,7 +65,7 @@
 {:else}
 	<button
 		bind:this={ref}
-		class={cn(buttonVariants({ variant, size, className }))}
+		class={cn(buttonVariants({ variant, size }), className)}
 		{type}
 		{...restProps}
 	>

--- a/sites/docs/src/lib/registry/default/ui/toggle/toggle.svelte
+++ b/sites/docs/src/lib/registry/default/ui/toggle/toggle.svelte
@@ -46,6 +46,6 @@
 <TogglePrimitive.Root
 	bind:ref
 	bind:pressed
-	class={cn(toggleVariants({ variant, size, className }))}
+	class={cn(toggleVariants({ variant, size }), className)}
 	{...restProps}
 />

--- a/sites/docs/src/lib/registry/new-york/example/checkbox-form-multiple.svelte
+++ b/sites/docs/src/lib/registry/new-york/example/checkbox-form-multiple.svelte
@@ -41,11 +41,11 @@
 	import { zodClient } from "sveltekit-superforms/adapters";
 	import { toast } from "svelte-sonner";
 	import { browser } from "$app/environment";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import * as Form from "$lib/registry/new-york/ui/form/index.js";
 	import { Checkbox } from "$lib/registry/new-york/ui/checkbox/index.js";
 
-	let { form: data = $page.data.checkboxMultiple }: { form: SuperValidated<Infer<FormSchema>> } =
+	let { form: data = page.data.checkboxMultiple }: { form: SuperValidated<Infer<FormSchema>> } =
 		$props();
 
 	const form = superForm(data, {

--- a/sites/docs/src/lib/registry/new-york/example/combobox-form.svelte
+++ b/sites/docs/src/lib/registry/new-york/example/combobox-form.svelte
@@ -33,14 +33,14 @@
 	import { toast } from "svelte-sonner";
 	import { useId } from "bits-ui";
 	import { browser } from "$app/environment";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import * as Form from "$lib/registry/new-york/ui/form/index.js";
 	import * as Popover from "$lib/registry/new-york/ui/popover/index.js";
 	import * as Command from "$lib/registry/new-york/ui/command/index.js";
 	import { cn } from "$lib/utils.js";
 	import { buttonVariants } from "$lib/registry/new-york/ui/button/index.js";
 
-	let { form: data = $page.data.combobox }: { form: SuperValidated<Infer<FormSchema>> } =
+	let { form: data = page.data.combobox }: { form: SuperValidated<Infer<FormSchema>> } =
 		$props();
 
 	const form = superForm(data, {

--- a/sites/docs/src/lib/registry/new-york/example/combobox-form.svelte
+++ b/sites/docs/src/lib/registry/new-york/example/combobox-form.svelte
@@ -40,8 +40,7 @@
 	import { cn } from "$lib/utils.js";
 	import { buttonVariants } from "$lib/registry/new-york/ui/button/index.js";
 
-	let { form: data = page.data.combobox }: { form: SuperValidated<Infer<FormSchema>> } =
-		$props();
+	let { form: data = page.data.combobox }: { form: SuperValidated<Infer<FormSchema>> } = $props();
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/sites/docs/src/lib/registry/new-york/example/date-picker-form.svelte
+++ b/sites/docs/src/lib/registry/new-york/example/date-picker-form.svelte
@@ -23,14 +23,14 @@
 	import { zodClient } from "sveltekit-superforms/adapters";
 	import { toast } from "svelte-sonner";
 	import { browser } from "$app/environment";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import { cn } from "$lib/utils.js";
 	import { Button } from "$lib/registry/new-york/ui/button/index.js";
 	import { Calendar } from "$lib/registry/new-york/ui/calendar/index.js";
 	import * as Popover from "$lib/registry/new-york/ui/popover/index.js";
 	import * as Form from "$lib/registry/new-york/ui/form/index.js";
 
-	let { form: data = $page.data.datePicker }: { form: SuperValidated<Infer<FormSchema>> } =
+	let { form: data = page.data.datePicker }: { form: SuperValidated<Infer<FormSchema>> } =
 		$props();
 
 	const form = superForm(data, {

--- a/sites/docs/src/lib/registry/new-york/example/form-demo.svelte
+++ b/sites/docs/src/lib/registry/new-york/example/form-demo.svelte
@@ -14,9 +14,9 @@
 	import { browser } from "$app/environment";
 	import * as Form from "$lib/registry/new-york/ui/form/index.js";
 	import { Input } from "$lib/registry/new-york/ui/input/index.js";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 
-	let { form: data = $page.data.form }: { form: SuperValidated<Infer<FormSchema>> } = $props();
+	let { form: data = page.data.form }: { form: SuperValidated<Infer<FormSchema>> } = $props();
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/sites/docs/src/lib/registry/new-york/example/input-otp-form.svelte
+++ b/sites/docs/src/lib/registry/new-york/example/input-otp-form.svelte
@@ -17,8 +17,7 @@
 	import * as Form from "$lib/registry/new-york/ui/form/index.js";
 	import { page } from "$app/state";
 
-	let { form: data = page.data.inputOtp }: { form: SuperValidated<Infer<FormSchema>> } =
-		$props();
+	let { form: data = page.data.inputOtp }: { form: SuperValidated<Infer<FormSchema>> } = $props();
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/sites/docs/src/lib/registry/new-york/example/input-otp-form.svelte
+++ b/sites/docs/src/lib/registry/new-york/example/input-otp-form.svelte
@@ -15,9 +15,9 @@
 	import { browser } from "$app/environment";
 	import * as InputOTP from "$lib/registry/new-york/ui/input-otp/index.js";
 	import * as Form from "$lib/registry/new-york/ui/form/index.js";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 
-	let { form: data = $page.data.inputOtp }: { form: SuperValidated<Infer<FormSchema>> } =
+	let { form: data = page.data.inputOtp }: { form: SuperValidated<Infer<FormSchema>> } =
 		$props();
 
 	const form = superForm(data, {

--- a/sites/docs/src/lib/registry/new-york/example/radio-group-form.svelte
+++ b/sites/docs/src/lib/registry/new-york/example/radio-group-form.svelte
@@ -14,11 +14,11 @@
 	import { zodClient } from "sveltekit-superforms/adapters";
 	import { toast } from "svelte-sonner";
 	import { browser } from "$app/environment";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import * as Form from "$lib/registry/new-york/ui/form/index.js";
 	import * as RadioGroup from "$lib/registry/new-york/ui/radio-group/index.js";
 
-	let { form: data = $page.data.radioGroup }: { form: SuperValidated<Infer<FormSchema>> } =
+	let { form: data = page.data.radioGroup }: { form: SuperValidated<Infer<FormSchema>> } =
 		$props();
 
 	const form = superForm(data, {

--- a/sites/docs/src/lib/registry/new-york/example/select-form.svelte
+++ b/sites/docs/src/lib/registry/new-york/example/select-form.svelte
@@ -13,11 +13,11 @@
 	import { zodClient } from "sveltekit-superforms/adapters";
 	import { toast } from "svelte-sonner";
 	import { browser } from "$app/environment";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import * as Form from "$lib/registry/new-york/ui/form/index.js";
 	import * as Select from "$lib/registry/new-york/ui/select/index.js";
 
-	let { form: data = $page.data.select }: { form: SuperValidated<Infer<FormSchema>> } = $props();
+	let { form: data = page.data.select }: { form: SuperValidated<Infer<FormSchema>> } = $props();
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/sites/docs/src/lib/registry/new-york/example/switch-form.svelte
+++ b/sites/docs/src/lib/registry/new-york/example/switch-form.svelte
@@ -12,11 +12,11 @@
 	import { zodClient } from "sveltekit-superforms/adapters";
 	import { toast } from "svelte-sonner";
 	import { browser } from "$app/environment";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import * as Form from "$lib/registry/new-york/ui/form/index.js";
 	import { Switch } from "$lib/registry/new-york/ui/switch/index.js";
 
-	let { form: data = $page.data.switch }: { form: SuperValidated<Infer<FormSchema>> } = $props();
+	let { form: data = page.data.switch }: { form: SuperValidated<Infer<FormSchema>> } = $props();
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/sites/docs/src/lib/registry/new-york/example/textarea-form.svelte
+++ b/sites/docs/src/lib/registry/new-york/example/textarea-form.svelte
@@ -18,8 +18,7 @@
 	import * as Form from "$lib/registry/new-york/ui/form/index.js";
 	import { Textarea } from "$lib/registry/new-york/ui/textarea/index.js";
 
-	let { form: data = page.data.textarea }: { form: SuperValidated<Infer<FormSchema>> } =
-		$props();
+	let { form: data = page.data.textarea }: { form: SuperValidated<Infer<FormSchema>> } = $props();
 
 	const form = superForm(data, {
 		validators: zodClient(formSchema),

--- a/sites/docs/src/lib/registry/new-york/example/textarea-form.svelte
+++ b/sites/docs/src/lib/registry/new-york/example/textarea-form.svelte
@@ -14,11 +14,11 @@
 	import { zodClient } from "sveltekit-superforms/adapters";
 	import { toast } from "svelte-sonner";
 	import { browser } from "$app/environment";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import * as Form from "$lib/registry/new-york/ui/form/index.js";
 	import { Textarea } from "$lib/registry/new-york/ui/textarea/index.js";
 
-	let { form: data = $page.data.textarea }: { form: SuperValidated<Infer<FormSchema>> } =
+	let { form: data = page.data.textarea }: { form: SuperValidated<Infer<FormSchema>> } =
 		$props();
 
 	const form = superForm(data, {

--- a/sites/docs/src/lib/registry/new-york/ui/badge/badge.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/badge/badge.svelte
@@ -42,7 +42,7 @@
 	this={href ? "a" : "span"}
 	bind:this={ref}
 	{href}
-	class={cn(badgeVariants({ variant, className }))}
+	class={cn(badgeVariants({ variant }), className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/sites/docs/src/lib/registry/new-york/ui/button/button.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/button/button.svelte
@@ -57,7 +57,7 @@
 {#if href}
 	<a
 		bind:this={ref}
-		class={cn(buttonVariants({ variant, size, className }))}
+		class={cn(buttonVariants({ variant, size }), className)}
 		{href}
 		{...restProps}
 	>
@@ -66,7 +66,7 @@
 {:else}
 	<button
 		bind:this={ref}
-		class={cn(buttonVariants({ variant, size, className }))}
+		class={cn(buttonVariants({ variant, size }), className)}
 		{type}
 		{...restProps}
 	>

--- a/sites/docs/src/lib/registry/new-york/ui/toggle/toggle.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/toggle/toggle.svelte
@@ -46,6 +46,6 @@
 <TogglePrimitive.Root
 	bind:ref
 	bind:pressed
-	class={cn(toggleVariants({ variant, size, className }))}
+	class={cn(toggleVariants({ variant, size }), className)}
 	{...restProps}
 />

--- a/sites/docs/src/routes/(app)/docs/+page.svelte
+++ b/sites/docs/src/routes/(app)/docs/+page.svelte
@@ -2,7 +2,7 @@
 	import ChevronRight from "lucide-svelte/icons/chevron-right";
 	import type { PageData } from "./$types.js";
 	import Carbon from "$lib/components/docs/carbon.svelte";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import DocsPager from "$lib/components/docs/docs-pager.svelte";
 	import TableOfContents from "$lib/components/docs/table-of-contents.svelte";
 	import { cn } from "$lib/utils.js";
@@ -39,7 +39,7 @@
 	</div>
 	<div class="hidden text-sm xl:block">
 		<div class="sticky top-16 -mt-10 h-[calc(100vh-3.5rem)] overflow-hidden pt-6">
-			{#key $page.url.pathname}
+			{#key page.url.pathname}
 				<TableOfContents />
 			{/key}
 			<div class="z-10 pt-4">

--- a/sites/docs/src/routes/(app)/docs/[...slug]/+page.svelte
+++ b/sites/docs/src/routes/(app)/docs/[...slug]/+page.svelte
@@ -10,7 +10,7 @@
 	import { badgeVariants } from "$lib/registry/new-york/ui/badge/index.js";
 	import { cn } from "$lib/utils.js";
 	import Carbon from "$lib/components/docs/carbon.svelte";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 
 	let { data }: { data: PageData } = $props();
 
@@ -85,7 +85,7 @@
 	<div class="hidden text-sm xl:block">
 		<div class="sticky top-14 -mt-10 h-[calc(100vh-3.5rem)] py-8">
 			<ScrollArea class="h-full">
-				{#key $page.url.pathname}
+				{#key page.url.pathname}
 					<TableOfContents />
 				{/key}
 				<Carbon />

--- a/sites/docs/src/routes/(app)/examples/forms/(components)/sidebar-nav.svelte
+++ b/sites/docs/src/routes/(app)/examples/forms/(components)/sidebar-nav.svelte
@@ -2,7 +2,7 @@
 	import { cubicInOut } from "svelte/easing";
 	import { crossfade } from "svelte/transition";
 	import { cn } from "$lib/utils.js";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import { Button } from "$lib/registry/new-york/ui/button/index.js";
 
 	let { items, class: className }: { items: { href: string; title: string }[]; class?: string } =
@@ -16,7 +16,7 @@
 
 <nav class={cn("flex space-x-2 lg:flex-col lg:space-x-0 lg:space-y-1", className)}>
 	{#each items as item}
-		{@const isActive = $page.url.pathname === item.href}
+		{@const isActive = page.url.pathname === item.href}
 		<Button
 			href={item.href}
 			variant="ghost"

--- a/sites/docs/src/routes/+layout.svelte
+++ b/sites/docs/src/routes/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { ModeWatcher } from "mode-watcher";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import Metadata from "$lib/components/docs/metadata.svelte";
 	import { updateTheme } from "$lib/utils.js";
 	import "../styles/globals.css";
@@ -16,7 +16,7 @@
 	setPackageManager();
 
 	$effect(() => {
-		updateTheme($config.theme, $page.url.pathname);
+		updateTheme($config.theme, page.url.pathname);
 	});
 </script>
 


### PR DESCRIPTION
Fixes #1582

This has always been an issue on next but I think it was only now noticed after the types for the `class` prop changed in [5.16.0](https://github.com/sveltejs/svelte/releases/tag/svelte%405.16.0).

## Also
- Bumps deps
- Runs `app-state` migration since `$page` will now show deprecated warning