### PR TITLE
fix(docs): Pass `data` instead of `form.data`

### DIFF
--- a/sites/docs/src/content/components/form.md
+++ b/sites/docs/src/content/components/form.md
@@ -158,7 +158,7 @@ We'll pass the `form` from the data returned from the load function to the form 
   let { data }: { data: PageData } = $props();
 </script>
 
-<SettingsForm data={data.form} />
+<SettingsForm {data} />
 ```
 
 ### Create an Action that handles the form submission


### PR DESCRIPTION
Fixes #1630 