### PR TITLE
fix: registry tree fetch

### DIFF
--- a/.changeset/sweet-steaks-teach.md
+++ b/.changeset/sweet-steaks-teach.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": patch
+---
+
+fix: workaround caching issue preventing the correct registry from being fetched

--- a/packages/cli/src/utils/registry/index.ts
+++ b/packages/cli/src/utils/registry/index.ts
@@ -12,7 +12,13 @@ let baseUrl: string | undefined;
 export type RegistryItem = v.InferOutput<typeof schemas.registryItemSchema>;
 
 export function setRegistry(url: string) {
-	baseUrl = url;
+	// temp workaround to circumvent some caching issues with CF between subdomain / root domain
+	// this will be removed once we have a proper solution and or we merge with main
+	if (url === "https://next.shadcn-svelte.com/registry") {
+		baseUrl = "https://huntabyte-next.shadcn-svelte.pages.dev/registry";
+	} else {
+		baseUrl = url;
+	}
 }
 
 function getRegistryUrl(path: string) {


### PR DESCRIPTION
<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->

This PR adds a temporary workaround to the CLI to prevent further disruption. If a user is looking to hit `https://next.shadcn-svelte.com/registry` as their registry base URL, we instead point them to the true cloudflare preview domain `https://huntabyte-next.shadcn-svelte.pages.dev/registry` to circumvent some odd caching issues that recently arose with CloudFlare.

For anyone curious, CloudFlare seems to be serving the static assets from the root site (shadcn-svelte.com) instead of next.shadcn-svelte.com, regardless of what is being hit via curl/fetch, causing schema validation issues with the CLI. This just started happening recently.

Closes #1726 
