### PR TITLE
docs(next): use `add` instead of `install` for `<PMInstall/>`

### DIFF
--- a/sites/docs/src/lib/components/docs/pm-install.svelte
+++ b/sites/docs/src/lib/components/docs/pm-install.svelte
@@ -3,4 +3,4 @@
 	export let command: string = "";
 </script>
 
-<PMBlock type="install" {command} />
+<PMBlock type="add" {command} />


### PR DESCRIPTION
Fixes #1614 

I know I will have to fix this in some of my other projects as well 🤦