### PR TITLE
fix: disable bg-accent from range-calendar-cell when it is the highlighted element

### DIFF
--- a/sites/docs/src/lib/registry/default/ui/range-calendar/range-calendar-cell.svelte
+++ b/sites/docs/src/lib/registry/default/ui/range-calendar/range-calendar-cell.svelte
@@ -12,7 +12,7 @@
 <RangeCalendarPrimitive.Cell
 	{date}
 	class={cn(
-		"[&:has([data-selected])]:bg-accent [&:has([data-selected][data-outside-month])]:bg-accent/50 relative h-9 w-9 p-0 text-center text-sm focus-within:relative focus-within:z-20 first:[&:has([data-selected])]:rounded-l-md last:[&:has([data-selected])]:rounded-r-md [&:has([data-selected][data-selection-end])]:rounded-r-md [&:has([data-selected][data-selection-start])]:rounded-l-md",
+		"[&:has([data-selected]):not(:has([data-highlighted]))]:bg-accent [&:has([data-selected][data-outside-month])]:bg-accent/50 relative h-9 w-9 p-0 text-center text-sm focus-within:relative focus-within:z-20 first:[&:has([data-selected])]:rounded-l-md last:[&:has([data-selected])]:rounded-r-md [&:has([data-selected][data-selection-end])]:rounded-r-md [&:has([data-selected][data-selection-start])]:rounded-l-md",
 		className
 	)}
 	{...$$restProps}


### PR DESCRIPTION
Resolves https://github.com/huntabyte/shadcn-svelte/issues/1587
