### PR TITLE
fix(v4): Remove extra semi from generated themes

### DIFF
--- a/sites/docs/src/lib/registry/themes.ts
+++ b/sites/docs/src/lib/registry/themes.ts
@@ -12,7 +12,7 @@ export const themes = [
 				foreground: "240 10% 3.9%",
 				card: "0 0% 100%",
 				"card-foreground": "240 10% 3.9%",
-				popover: "0 0% 100%;",
+				popover: "0 0% 100%",
 				"popover-foreground": "240 10% 3.9%",
 				primary: "240 5.9% 10%",
 				"primary-foreground": "0 0% 98%",


### PR DESCRIPTION
Fixes #1799 for v4 follow up to #1804 