### PR TITLE
chore: Add tailwindcss to system info command in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/3-bug_report.yml
@@ -44,7 +44,7 @@ body:
     id: system-info
     attributes:
       label: System Info
-      description: Output of `npx envinfo --system --npmPackages svelte,shadcn-svelte,bits-ui,vaul-svelte,sveltekit-superforms,@sveltejs/kit,mode-watcher,formsnap,cmdk-sv,svelte-radix,lucide-svelte,svelte-sonner --binaries --browsers`
+      description: Output of `npx envinfo --system --npmPackages svelte,shadcn-svelte,tailwindcss,bits-ui,vaul-svelte,sveltekit-superforms,@sveltejs/kit,mode-watcher,formsnap,cmdk-sv,svelte-radix,lucide-svelte,svelte-sonner --binaries --browsers`
       render: bash
       placeholder: System, Binaries, Browsers
     validations:


### PR DESCRIPTION
This should help more easily diagnose issues with incompatible tailwind versions.
