### PR TITLE
docs(next): pin `sv` version

### DIFF
--- a/sites/docs/src/content/installation/manual.md
+++ b/sites/docs/src/content/installation/manual.md
@@ -15,7 +15,7 @@ description: How to setup shadcn-svelte manually.
 
 Use the `sv` CLI to add Tailwind CSS to your project.
 
-<PMExecute command="sv add tailwindcss" />
+<PMExecute command="sv@0.6.18 add tailwindcss" />
 
 ### Add dependencies
 

--- a/sites/docs/src/content/installation/sveltekit.md
+++ b/sites/docs/src/content/installation/sveltekit.md
@@ -16,13 +16,13 @@ description: How to setup shadcn-svelte in a SvelteKit project.
 
 Use the SvelteKit CLI to create a new project.
 
-<PMExecute command="sv create my-app" />
+<PMExecute command="sv@0.6.18 create my-app" />
 
 ### Add TailwindCSS
 
 Use the Svelte CLI to add Tailwind CSS to your project.
 
-<PMExecute command="sv add tailwindcss" />
+<PMExecute command="sv@0.6.18 add tailwindcss" />
 
 ### Install dependencies
 

--- a/sites/docs/src/content/installation/vite.md
+++ b/sites/docs/src/content/installation/vite.md
@@ -16,7 +16,7 @@ description: How to setup shadcn-svelte in a Vite project.
 
 Use the Svelte CLI to add Tailwind CSS to your project.
 
-<PMExecute command="sv add tailwindcss" />
+<PMExecute command="sv@0.6.18 add tailwindcss" />
 
 ### Install dependencies
 


### PR DESCRIPTION
Fixes #1671 

Pins the `sv` version to the latest version supporting tailwind v3 (`0.6.18`)