### PR TITLE
fix(drawer): add bottom safe inset

### DIFF
--- a/sites/docs/src/lib/registry/default/ui/drawer/drawer-content.svelte
+++ b/sites/docs/src/lib/registry/default/ui/drawer/drawer-content.svelte
@@ -13,7 +13,7 @@
 	<DrawerOverlay />
 	<DrawerPrimitive.Content
 		class={cn(
-			"bg-background fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border",
+			"bg-background fixed inset-x-0 bottom-[env(safe-area-inset-bottom)] z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border",
 			className
 		)}
 		{...$$restProps}

--- a/sites/docs/src/lib/registry/default/ui/drawer/drawer-content.svelte
+++ b/sites/docs/src/lib/registry/default/ui/drawer/drawer-content.svelte
@@ -13,7 +13,7 @@
 	<DrawerOverlay />
 	<DrawerPrimitive.Content
 		class={cn(
-			"bg-background fixed inset-x-0 bottom-[env(safe-area-inset-bottom)] z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border",
+			"bg-background fixed inset-x-0 bottom-0 pb-[env(safe-area-inset-bottom)] z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border",
 			className
 		)}
 		{...$$restProps}


### PR DESCRIPTION
When an app is installed as a PWA in standalone mode, the bottommost button overlaps with the iPhone’s "home bar".

Before:
![IMG_2566](https://github.com/user-attachments/assets/b5d7fbf2-6038-4936-ab8f-a71aeb460549)

After:
![IMG_2567](https://github.com/user-attachments/assets/96c043f1-d0f8-4d9d-8fdb-0bd04e5e8bdf)
