### PR TITLE
fix(slider): add missing each-key

### DIFF
--- a/sites/docs/src/lib/registry/default/ui/slider/slider.svelte
+++ b/sites/docs/src/lib/registry/default/ui/slider/slider.svelte
@@ -18,7 +18,7 @@
 	<span class="bg-secondary relative h-2 w-full grow overflow-hidden rounded-full">
 		<SliderPrimitive.Range class="bg-primary absolute h-full" />
 	</span>
-	{#each thumbs as thumb}
+	{#each thumbs as thumb (thumb)}
 		<SliderPrimitive.Thumb
 			{thumb}
 			class="border-primary bg-background ring-offset-background focus-visible:ring-ring block h-5 w-5 rounded-full border-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"

--- a/sites/docs/src/lib/registry/new-york/ui/slider/slider.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/slider/slider.svelte
@@ -18,7 +18,7 @@
 	<span class="bg-primary/20 relative h-1.5 w-full grow overflow-hidden rounded-full">
 		<SliderPrimitive.Range class="bg-primary absolute h-full" />
 	</span>
-	{#each thumbs as thumb}
+	{#each thumbs as thumb (thumb)}
 		<SliderPrimitive.Thumb
 			{thumb}
 			class="border-primary/50 bg-background focus-visible:ring-ring block h-4 w-4 rounded-full border shadow transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50"


### PR DESCRIPTION
This PR adds a key to the each-block of slider, which resolves this lint error
https://sveltejs.github.io/eslint-plugin-svelte/rules/require-each-key/

That lint rule (or the inclusion of the rule) was added in eslint-plugin-svelte v3 (which this project doesn't yet use).
