### PR TITLE
docs: Fix `<FixPMBlock/>`

### DIFF
--- a/sites/docs/src/lib/components/docs/copy-button.svelte
+++ b/sites/docs/src/lib/components/docs/copy-button.svelte
@@ -26,6 +26,7 @@
 				variant="ghost"
 				class={cn(
 					"bg-background/10 text-background/70 hover:bg-background/20 hover:text-background/80 dark:bg-foreground/5 dark:text-foreground/70 dark:hover:bg-foreground/10 dark:hover:text-foreground/80 relative !right-12 h-6 w-fit items-center justify-center rounded-md p-1",
+					"hidden sm:block",
 					className
 				)}
 				{...$$restProps}


### PR DESCRIPTION
Fixes #1763 

Updates `<PMBlock/>` to hide the package manager selector on smaller screens to match the current behavior of the next branch.

It seems kinda silly to do a bunch of changes like #1765 to main right now since next will eventually replace it.