### PR TITLE
docs(next): Update PM Block

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,8 +127,8 @@ importers:
         specifier: ^3.5.6
         version: 3.5.6
       '@lucide/svelte':
-        specifier: ^0.479.0
-        version: 0.479.0(svelte@5.16.1)
+        specifier: ^0.482.0
+        version: 0.482.0(svelte@5.16.1)
       '@prettier/sync':
         specifier: 0.3.0
         version: 0.3.0(prettier@3.3.3)
@@ -1266,8 +1266,8 @@ packages:
   '@juggle/resize-observer@3.4.0':
     resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
 
-  '@lucide/svelte@0.479.0':
-    resolution: {integrity: sha512-k/JaO8FHvmK7GLCy9vibA7O1a9nCtlfIs0tU/yYlmkqykVEvz9NRFkpR8g2kbsc79uFVz0Q2tjnRC09vd9AxmA==}
+  '@lucide/svelte@0.482.0':
+    resolution: {integrity: sha512-n2ycHU9cNcleRDwwpEHBJ6pYzVhHIaL3a+9dQa8kns9hB2g05bY+v2p2KP8v0pZwtNhYTHk/F2o2uZ1bVtQGhw==}
     peerDependencies:
       svelte: ^5
 
@@ -6139,7 +6139,7 @@ snapshots:
 
   '@juggle/resize-observer@3.4.0': {}
 
-  '@lucide/svelte@0.479.0(svelte@5.16.1)':
+  '@lucide/svelte@0.482.0(svelte@5.16.1)':
     dependencies:
       svelte: 5.16.1
 

