### PR TITLE
docs: Update the installation documentation for svelte shadcn/ui when using vite.

### DIFF
--- a/sites/docs/src/content/installation/vite.md
+++ b/sites/docs/src/content/installation/vite.md
@@ -22,9 +22,11 @@ Use the Svelte CLI to add Tailwind CSS to your project.
 
 <PMInstall />
 
-### Setup path aliases
+### Edit tsconfig.json file
 
-Update your path aliases in your `tsconfig.json` and `vite.config.ts`.
+The current version of Vite splits TypeScript configuration into three files, two of which need to be edited.
+Add the `baseUrl` and `paths` properties to the `compilerOptions` section of the `tsconfig.json` and
+`tsconfig.app.json` files:
 
 ```json title="tsconfig.json" {3-7}
 {
@@ -37,6 +39,35 @@ Update your path aliases in your `tsconfig.json` and `vite.config.ts`.
   }
 }
 ```
+
+### Edit tsconfig.app.json file
+
+Add the following code to the `tsconfig.app.json` file to resolve paths, for your IDE:
+
+```ts title="tsconfig.app.json" {11-17}
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "$lib": ["./src/lib"],
+      "$lib/*": ["./src/lib/*"]
+    }
+  }
+}
+```
+
+### Update vite.config.ts
+
+Add the following code to the vite.config.ts so your app can resolve paths without error:
 
 ```js title="vite.config.ts" {1, 5-9}
 import path from "path";


### PR DESCRIPTION
In the latest version of Vite, tsconfig.json has been split into three parts.

- tsconfig.app.json
- tsconfig.json
- tsconfig.node.json

Both tsconfig.app.json and tsconfig.json need to configure path aliases. In fact, the React version of shadcn/ui has already fixed this issue, so the documentation error also needs to be fixed in the Svelte version.

<img width="747" alt="image" src="https://github.com/user-attachments/assets/fe20036b-a38a-4c4a-9eb8-93f61a1f94f2" />
<img width="764" alt="image" src="https://github.com/user-attachments/assets/642fe5bd-4aef-44de-a047-3ec9f50f7218" />
