### PR TITLE
fix(next): remove rounded-full from avatar-fallback + use size instead of w and h

### DIFF
--- a/sites/docs/src/lib/registry/default/ui/avatar/avatar-fallback.svelte
+++ b/sites/docs/src/lib/registry/default/ui/avatar/avatar-fallback.svelte
@@ -11,6 +11,6 @@
 
 <AvatarPrimitive.Fallback
 	bind:ref
-	class={cn("bg-muted flex h-full w-full items-center justify-center rounded-full", className)}
+	class={cn("bg-muted flex h-full w-full items-center justify-center", className)}
 	{...restProps}
 />

--- a/sites/docs/src/lib/registry/default/ui/avatar/avatar-fallback.svelte
+++ b/sites/docs/src/lib/registry/default/ui/avatar/avatar-fallback.svelte
@@ -11,6 +11,6 @@
 
 <AvatarPrimitive.Fallback
 	bind:ref
-	class={cn("bg-muted flex h-full w-full items-center justify-center", className)}
+	class={cn("bg-muted flex size-full items-center justify-center", className)}
 	{...restProps}
 />

--- a/sites/docs/src/lib/registry/default/ui/avatar/avatar-image.svelte
+++ b/sites/docs/src/lib/registry/default/ui/avatar/avatar-image.svelte
@@ -9,8 +9,4 @@
 	}: AvatarPrimitive.ImageProps = $props();
 </script>
 
-<AvatarPrimitive.Image
-	bind:ref
-	class={cn("aspect-square size-full", className)}
-	{...restProps}
-/>
+<AvatarPrimitive.Image bind:ref class={cn("aspect-square size-full", className)} {...restProps} />

--- a/sites/docs/src/lib/registry/default/ui/avatar/avatar-image.svelte
+++ b/sites/docs/src/lib/registry/default/ui/avatar/avatar-image.svelte
@@ -11,6 +11,6 @@
 
 <AvatarPrimitive.Image
 	bind:ref
-	class={cn("aspect-square h-full w-full", className)}
+	class={cn("aspect-square size-full", className)}
 	{...restProps}
 />

--- a/sites/docs/src/lib/registry/new-york/ui/avatar/avatar-fallback.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/avatar/avatar-fallback.svelte
@@ -11,6 +11,6 @@
 
 <AvatarPrimitive.Fallback
 	bind:ref
-	class={cn("bg-muted flex h-full w-full items-center justify-center rounded-full", className)}
+	class={cn("bg-muted flex h-full w-full items-center justify-center", className)}
 	{...restProps}
 />

--- a/sites/docs/src/lib/registry/new-york/ui/avatar/avatar-fallback.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/avatar/avatar-fallback.svelte
@@ -11,6 +11,6 @@
 
 <AvatarPrimitive.Fallback
 	bind:ref
-	class={cn("bg-muted flex h-full w-full items-center justify-center", className)}
+	class={cn("bg-muted flex size-full items-center justify-center", className)}
 	{...restProps}
 />

--- a/sites/docs/src/lib/registry/new-york/ui/avatar/avatar-image.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/avatar/avatar-image.svelte
@@ -15,6 +15,6 @@
 	bind:ref
 	{src}
 	{alt}
-	class={cn("aspect-square h-full w-full", className)}
+	class={cn("aspect-square size-full", className)}
 	{...restProps}
 />


### PR DESCRIPTION
This PR removes the rounded-full class from the avatar-fallback implementation. 

Since we are already using overflow-hidden on `<Avatar.Root/>` there isn't really any reason this should be rounded especially since it can cause issues like the following:
```svelte
<Avatar.Root class="rounded-md">
	<Avatar.Image src=""/>
	<Avatar.Fallback>
		<Upload/>
	</Avatar.Fallback>
</Avatar.Root>
```

![image](https://github.com/user-attachments/assets/50a3d5a0-7d0b-469e-9692-738bc87a6d00)

Went ahead and also changed the sizing classes to use size-full instead of w and h.