### PR TITLE
Fix: Sheet overlay - TypeError: Cannot redefine property: class

### DIFF
--- a/sites/docs/src/lib/registry/default/ui/sheet/sheet-overlay.svelte
+++ b/sites/docs/src/lib/registry/default/ui/sheet/sheet-overlay.svelte
@@ -8,7 +8,8 @@
 		...restProps
 	}: SheetPrimitive.OverlayProps = $props();
 
-	export { className as class };
+	//removed export { className as class } since it is already exported by props
+
 </script>
 
 <SheetPrimitive.Overlay


### PR DESCRIPTION
**Describe issue**
Sheet overlay has a bug and causes site to crash. 

**Using**
npm info using npm@10.9.0
npm info using node@v22.12.0
"bits-ui": "^1.0.0-next.77"
"svelte": "^5.0.0",
shadcn-svelte@next

**Error stack**
TypeError: Cannot redefine property: class
    at defineProperty (<anonymous>)
    at chunk-DU37TRKP.js?v=a56227c5:3578:5
    at Array.forEach (<anonymous>)
    at Module.create_custom_element (chunk-DU37TRKP.js?v=a56227c5:3577:11)
    at sheet-overlay.svelte:6:23


**Proposal for fix**
remove `export { className as class };` in line 11
class is already exported using $props() 

**Changes made**
Removed the export line.