### PR TITLE
Chore bump package manager detector

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,7 @@
 		"cross-env": "^7.0.3",
 		"get-tsconfig": "^4.7.3",
 		"ignore": "^5.3.1",
-		"package-manager-detector": "^0.1.2",
+		"package-manager-detector": "^0.2.8",
 		"sisteransi": "^1.0.5",
 		"tsup": "^8.0.0",
 		"type-fest": "^3.13.1",

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -247,23 +247,21 @@ async function runAdd(cwd: string, config: Config, options: AddOptions) {
 	// Install dependencies.
 	const pm = await detectPM(cwd, options.deps);
 	if (pm) {
-    const add = resolveCommand(pm, "add", ["-D", ...dependencies]);
-    if(add) {
-      tasks.push({
-        title: `${highlight(pm)}: Installing dependencies`,
-        enabled: dependencies.size > 0,
-        async task() {
-          await execa(add.command, add.args, {
-            cwd,
-          });
-          return `Dependencies installed with ${highlight(pm)}`;
-        },
-      });
-    } else {
-      p.log.warn(
-        `Could not detect a package manager in ${cwd}.`
-      );  
-    }
+		const add = resolveCommand(pm, "add", ["-D", ...dependencies]);
+		if (add) {
+			tasks.push({
+				title: `${highlight(pm)}: Installing dependencies`,
+				enabled: dependencies.size > 0,
+				async task() {
+					await execa(add.command, add.args, {
+						cwd,
+					});
+					return `Dependencies installed with ${highlight(pm)}`;
+				},
+			});
+		} else {
+			p.log.warn(`Could not detect a package manager in ${cwd}.`);
+		}
 	}
 
 	await p.tasks(tasks);

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -5,6 +5,7 @@ import color from "chalk";
 import * as v from "valibot";
 import { Command, Option } from "commander";
 import { execa } from "execa";
+import { resolveCommand } from "package-manager-detector";
 import * as cliConfig from "../utils/get-config.js";
 import type { Config } from "../utils/get-config.js";
 import { error, handleError } from "../utils/errors.js";
@@ -363,19 +364,25 @@ export async function runInit(cwd: string, config: Config, options: InitOptions)
 	});
 
 	// Install dependencies.
