### PR TITLE
fix(next): update `is-mobile` hook to use new `MediaQuery` class

### DIFF
--- a/sites/docs/src/lib/registry/default/hook/is-mobile.svelte.ts
+++ b/sites/docs/src/lib/registry/default/hook/is-mobile.svelte.ts
@@ -1,27 +1,9 @@
-import { untrack } from "svelte";
+import { MediaQuery } from "svelte/reactivity";
 
 const MOBILE_BREAKPOINT = 768;
 
-export class IsMobile {
-	#current = $state<boolean>(false);
-
+export class IsMobile extends MediaQuery {
 	constructor() {
-		$effect(() => {
-			return untrack(() => {
-				const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
-				const onChange = () => {
-					this.#current = window.innerWidth < MOBILE_BREAKPOINT;
-				};
-				mql.addEventListener("change", onChange);
-				onChange();
-				return () => {
-					mql.removeEventListener("change", onChange);
-				};
-			});
-		});
-	}
-
-	get current() {
-		return this.#current;
+		super(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
 	}
 }

--- a/sites/docs/src/lib/registry/default/hook/is-mobile.svelte.ts
+++ b/sites/docs/src/lib/registry/default/hook/is-mobile.svelte.ts
@@ -4,6 +4,6 @@ const MOBILE_BREAKPOINT = 768;
 
 export class IsMobile extends MediaQuery {
 	constructor() {
-		super(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+		super(`max-width: ${MOBILE_BREAKPOINT - 1}px`);
 	}
 }

--- a/sites/docs/src/lib/registry/new-york/hook/is-mobile.svelte.ts
+++ b/sites/docs/src/lib/registry/new-york/hook/is-mobile.svelte.ts
@@ -1,27 +1,9 @@
-import { untrack } from "svelte";
+import { MediaQuery } from "svelte/reactivity";
 
 const MOBILE_BREAKPOINT = 768;
 
-export class IsMobile {
-	#current = $state<boolean>(false);
-
+export class IsMobile extends MediaQuery {
 	constructor() {
-		$effect(() => {
-			return untrack(() => {
-				const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
-				const onChange = () => {
-					this.#current = window.innerWidth < MOBILE_BREAKPOINT;
-				};
-				mql.addEventListener("change", onChange);
-				onChange();
-				return () => {
-					mql.removeEventListener("change", onChange);
-				};
-			});
-		});
-	}
-
-	get current() {
-		return this.#current;
+		super(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
 	}
 }

--- a/sites/docs/src/lib/registry/new-york/hook/is-mobile.svelte.ts
+++ b/sites/docs/src/lib/registry/new-york/hook/is-mobile.svelte.ts
@@ -4,6 +4,6 @@ const MOBILE_BREAKPOINT = 768;
 
 export class IsMobile extends MediaQuery {
 	constructor() {
-		super(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+		super(`max-width: ${MOBILE_BREAKPOINT - 1}px`);
 	}
 }


### PR DESCRIPTION
## Quick Glance

- Fixes code redundancy.
- Does not introduce breaking changes for dependent components.
- Introduces breaking change when using `svelte` version older than `5.7.0`.
- Addresses #1615.

## Description

Hey, since the Svelte team added the [`MediaQuery`](https://svelte.dev/docs/svelte/svelte-reactivity#MediaQuery) class, the `IsMobile` hook is now somewhat redundant. 

To keep compatibility with all dependent components, the `IsMobile` class still exists but extends the `MediaQuery` class, which provides the same functionality.