### PR TITLE
fix(v4): remove `cursor-pointer` where it doesn't belong

### DIFF
--- a/sites/docs/src/lib/components/colors/color-card.svelte
+++ b/sites/docs/src/lib/components/colors/color-card.svelte
@@ -63,7 +63,7 @@
 			<div class="flex place-items-center justify-between">
 				<h2>{`${color.name[0].toUpperCase()}${color.name.slice(1)}`}</h2>
 				<Select.Root type="single" bind:value={selectedFormat.current}>
-					<Select.Trigger class="h-7 w-fit cursor-pointer text-xs">
+					<Select.Trigger class="h-7 w-fit text-xs">
 						<span class="mr-2">
 							<span class="font-bold">Format:</span>
 							<span class="text-muted-foreground font-mono"
@@ -90,7 +90,7 @@
 					<button
 						type="button"
 						onclick={() => copy(shade)}
-						class="group w-full flex-1 shrink-0 cursor-pointer md:h-full md:w-auto"
+						class="group w-full flex-1 shrink-0 md:h-full md:w-auto"
 					>
 						<div class="relative">
 							<div class="hidden md:block">
@@ -123,12 +123,12 @@
 						</div>
 
 						<span
-							class="text-muted-foreground hidden text-nowrap py-1 font-mono text-sm xl:block"
+							class="group-hover:text-foreground text-muted-foreground hidden text-nowrap py-1 font-mono text-sm transition-colors xl:block"
 						>
 							{shade.className}
 						</span>
 						<span
-							class="text-muted-foreground block text-nowrap py-1 font-mono text-sm xl:hidden"
+							class="group-hover:text-foreground text-muted-foreground block text-nowrap py-1 font-mono text-sm transition-colors xl:hidden"
 						>
 							{shade.className.split("-")[1]}
 						</span>

--- a/sites/docs/src/lib/components/docs/copy-button.svelte
+++ b/sites/docs/src/lib/components/docs/copy-button.svelte
@@ -33,7 +33,7 @@
 	{...restProps}
 	{variant}
 	size="icon"
-	class={cn("cursor-pointer", className)}
+	class={cn("", className)}
 	type="button"
 	onclick={async () => {
 		const status = await clipboard.copy(text);

--- a/sites/docs/src/lib/components/docs/pm-block.svelte
+++ b/sites/docs/src/lib/components/docs/pm-block.svelte
@@ -30,7 +30,7 @@
 					<button
 						type="button"
 						class={{
-							"-mb-0.5 cursor-pointer border-b-2 border-transparent p-1 font-mono text-sm": true,
+							"-mb-0.5 border-b-2 border-transparent p-1 font-mono text-sm": true,
 							"border-b-primary": $agent === pm,
 						}}
 						onclick={() => ($agent = pm)}

--- a/sites/docs/src/lib/registry/ui/button/button.svelte
+++ b/sites/docs/src/lib/registry/ui/button/button.svelte
@@ -4,7 +4,7 @@
 	import { type VariantProps, tv } from "tailwind-variants";
 
 	export const buttonVariants = tv({
-		base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium outline-none transition-all hover:cursor-pointer focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium outline-none transition-all focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		variants: {
 			variant: {
 				default: "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",

--- a/sites/docs/src/lib/registry/ui/switch/switch.svelte
+++ b/sites/docs/src/lib/registry/ui/switch/switch.svelte
@@ -14,7 +14,7 @@
 	bind:ref
 	bind:checked
 	class={cn(
-		"focus-visible:ring-ring focus-visible:ring-offset-background data-[state=checked]:bg-primary data-[state=unchecked]:bg-input peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+		"focus-visible:ring-ring focus-visible:ring-offset-background data-[state=checked]:bg-primary data-[state=unchecked]:bg-input peer inline-flex h-6 w-11 shrink-0 items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
 		className
 	)}
 	{...restProps}


### PR DESCRIPTION
Removes `cursor-pointer` anywhere it's applied that's not a link I made some incorrect assumptions when changing some of these before.

Also adds some better styling indication to `/colors` to show that any part of the color card is clickable.