-	const commands = await detectPM(cwd, options.deps);
-	if (commands) {
-		const [pm, add] = commands.add.split(" ") as [string, string];
-		tasks.push({
-			title: `${highlight(pm)}: Installing dependencies`,
-			enabled: options.deps,
-			async task() {
-				await execa(pm, [add, "-D", ...PROJECT_DEPENDENCIES], {
-					cwd,
-				});
-				return `Dependencies installed with ${highlight(pm)}`;
-			},
-		});
+	const pm = await detectPM(cwd, options.deps);
+	if (pm) {
+		const add = resolveCommand(pm, "add", ["-D", ...PROJECT_DEPENDENCIES]);
+    if(add) {
+      tasks.push({
+        title: `${highlight(pm)}: Installing dependencies`,
+        enabled: options.deps,
+        async task() {
+          await execa(add.command, add.args, {
+            cwd,
+          });
+          return `Dependencies installed with ${highlight(pm)}`;
+        },
+      });  
+    } else {
+      p.log.warn(
+        `Could not detect a package manager in ${cwd}.`
+      );  
+    }
 	}
 
 	await p.tasks(tasks);

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -367,22 +367,20 @@ export async function runInit(cwd: string, config: Config, options: InitOptions)
 	const pm = await detectPM(cwd, options.deps);
 	if (pm) {
 		const add = resolveCommand(pm, "add", ["-D", ...PROJECT_DEPENDENCIES]);
-    if(add) {
-      tasks.push({
-        title: `${highlight(pm)}: Installing dependencies`,
-        enabled: options.deps,
-        async task() {
-          await execa(add.command, add.args, {
-            cwd,
-          });
-          return `Dependencies installed with ${highlight(pm)}`;
-        },
-      });  
-    } else {
-      p.log.warn(
-        `Could not detect a package manager in ${cwd}.`
-      );  
-    }
+		if (add) {
+			tasks.push({
+				title: `${highlight(pm)}: Installing dependencies`,
+				enabled: options.deps,
+				async task() {
+					await execa(add.command, add.args, {
+						cwd,
+					});
+					return `Dependencies installed with ${highlight(pm)}`;
+				},
+			});
+		} else {
+			p.log.warn(`Could not detect a package manager in ${cwd}.`);
+		}
 	}
 
 	await p.tasks(tasks);

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -229,22 +229,20 @@ async function runUpdate(cwd: string, config: Config, options: UpdateOptions) {
 	const pm = await detectPM(cwd, true);
 	if (pm) {
 		const add = resolveCommand(pm, "add", ["-D", ...dependencies]);
-    if(add) {
-      tasks.push({
-        title: `${highlight(pm)}: Installing dependencies`,
-        enabled: dependencies.size > 0,
-        async task() {
-          await execa(add.command, add.args, {
-            cwd,
-          });
-          return `Dependencies installed with ${highlight(pm)}`;
-        },
-      });  
-    } else {
-      p.log.warn(
-        `Could not detect a package manager in ${cwd}.`
-      );  
-    }
+		if (add) {
+			tasks.push({
+				title: `${highlight(pm)}: Installing dependencies`,
+				enabled: dependencies.size > 0,
+				async task() {
+					await execa(add.command, add.args, {
+						cwd,
+					});
+					return `Dependencies installed with ${highlight(pm)}`;
+				},
+			});
+		} else {
+			p.log.warn(`Could not detect a package manager in ${cwd}.`);
+		}
 	}
 
 	await p.tasks(tasks);

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -5,6 +5,7 @@ import color from "chalk";
 import { Command } from "commander";
 import { execa } from "execa";
 import * as v from "valibot";
+import { resolveCommand } from "package-manager-detector";
 import { type Config, getConfig } from "../utils/get-config.js";
 import { error, handleError } from "../utils/errors.js";
 import { fetchTree, getItemTargetPath, getRegistryIndex, resolveTree } from "../utils/registry";
@@ -225,19 +226,25 @@ async function runUpdate(cwd: string, config: Config, options: UpdateOptions) {
 	}
 
 	// Install dependencies.
-	const commands = await detectPM(cwd, true);
-	if (commands) {
-		const [pm, add] = commands.add.split(" ") as [string, string];
-		tasks.push({
-			title: `${highlight(pm)}: Installing dependencies`,
-			enabled: dependencies.size > 0,
-			async task() {
-				await execa(pm, [add, "-D", ...dependencies], {
-					cwd,
-				});
-				return `Dependencies installed with ${highlight(pm)}`;
-			},
-		});
+	const pm = await detectPM(cwd, true);
+	if (pm) {
+		const add = resolveCommand(pm, "add", ["-D", ...dependencies]);
+    if(add) {
+      tasks.push({
+        title: `${highlight(pm)}: Installing dependencies`,
+        enabled: dependencies.size > 0,
+        async task() {
+          await execa(add.command, add.args, {
+            cwd,
+          });
+          return `Dependencies installed with ${highlight(pm)}`;
+        },
+      });  
+    } else {
+      p.log.warn(
+        `Could not detect a package manager in ${cwd}.`
+      );  
+    }
 	}
 
 	await p.tasks(tasks);

--- a/packages/cli/src/utils/auto-detect.ts
+++ b/packages/cli/src/utils/auto-detect.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import ignore, { type Ignore } from "ignore";
 import { type TsConfigResult, getTsconfig } from "get-tsconfig";
-import { AGENTS,type Agent, COMMANDS, detect } from "package-manager-detector";
+import { AGENTS, type Agent, COMMANDS, detect } from "package-manager-detector";
 // import { AGENTS, type Agent, COMMANDS } from "package-manager-detector/agents";
 import * as p from "./prompts.js";
 import { cancel } from "./prompt-helpers.js";
@@ -99,10 +99,11 @@ export function detectLanguage(cwd: string): DetectLanguageResult | undefined {
 type Options = Array<{ value: Agent | undefined; label: Agent | "None" }>;
 export async function detectPM(cwd: string, prompt: boolean) {
 	let agent: Agent | undefined;
-  const detectResult = await detect({ cwd });
-  if (detectResult != null) {
+	const detectResult = await detect({ cwd });
+	if (detectResult != null) {
 		agent = detectResult.agent;
-	} if (detectResult === null && prompt) {
+	}
+	if (detectResult === null && prompt) {
 		const options: Options = AGENTS.filter((agent) => !agent.includes("@")).map((pm) => ({
 			value: pm,
 			label: pm,

--- a/packages/cli/src/utils/auto-detect.ts
+++ b/packages/cli/src/utils/auto-detect.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import ignore, { type Ignore } from "ignore";
 import { type TsConfigResult, getTsconfig } from "get-tsconfig";
-import { detect } from "package-manager-detector";
-import { AGENTS, type Agent, COMMANDS } from "package-manager-detector/agents";
+import { AGENTS,type Agent, COMMANDS, detect } from "package-manager-detector";
+// import { AGENTS, type Agent, COMMANDS } from "package-manager-detector/agents";
 import * as p from "./prompts.js";
 import { cancel } from "./prompt-helpers.js";
 
@@ -98,9 +98,11 @@ export function detectLanguage(cwd: string): DetectLanguageResult | undefined {
 
 type Options = Array<{ value: Agent | undefined; label: Agent | "None" }>;
 export async function detectPM(cwd: string, prompt: boolean) {
-	let { agent } = await detect({ cwd });
-
-	if (agent === undefined && prompt) {
+	let agent: Agent | undefined;
+  const detectResult = await detect({ cwd });
+  if (detectResult != null) {
+		agent = detectResult.agent;
+	} if (detectResult === null && prompt) {
 		const options: Options = AGENTS.filter((agent) => !agent.includes("@")).map((pm) => ({
 			value: pm,
 			label: pm,
@@ -118,5 +120,5 @@ export async function detectPM(cwd: string, prompt: boolean) {
 		agent = res;
 	}
 
-	return agent ? COMMANDS[agent] : undefined;
+	return agent;
 }

--- a/packages/cli/src/utils/sveltekit.ts
+++ b/packages/cli/src/utils/sveltekit.ts
@@ -13,16 +13,14 @@ export async function syncSvelteKit(cwd: string) {
 		if (fs.existsSync(path.join(cwd, ".svelte-kit"))) return;
 		const detectResult = await detect({ cwd });
 		const cmd = resolveCommand(detectResult?.agent ?? "npm", "execute", ["svelte-kit", "sync"]);
-    if(!cmd) {
-      log.warn(
-        `Could not detect a package manager in ${cwd} to sync svelte-kit.`
-      );
-      return 
-    }
-    await execa(cmd.command, cmd.args, {
-      cwd,
-    });
-  }
+		if (!cmd) {
+			log.warn(`Could not detect a package manager in ${cwd} to sync svelte-kit.`);
+			return;
+		}
+		await execa(cmd.command, cmd.args, {
+			cwd,
+		});
+	}
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 2.27.7
       '@huntabyte/eslint-config':
         specifier: ^0.3.2
-        version: 0.3.2(@vue/compiler-sfc@3.4.36)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@4.2.18))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@4.2.18))(svelte@4.2.18)(typescript@5.5.4)(vitest@1.6.0)
+        version: 0.3.2(@vue/compiler-sfc@3.4.36)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@4.2.18))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@4.2.18))(svelte@4.2.18)(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.43))
       '@huntabyte/eslint-plugin':
         specifier: ^0.1.0
         version: 0.1.0(eslint@9.8.0)
@@ -82,8 +82,8 @@ importers:
         specifier: ^5.3.1
         version: 5.3.1
       package-manager-detector:
-        specifier: ^0.1.2
-        version: 0.1.2
+        specifier: ^0.2.8
+        version: 0.2.8
       sisteransi:
         specifier: ^1.0.5
         version: 1.0.5
@@ -4226,8 +4226,8 @@ packages:
   package-json-from-dist@1.0.0:
     resolution: {integrity: sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==}
 
-  package-manager-detector@0.1.2:
-    resolution: {integrity: sha512-iePyefLTOm2gEzbaZKSW+eBMjg+UYsQvUKxmvGXAQ987K16efBg10MxIjZs08iyX+DY2/owKY9DIdu193kX33w==}
+  package-manager-detector@0.2.8:
+    resolution: {integrity: sha512-ts9KSdroZisdvKMWVAVCXiKqnqNfXz4+IbrBG8/BWx/TR5le+jfenvoBuIZ6UWM9nz47W7AbD9qYfAwfWMIwzA==}
 
   paneforge@0.0.2:
     resolution: {integrity: sha512-1xNMq+uslstqum4D8CzzkPGqnTWUlevjYtMjUhuEOiuz7E0fJHFuM8ogk8+LJnVbAg3hMJJ/9Mu4A1KaxK38oQ==}
@@ -5656,7 +5656,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@antfu/eslint-config@2.24.1(@vue/compiler-sfc@3.4.36)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@4.2.18))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@4.2.18))(svelte@4.2.18)(typescript@5.5.4)(vitest@1.6.0)':
+  '@antfu/eslint-config@2.24.1(@vue/compiler-sfc@3.4.36)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@4.2.18))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@4.2.18))(svelte@4.2.18)(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.43))':
     dependencies:
       '@antfu/install-pkg': 0.3.3
       '@clack/prompts': 0.7.0
@@ -5681,7 +5681,7 @@ snapshots:
       eslint-plugin-toml: 0.11.1(eslint@9.8.0)
       eslint-plugin-unicorn: 55.0.0(eslint@9.8.0)
       eslint-plugin-unused-imports: 4.0.1(@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@8.0.1(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)
-      eslint-plugin-vitest: 0.5.4(@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@8.0.1(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)(vitest@1.6.0)
+      eslint-plugin-vitest: 0.5.4(@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@8.0.1(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.43))
       eslint-plugin-vue: 9.27.0(eslint@9.8.0)
       eslint-plugin-yml: 1.14.0(eslint@9.8.0)
       eslint-processor-vue-blocks: 0.1.2(@vue/compiler-sfc@3.4.36)(eslint@9.8.0)
@@ -6490,9 +6490,9 @@ snapshots:
 
   '@humanwhocodes/retry@0.3.0': {}
 
-  '@huntabyte/eslint-config@0.3.2(@vue/compiler-sfc@3.4.36)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@4.2.18))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@4.2.18))(svelte@4.2.18)(typescript@5.5.4)(vitest@1.6.0)':
+  '@huntabyte/eslint-config@0.3.2(@vue/compiler-sfc@3.4.36)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@4.2.18))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@4.2.18))(svelte@4.2.18)(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.43))':
     dependencies:
-      '@antfu/eslint-config': 2.24.1(@vue/compiler-sfc@3.4.36)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@4.2.18))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@4.2.18))(svelte@4.2.18)(typescript@5.5.4)(vitest@1.6.0)
+      '@antfu/eslint-config': 2.24.1(@vue/compiler-sfc@3.4.36)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@4.2.18))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@4.2.18))(svelte@4.2.18)(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.43))
       '@antfu/install-pkg': 0.3.3
       '@clack/prompts': 0.7.0
       '@huntabyte/eslint-plugin': 0.1.0(eslint@9.8.0)
@@ -8524,7 +8524,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.0.1(@typescript-eslint/parser@7.18.0(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)
 
-  eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@8.0.1(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)(vitest@1.6.0):
+  eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@8.0.1(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.43)):
     dependencies:
       '@typescript-eslint/utils': 7.18.0(eslint@9.8.0)(typescript@5.5.4)
       eslint: 9.8.0
@@ -9910,7 +9910,7 @@ snapshots:
 
   package-json-from-dist@1.0.0: {}
 
-  package-manager-detector@0.1.2: {}
+  package-manager-detector@0.2.8: {}
 
   paneforge@0.0.2(svelte@4.2.18):
     dependencies:


### PR DESCRIPTION
Closes: #1642

bun 1.2 introduces new lock format, which is not supported by  package-manager-detector until 0.2.8. 

### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
