### PR TITLE
feat: Allow `bind:files` on input component

### DIFF
--- a/sites/docs/src/lib/registry/default/ui/input/input.svelte
+++ b/sites/docs/src/lib/registry/default/ui/input/input.svelte
@@ -1,22 +1,46 @@
 <script lang="ts">
-	import type { HTMLInputAttributes } from "svelte/elements";
+	import type { HTMLInputAttributes, HTMLInputTypeAttribute } from "svelte/elements";
 	import type { WithElementRef } from "bits-ui";
 	import { cn } from "$lib/utils.js";
+
+	type InputType = Exclude<HTMLInputTypeAttribute, "file">;
+
+	type Props = WithElementRef<
+		Omit<HTMLInputAttributes, "type"> &
+			({ type: "file"; files?: FileList } | { type?: InputType; files?: undefined })
+	>;
 
 	let {
 		ref = $bindable(null),
 		value = $bindable(),
+		type,
+		files = $bindable(),
 		class: className,
 		...restProps
-	}: WithElementRef<HTMLInputAttributes> = $props();
+	}: Props = $props();
 </script>
 
-<input
-	bind:this={ref}
-	class={cn(
-		"border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-base file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-		className
-	)}
-	bind:value
-	{...restProps}
-/>
+{#if type === "file"}
+	<input
+		bind:this={ref}
+		class={cn(
+			"border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-base file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+			className
+		)}
+		type="file"
+		bind:files
+		bind:value
+		{...restProps}
+	/>
+{:else}
+	<input
+		bind:this={ref}
+		class={cn(
+			"border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-base file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+			className
+		)}
+		{type}
+		bind:value
+		{...restProps}
+	/>
+{/if}

--- a/sites/docs/src/lib/registry/new-york/ui/input/input.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/input/input.svelte
@@ -1,22 +1,46 @@
 <script lang="ts">
-	import type { HTMLInputAttributes } from "svelte/elements";
+	import type { HTMLInputAttributes, HTMLInputTypeAttribute } from "svelte/elements";
 	import type { WithElementRef } from "bits-ui";
 	import { cn } from "$lib/utils.js";
+
+	type InputType = Exclude<HTMLInputTypeAttribute, "file">;
+
+	type Props = WithElementRef<
+		Omit<HTMLInputAttributes, "type"> &
+			({ type: "file"; files?: FileList } | { type?: InputType; files?: undefined })
+	>;
 
 	let {
 		ref = $bindable(null),
 		value = $bindable(),
+		type,
+		files = $bindable(),
 		class: className,
 		...restProps
-	}: WithElementRef<HTMLInputAttributes> = $props();
+	}: Props = $props();
 </script>
 
-<input
-	bind:this={ref}
-	class={cn(
-		"border-input placeholder:text-muted-foreground focus-visible:ring-ring flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-		className
-	)}
-	bind:value
-	{...restProps}
-/>
+{#if type === "file"}
+	<input
+		bind:this={ref}
+		class={cn(
+			"border-input placeholder:text-muted-foreground focus-visible:ring-ring flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+			className
+		)}
+		type="file"
+		bind:files
+		bind:value
+		{...restProps}
+	/>
+{:else}
+	<input
+		bind:this={ref}
+		class={cn(
+			"border-input placeholder:text-muted-foreground focus-visible:ring-ring flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+			className
+		)}
+		{type}
+		bind:value
+		{...restProps}
+	/>
+{/if}


### PR DESCRIPTION
Fixes #1524 

With a little bit of type gymnastics we are able to make this work.

A few examples:
```svelte
<Input type="file" bind:files />
<!-- No error -->
```

```svelte
<Input />
<!-- No error -->
```

```svelte
<Input type="search" />
<!-- No error -->
```

```svelte
<Input type="text" bind:files/>
<!-- bind:files gives the error: Type 'FileList | undefined' is not assignable to type 'undefined'.
  Type 'FileList' is not assignable to type 'undefined'. -->
```

```svelte
<Input bind:files />
<!-- This gives a really ugly type error:
Type '{ files: FileList | undefined; }' is not assignable to type 'Props | undefined'.
  Type '{ files: FileList | undefined; }' is not assignable to type '(Omit<HTMLInputAttributes, "type"> & { type: "file"; files?: FileList | undefined; } & { ref?: HTMLElement | null | undefined; }) | (Omit<...> & ... 1 more ... & { ...; })'.
    Type '{ files: FileList | undefined; }' is not assignable to type 'Omit<HTMLInputAttributes, "type"> & { type?: InputType | undefined; files?: undefined; } & { ref?: HTMLElement | null | undefined; }'.
      Type '{ files: FileList | undefined; }' is not assignable to type '{ type?: InputType | undefined; files?: undefined; }'.
        Types of property 'files' are incompatible.
          Type 'FileList | undefined' is not assignable to type 'undefined'.
            Type 'FileList' is not assignable to type 'undefined'. -->
```