### PR TITLE
fix: replace hard coded components path with the resolved path

### DIFF
--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -81,7 +81,7 @@ async function runUpdate(cwd: string, config: cliConfig.Config, options: UpdateO
 	const components = options.components;
 	const registryIndex = await registry.getRegistryIndex();
 
-	const componentDir = path.resolve(config.resolvedPaths.components, "ui");
+	const componentDir = path.resolve(config.resolvedPaths.ui);
 	if (!existsSync(componentDir)) {
 		throw error(`Component directory ${color.cyan(componentDir)} does not exist.`);
 	}

--- a/packages/cli/test/fixtures/config-custom/components.json
+++ b/packages/cli/test/fixtures/config-custom/components.json
@@ -1,0 +1,16 @@
+{
+	"style": "new-york",
+	"tailwind": {
+		"config": "custom-tailwind.config.js",
+		"css": "src/custom-app.pcss",
+		"baseColor": "zinc"
+	},
+	"aliases": {
+		"components": "$lib/custom-components",
+		"utils": "$lib/custom-utils",
+		"ui": "$lib/components/custom-ui",
+		"hooks": "$lib/custom-hooks"
+	},
+	"typescript": true,
+	"registry": "https://next.shadcn-svelte.com/registry"
+}

--- a/packages/cli/test/fixtures/config-custom/package.json
+++ b/packages/cli/test/fixtures/config-custom/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "test-cli-config-full",
+	"version": "0.0.0",
+	"private": true,
+	"devDependencies": {
+		"@sveltejs/adapter-auto": "^3.0.0",
+		"@sveltejs/kit": "^2.0.0",
+		"@sveltejs/vite-plugin-svelte": "^3.0.0",
+		"svelte": "^4.2.7",
+		"svelte-check": "^3.6.0",
+		"tslib": "^2.4.1",
+		"typescript": "^5.0.0",
+		"vite": "^5.0.3"
+	},
+	"type": "module"
+}

--- a/packages/cli/test/fixtures/config-custom/tsconfig.json
+++ b/packages/cli/test/fixtures/config-custom/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"extends": "./.svelte-kit/tsconfig.json",
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"skipLibCheck": true,
+		"sourceMap": true,
+		"strict": true,
+		"moduleResolution": "bundler"
+	}
+}

--- a/packages/cli/test/utils/get-config.spec.ts
+++ b/packages/cli/test/utils/get-config.spec.ts
@@ -175,4 +175,32 @@ describe("getConfig", () => {
 			registry: `${SITE_BASE_URL}/registry`,
 		});
 	});
+
+	it("handles cases where a full custom config is present", async () => {
+		expect(await getConf("config-custom")).toEqual({
+			style: "new-york",
+			tailwind: {
+				config: "custom-tailwind.config.js",
+				css: "src/custom-app.pcss",
+				baseColor: "zinc",
+			},
+			aliases: {
+				components: "$lib/custom-components",
+				utils: "$lib/custom-utils",
+				ui: "$lib/components/custom-ui",
+				hooks: "$lib/custom-hooks",
+			},
+			resolvedPaths: {
+				tailwindConfig: resolvePath("../fixtures/config-custom/custom-tailwind.config.js"),
+				tailwindCss: resolvePath("../fixtures/config-custom/src/custom-app.pcss"),
+				cwd: resolvePath("../fixtures/config-custom"),
+				components: resolvePath("../fixtures/config-custom/src/lib/custom-components"),
+				utils: resolvePath("../fixtures/config-custom/src/lib/custom-utils"),
+				ui: resolvePath("../fixtures/config-custom/src/lib/components/custom-ui"),
+				hooks: resolvePath("../fixtures/config-custom/src/lib/custom-hooks"),
+			},
+			typescript: true,
+			registry: `${SITE_BASE_URL}/registry`,
+		});
+	});
 });


### PR DESCRIPTION
Closes #1532 

Previously, anybody who didn't use the default components.json couldn't execute the update because if the ui path had been changed, this would resolve in an exception. Now the resolved alias path from the components.json is used.

### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
