### PR TITLE
docs: update install command

### DIFF
--- a/sites/docs/src/content/installation/vite.md
+++ b/sites/docs/src/content/installation/vite.md
@@ -28,8 +28,13 @@ The current version of Vite splits TypeScript configuration into three files, tw
 Add the `baseUrl` and `paths` properties to the `compilerOptions` section of the `tsconfig.json` and
 `tsconfig.app.json` files:
 
-```json title="tsconfig.json" {3-7}
+```ts title="tsconfig.json" {7-13}
 {
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ],
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
@@ -44,18 +49,10 @@ Add the `baseUrl` and `paths` properties to the `compilerOptions` section of the
 
 Add the following code to the `tsconfig.app.json` file to resolve paths, for your IDE:
 
-```ts title="tsconfig.app.json" {11-17}
+```json title="tsconfig.app.json" {4-8}
 {
-  "files": [],
-  "references": [
-    {
-      "path": "./tsconfig.app.json"
-    },
-    {
-      "path": "./tsconfig.node.json"
-    }
-  ],
   "compilerOptions": {
+    // ...
     "baseUrl": ".",
     "paths": {
       "$lib": ["./src/lib"],

--- a/sites/docs/src/lib/components/docs/pm-install.svelte
+++ b/sites/docs/src/lib/components/docs/pm-install.svelte
@@ -3,4 +3,4 @@
 	export let command: string = "";
 </script>
 
-<PMBlock type="add" {command} />
+<PMBlock type="install" {command} />


### PR DESCRIPTION
The `pnpm add` in the current document is not a valid command and should be changed to `pnpm i` to install dependencies.

Before
<img width="767" alt="image" src="https://github.com/user-attachments/assets/b056a3d0-3eb5-4526-b09b-d30603c0aec5" />
After
<img width="760" alt="image" src="https://github.com/user-attachments/assets/51055ef5-0dca-4336-9acf-da2fdb2d7ed3" />
