### PR TITLE
fix: removed duplicate avatar on themes page

### DIFF
--- a/sites/docs/src/lib/registry/default/example/cards/team-members.svelte
+++ b/sites/docs/src/lib/registry/default/example/cards/team-members.svelte
@@ -139,7 +139,6 @@
 		</div>
 		<div class="flex items-center justify-between space-x-4">
 			<div class="flex items-center space-x-4">
-				<img src="avatars/03.png" alt="Avatar" class="h-8 w-8 rounded-full" />
 				<Avatar.Root class="size-8">
 					<Avatar.Image src="/avatars/03.png" alt="Image" />
 					<Avatar.Fallback>IN</Avatar.Fallback>


### PR DESCRIPTION
### Removed duplicate avatar on themes page:
<img width="335" alt="image" src="https://github.com/user-attachments/assets/c60b2442-c351-4e78-807e-d0f722ca59d1" />
