### PR TITLE
Fix pagination item hidden attribute

### DIFF
--- a/sites/docs/src/content/components/pagination.md
+++ b/sites/docs/src/content/components/pagination.md
@@ -48,7 +48,7 @@ bits: https://www.bits-ui.com/docs/components/pagination
           <Pagination.Ellipsis />
         </Pagination.Item>
       {:else}
-        <Pagination.Item isVisible={currentPage == page.value}>
+        <Pagination.Item hidden={currentPage != page.value}>
           <Pagination.Link {page} isActive={currentPage == page.value}>
             {page.value}
           </Pagination.Link>

--- a/sites/docs/src/lib/registry/default/ui/pagination/pagination-item.svelte
+++ b/sites/docs/src/lib/registry/default/ui/pagination/pagination-item.svelte
@@ -8,6 +8,6 @@
 	export { className as class };
 </script>
 
-<li class={cn("", className)} {...$$restProps}>
+<li class={cn("", className)} {...$$restProps} hidden={hidden}>
 	<slot />
 </li>

--- a/sites/docs/src/lib/registry/new-york/ui/pagination/pagination-item.svelte
+++ b/sites/docs/src/lib/registry/new-york/ui/pagination/pagination-item.svelte
@@ -8,6 +8,6 @@
 	export { className as class };
 </script>
 
-<li class={cn("", className)} {...$$restProps}>
+<li class={cn("", className)} {...$$restProps} hidden={hidden}>
 	<slot />
 </li>


### PR DESCRIPTION
Related to #1681

Update the Pagination component to use the `hidden` attribute instead of `isVisible`.

* Modify `sites/docs/src/content/components/pagination.md` to replace `isVisible` with `hidden` in the example code.
* Update `sites/docs/src/lib/registry/default/ui/pagination/pagination-item.svelte` to add the `hidden` attribute to the `li` element.
* Update `sites/docs/src/lib/registry/new-york/ui/pagination/pagination-item.svelte` to add the `hidden` attribute to the `li` element.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/huntabyte/shadcn-svelte/pull/1738?shareId=b65829fa-5a13-4a9d-9a2a-8dd3ade2491e).