--- a/sites/docs/package.json
+++ b/sites/docs/package.json
@@ -27,7 +27,7 @@
 	},
 	"devDependencies": {
 		"@internationalized/date": "^3.5.6",
-		"@lucide/svelte": "^0.479.0",
+		"@lucide/svelte": "^0.482.0",
 		"@prettier/sync": "0.3.0",
 		"@sveltejs/adapter-cloudflare": "4.6.1",
 		"@sveltejs/kit": "^2.12.0",

--- a/sites/docs/src/content/components/dropdown-menu.md
+++ b/sites/docs/src/content/components/dropdown-menu.md
@@ -36,6 +36,7 @@ Install `bits-ui`:
 </Steps>
 {/snippet}
 </InstallTabs>
+
 ## Usage
 
 ```svelte

--- a/sites/docs/src/lib/components/docs/copy-button.svelte
+++ b/sites/docs/src/lib/components/docs/copy-button.svelte
@@ -1,25 +1,27 @@
 <script lang="ts">
-	import { Button, type ButtonProps } from '$lib/registry/default/ui/button/index.js';
-	import { UseClipboard } from '$lib/hooks/use-clipboard.svelte.js';
-	import { cn } from '$lib/utils.js';
-	import { Check, Copy, X } from '@lucide/svelte';
-	import type { Snippet } from 'svelte';
-	import { scale } from 'svelte/transition';
+	import { Button, type ButtonProps } from "$lib/registry/default/ui/button/index.js";
+	import { UseClipboard } from "$lib/hooks/use-clipboard.svelte.js";
+	import { cn } from "$lib/utils.js";
+	import Copy from "@lucide/svelte/icons/copy";
+	import Check from "@lucide/svelte/icons/check";
+	import X from "@lucide/svelte/icons/x";
+	import type { Snippet } from "svelte";
+	import { scale } from "svelte/transition";
 
 	// omit href so you can't create a link
-	interface Props extends Omit<ButtonProps, 'href'> {
+	interface Props extends Omit<ButtonProps, "href"> {
 		text: string;
 		icon?: Snippet<[]>;
 		animationDuration?: number;
-		onCopy?: (status: UseClipboard['status']) => void;
+		onCopy?: (status: UseClipboard["status"]) => void;
 	}
 
 	let {
 		text,
 		icon,
 		animationDuration = 500,
-		variant = 'ghost',
-		size = 'icon',
+		variant = "ghost",
+		size = "icon",
 		onCopy,
 		class: className,
 		...restProps
@@ -42,12 +44,12 @@
 		onCopy?.(status);
 	}}
 >
-	{#if clipboard.status === 'success'}
+	{#if clipboard.status === "success"}
 		<div in:scale={{ duration: animationDuration, start: 0.85 }}>
 			<Check />
 			<span class="sr-only">Copied</span>
 		</div>
-	{:else if clipboard.status === 'failure'}
+	{:else if clipboard.status === "failure"}
 		<div in:scale={{ duration: animationDuration, start: 0.85 }}>
 			<X />
 			<span class="sr-only">Failed to copy</span>

--- a/sites/docs/src/lib/components/docs/copy-button.svelte
+++ b/sites/docs/src/lib/components/docs/copy-button.svelte
@@ -43,12 +43,12 @@
 >
 	{#if clipboard.status === "success"}
 		<div in:scale={{ duration: animationDuration, start: 0.85 }}>
-			<Check tabindex={-1}/>
+			<Check tabindex={-1} />
 			<span class="sr-only">Copied</span>
 		</div>
 	{:else if clipboard.status === "failure"}
 		<div in:scale={{ duration: animationDuration, start: 0.85 }}>
-			<X tabindex={-1}/>
+			<X tabindex={-1} />
 			<span class="sr-only">Failed to copy</span>
 		</div>
 	{:else}
@@ -56,7 +56,7 @@
 			{#if icon}
 				{@render icon()}
 			{:else}
-				<Copy tabindex={-1}/>
+				<Copy tabindex={-1} />
 			{/if}
 			<span class="sr-only">Copy</span>
 		</div>

--- a/sites/docs/src/lib/components/docs/copy-button.svelte
+++ b/sites/docs/src/lib/components/docs/copy-button.svelte
@@ -21,7 +21,6 @@
 		icon,
 		animationDuration = 500,
 		variant = "ghost",
-		size = "icon",
 		onCopy,
 		class: className,
 		...restProps
@@ -33,11 +32,9 @@
 <Button
 	{...restProps}
 	{variant}
-	{size}
+	size="icon"
 	class={cn(className)}
 	type="button"
-	name="copy"
-	tabindex={-1}
 	onclick={async () => {
 		const status = await clipboard.copy(text);
 
@@ -46,12 +43,12 @@
 >
 	{#if clipboard.status === "success"}
 		<div in:scale={{ duration: animationDuration, start: 0.85 }}>
-			<Check />
+			<Check tabindex={-1}/>
 			<span class="sr-only">Copied</span>
 		</div>
 	{:else if clipboard.status === "failure"}
 		<div in:scale={{ duration: animationDuration, start: 0.85 }}>
-			<X />
+			<X tabindex={-1}/>
 			<span class="sr-only">Failed to copy</span>
 		</div>
 	{:else}
@@ -59,7 +56,7 @@
 			{#if icon}
 				{@render icon()}
 			{:else}
-				<Copy />
+				<Copy tabindex={-1}/>
 			{/if}
 			<span class="sr-only">Copy</span>
 		</div>

--- a/sites/docs/src/lib/components/docs/hex-to-channels.svelte
+++ b/sites/docs/src/lib/components/docs/hex-to-channels.svelte
@@ -31,16 +31,16 @@
 			<Label for="hsl">HSL</Label>
 			<Input name="hsl" value={hslString} readonly />
 			<CopyButton
-				class="text-primary hover:bg-accent hover:text-primary absolute right-2 top-[28.5px]"
-				value={hslString}
+				class="text-primary hover:bg-accent hover:text-primary absolute right-2 top-[28.5px] mb-1 size-6 [&_svg]:size-3"
+				text={hslString}
 			/>
 		</div>
 		<div class="relative grid gap-2">
 			<Label for="rgb">RGB</Label>
 			<Input name="rgb" value={rgbString} readonly />
 			<CopyButton
-				class="text-primary hover:bg-accent hover:text-primary absolute right-2 top-[28.5px]"
-				value={rgbString}
+				class="text-primary hover:bg-accent hover:text-primary absolute right-2 top-[28.5px] mb-1 size-6 [&_svg]:size-3"
+				text={rgbString}
 			/>
 		</div>
 	</div>

--- a/sites/docs/src/lib/components/docs/markdown/pre.svelte
+++ b/sites/docs/src/lib/components/docs/markdown/pre.svelte
@@ -1,37 +1,22 @@
 <script lang="ts">
-	import { tick } from "svelte";
+	import { onMount } from "svelte";
 	import CopyButton from "$lib/components/docs/copy-button.svelte";
-	import { type PrimitiveElementAttributes, cn, createCopyCodeButton } from "$lib/utils.js";
-	import { getPackageManager } from "$lib/stores/package-manager.js";
+	import { type PrimitiveElementAttributes, cn } from "$lib/utils.js";
 
-	const selectedPackageManager = getPackageManager();
+	let { class: className, children, ...restProps }: PrimitiveElementAttributes = $props();
 
-	let {
-		class: className,
-		isPackageManagerBlock = false,
-		children,
-		...restProps
-	}: PrimitiveElementAttributes & {
-		isPackageManagerBlock?: boolean;
-	} = $props();
+	let preNode = $state<HTMLPreElement>();
+	let code = $state('');
 
-	const { copied, copyCode, codeString, setCodeString } = createCopyCodeButton();
-
-	let preNode: HTMLPreElement;
-
-	function handleCopy() {
-		if ($selectedPackageManager && preNode) {
-			codeString.set(preNode.innerText.trim().replaceAll("  ", " ") ?? "");
+	onMount(() => {
+		if (preNode) {
+			code = preNode.innerText.trim().replaceAll("  ", " ")
 		}
-		tick().then(() => {
-			copyCode();
-		});
-	}
+	})
 </script>
 
 <pre
 	bind:this={preNode}
-	use:setCodeString
 	class={cn(
 		"mb-4 mt-6 max-h-[650px] overflow-x-auto rounded-lg border bg-zinc-950 py-4 dark:bg-zinc-900",
 		className
@@ -40,9 +25,6 @@
 	{@render children?.()}
 </pre>
 <CopyButton
-	{isPackageManagerBlock}
-	copied={$copied}
-	copyCode={handleCopy}
-	value={$codeString}
-	class={cn("pre-copy-btn absolute right-4 top-4")}
+	text={code}
+	class={cn("pre-copy-btn absolute right-2 top-2")}
 />

--- a/sites/docs/src/lib/components/docs/markdown/pre.svelte
+++ b/sites/docs/src/lib/components/docs/markdown/pre.svelte
@@ -6,13 +6,13 @@
 	let { class: className, children, ...restProps }: PrimitiveElementAttributes = $props();
 
 	let preNode = $state<HTMLPreElement>();
-	let code = $state('');
+	let code = $state("");
 
 	onMount(() => {
 		if (preNode) {
-			code = preNode.innerText.trim().replaceAll("  ", " ")
+			code = preNode.innerText.trim().replaceAll("  ", " ");
 		}
-	})
+	});
 </script>
 
 <pre
@@ -24,7 +24,4 @@
 	{...restProps}>
 	{@render children?.()}
 </pre>
-<CopyButton
-	text={code}
-	class={cn("pre-copy-btn absolute right-2 top-2")}
-/>
+<CopyButton text={code} class={cn("pre-copy-btn absolute right-2 top-2")} />

--- a/sites/docs/src/lib/components/docs/pm-block.svelte
+++ b/sites/docs/src/lib/components/docs/pm-block.svelte
@@ -5,7 +5,7 @@
 		PACKAGE_MANAGERS,
 	} from "$lib/stores/package-manager.js";
 	import type { Command } from "package-manager-detector";
-	import { Clipboard } from "@lucide/svelte";
+	import Clipboard from "@lucide/svelte/icons/clipboard";
 	import CopyButton from "./copy-button.svelte";
 
 	type Props = {
@@ -23,7 +23,7 @@
 </script>
 
 <figure data-rehype-pretty-code-figure>
-	<div class="bg-accent/50 border-accent/50 w-full rounded-lg border mt-6">
+	<div class="bg-accent/50 border-accent/50 mt-6 w-full rounded-lg border">
 		<div class="border-border flex place-items-end justify-between border-b p-2 pb-0">
 			<div class="flex place-items-center gap-1">
 				{#each PACKAGE_MANAGERS as pm (pm)}

--- a/sites/docs/src/lib/components/docs/pm-block.svelte
+++ b/sites/docs/src/lib/components/docs/pm-block.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
-	import Pre from "./markdown/pre.svelte";
-	import { getCommand, getPackageManager } from "$lib/stores/package-manager.js";
+	import {
+		getCommand,
+		getPackageManager,
+		PACKAGE_MANAGERS,
+	} from "$lib/stores/package-manager.js";
 	import type { Command } from "package-manager-detector";
+	import { Clipboard } from "@lucide/svelte";
+	import CopyButton from "./copy-button.svelte";
 
 	type Props = {
 		type: Command | "create";
@@ -10,18 +15,47 @@
 
 	const { type, command }: Props = $props();
 
-	const selectedPackageManager = getPackageManager();
+	const agent = getPackageManager();
 
-	let resolvedCommand = $derived(getCommand($selectedPackageManager, type, command));
+	const cmd = $derived(getCommand($agent, type, command));
+
+	const commandText = $derived(`${cmd.command} ${cmd.args.join(" ")}`);
 </script>
 
 <figure data-rehype-pretty-code-figure>
-	<Pre isPackageManagerBlock={true} tabindex={0} data-language="bash" data-theme="github-dark">
-		<code data-language="bash" data-theme="github-dark" style="display: grid;">
-			<span data-line>
-				<span style="color:#B392F0;font-weight:bold">{resolvedCommand.command}</span>
-				<span style="color:#9ECBFF">{resolvedCommand.args.join(" ")}</span>
+	<div class="bg-accent/50 border-accent/50 w-full rounded-lg border mt-6">
+		<div class="border-border flex place-items-end justify-between border-b p-2 pb-0">
+			<div class="flex place-items-center gap-1">
+				{#each PACKAGE_MANAGERS as pm (pm)}
+					<button
+						type="button"
+						class={{
+							"-mb-0.5 border-b-2 border-transparent p-1 font-mono text-sm": true,
+							"border-b-primary": $agent === pm,
+						}}
+						onclick={() => ($agent = pm)}
+					>
+						{pm}
+					</button>
+				{/each}
+			</div>
+			<CopyButton text={commandText} class="mb-1 size-6 [&_svg]:size-3">
+				{#snippet icon()}
+					<Clipboard />
+				{/snippet}
+			</CopyButton>
+		</div>
+		<div class="no-scrollbar overflow-x-auto p-3">
+			<span class="text-nowrap font-mono text-sm">
+				{commandText}
 			</span>
-		</code>
-	</Pre>
+		</div>
+	</div>
 </figure>
+
+<style lang="postcss">
+	:global(.no-scrollbar) {
+		-ms-overflow-style: none; /* IE and Edge */
+		scrollbar-width: none; /* Firefox */
+	}
+</style>

--- a/sites/docs/src/lib/hooks/use-clipboard.svelte.ts
+++ b/sites/docs/src/lib/hooks/use-clipboard.svelte.ts
@@ -1,0 +1,83 @@
+type Options = {
+	/** The time before the copied status is reset. */
+	delay: number;
+};
+
+/** Use this hook to copy text to the clipboard and show a copied state.
+ *
+ * ## Usage
+ * ```svelte
+ * <script lang="ts">
+ * 		import { UseClipboard } from "$lib/hooks/use-clipboard.svelte";
+ *
+ * 		const clipboard = new UseClipboard();
+ * </script>
+ *
+ * <button onclick={clipboard.copy('Hello, World!')}>
+ *     {#if clipboard.copied === 'success'}
+ *         Copied!
+ *     {:else if clipboard.copied === 'failure'}
+ *         Failed to copy!
+ *     {:else}
+ *         Copy
+ *     {/if}
+ * </button>
+ * ```
+ *
+ */
+export class UseClipboard {
+	#copiedStatus = $state<'success' | 'failure'>();
+	private delay: number;
+	private timeout: ReturnType<typeof setTimeout> | undefined = undefined;
+
+	constructor({ delay = 500 }: Partial<Options> = {}) {
+		this.delay = delay;
+	}
+
+	/** Copies the given text to the users clipboard.
+	 *
+	 * ## Usage
+	 * ```ts
+	 * clipboard.copy('Hello, World!');
+	 * ```
+	 *
+	 * @param text
+	 * @returns
+	 */
+	async copy(text: string) {
+		if (this.timeout) {
+			this.#copiedStatus = undefined;
+			clearTimeout(this.timeout);
+		}
+
+		try {
+			await navigator.clipboard.writeText(text);
+
+			this.#copiedStatus = 'success';
+
+			this.timeout = setTimeout(() => {
+				this.#copiedStatus = undefined;
+			}, this.delay);
+		} catch {
+			// an error can occur when not in the browser or if the user hasn't given clipboard access
+			this.#copiedStatus = 'failure';
+
+			this.timeout = setTimeout(() => {
+				this.#copiedStatus = undefined;
+			}, this.delay);
+		}
+
+		return this.#copiedStatus;
+	}
+
+	/** True when the user has just copied to the clipboard. */
+	get copied() {
+		return this.#copiedStatus === 'success';
+	}
+
+	/**	Indicates whether a copy has occurred
+	 * and gives a status of either `success` or `failure`. */
+	get status() {
+		return this.#copiedStatus;
+	}
+}

--- a/sites/docs/src/lib/hooks/use-clipboard.svelte.ts
+++ b/sites/docs/src/lib/hooks/use-clipboard.svelte.ts
@@ -26,7 +26,7 @@ type Options = {
  *
  */
 export class UseClipboard {
-	#copiedStatus = $state<'success' | 'failure'>();
+	#copiedStatus = $state<"success" | "failure">();
 	private delay: number;
 	private timeout: ReturnType<typeof setTimeout> | undefined = undefined;
 
@@ -53,14 +53,14 @@ export class UseClipboard {
 		try {
 			await navigator.clipboard.writeText(text);
 
-			this.#copiedStatus = 'success';
+			this.#copiedStatus = "success";
 
 			this.timeout = setTimeout(() => {
 				this.#copiedStatus = undefined;
 			}, this.delay);
 		} catch {
 			// an error can occur when not in the browser or if the user hasn't given clipboard access
-			this.#copiedStatus = 'failure';
+			this.#copiedStatus = "failure";
 
 			this.timeout = setTimeout(() => {
 				this.#copiedStatus = undefined;
@@ -72,7 +72,7 @@ export class UseClipboard {
 
 	/** True when the user has just copied to the clipboard. */
 	get copied() {
-		return this.#copiedStatus === 'success';
+		return this.#copiedStatus === "success";
 	}
 
 	/**	Indicates whether a copy has occurred

--- a/sites/docs/src/lib/stores/package-manager.ts
+++ b/sites/docs/src/lib/stores/package-manager.ts
@@ -3,7 +3,7 @@ import { persisted } from "svelte-persisted-store";
 import type { Agent, Command, ResolvedCommand } from "package-manager-detector";
 import { resolveCommand } from "package-manager-detector/commands";
 
-export const PACKAGE_MANAGERS: Agent[] = ['pnpm', 'npm', 'bun', 'yarn'] as const;
+export const PACKAGE_MANAGERS: Agent[] = ["pnpm", "npm", "bun", "yarn"] as const;
 
 const PACKAGE_MANAGER = Symbol("packageManager");
 

--- a/sites/docs/src/lib/stores/package-manager.ts
+++ b/sites/docs/src/lib/stores/package-manager.ts
@@ -3,6 +3,8 @@ import { persisted } from "svelte-persisted-store";
 import type { Agent, Command, ResolvedCommand } from "package-manager-detector";
 import { resolveCommand } from "package-manager-detector/commands";
 
+export const PACKAGE_MANAGERS: Agent[] = ['pnpm', 'npm', 'bun', 'yarn'] as const;
+
 const PACKAGE_MANAGER = Symbol("packageManager");
 
 export function setPackageManager(initialValue: Agent = "npm") {


### PR DESCRIPTION
Updates the `<PMBlock/>` to use the style of the original. 

![image](https://github.com/user-attachments/assets/bd63866a-5224-4e07-acda-a2ddaacc3468)

This also decouples the code for `<Pre/>` and `<CopyButton/>` from the `<PMBlock/>`. 

