### PR TITLE
fix(cli)(next): add missing ui alias option

### DIFF
--- a/.changeset/flat-sloths-learn.md
+++ b/.changeset/flat-sloths-learn.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": patch
+---
+
+fix(cli)(next): Add missing ui alias option

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -70,6 +70,7 @@ export const init = new Command()
 	.option("--components-alias <path>", "import alias for components")
 	.option("--utils-alias <path>", "import alias for utils")
 	.option("--hooks-alias <path>", "import alias for hooks")
+	.option("--ui-alias <path>", "import alias for ui")
 	.action(async (opts) => {
 		intro();
 		const options = v.parse(initOptionsSchema, opts);


### PR DESCRIPTION
Adds missing option `--ui-alias <path>` to CLI

This would allow a non-interactive initialization:

```bash
pnpm dlx shadcn-svelte@next init \
  --style default \
  --base-color slate \
  --css src/app.css \
  --tailwind-config tailwind.config.ts \
  --components-alias '$lib/components' \
  --utils-alias '$lib/utils' \
  --hooks-alias '$lib/hooks' \
  --ui-alias '$lib/components/ui'
```