### PR TITLE
fix: Export `Portal` component from Tooltip

### DIFF
--- a/sites/docs/src/lib/registry/ui/tooltip/index.ts
+++ b/sites/docs/src/lib/registry/ui/tooltip/index.ts
@@ -4,15 +4,18 @@ import Content from "./tooltip-content.svelte";
 const Root = TooltipPrimitive.Root;
 const Trigger = TooltipPrimitive.Trigger;
 const Provider = TooltipPrimitive.Provider;
+const Portal = TooltipPrimitive.Portal;
 
 export {
 	Root,
 	Trigger,
 	Content,
 	Provider,
+	Portal,
 	//
 	Root as Tooltip,
 	Content as TooltipContent,
 	Trigger as TooltipTrigger,
 	Provider as TooltipProvider,
+	Portal as TooltipPortal,
 };


### PR DESCRIPTION
Fixes #1779 

I am gonna open this on the v4 version to make sure there aren't any conflicts and that the changes make it through. The changes are simple enough that those that need this can use this PR for reference.