### PR TITLE
docs: Specify Drawer target devices to avoid confusion

### DIFF
--- a/sites/docs/src/content/components/drawer.md
+++ b/sites/docs/src/content/components/drawer.md
@@ -19,6 +19,7 @@ bits: https://www.vaul-svelte.com
 ## About
 
 Drawer is built on top of [Vaul Svelte](https://vaul-svelte.com), which is a Svelte port of [Vaul](https://vaul.emilkowal.ski) by [Emil Kowalski](https://twitter.com/emilkowalski_).
+This component can be used as a Dialog replacement on mobile and tablet devices.
 
 ## Installation
 


### PR DESCRIPTION
Drawer is only for mobile and tablets, specified to avoid confusion for people coming from other UI frameworks in which Drawers can be used in other devices, including PC.