### PR TITLE
fix(docs): update bits-ui installation command in migration guide

### DIFF
--- a/sites/docs/src/content/migration/svelte-5/index.md
+++ b/sites/docs/src/content/migration/svelte-5/index.md
@@ -145,7 +145,7 @@ Pick and choose which components to upgrade with the `update` command.
 
 The `update` command doesn't upgrade `bits-ui` so you will need to do that yourself.
 
-<PMInstall command="bits-ui@next"/>
+<PMInstall command="bits-ui"/>
 
 ## Remove unused dependencies
 


### PR DESCRIPTION
Related: https://github.com/huntabyte/shadcn-svelte/issues/1718#issuecomment-2677279768 (Since it's morning for me before you, @ieedan 😅 )