### PR TITLE
fix(docs)(next): z-index overlap in block toolbar on /blocks

### DIFF
--- a/sites/docs/src/lib/components/docs/block-toolbar.svelte
+++ b/sites/docs/src/lib/components/docs/block-toolbar.svelte
@@ -100,7 +100,7 @@
 			aria-label="View block source code"
 			href={blockSource}
 			target="_blank"
-			class="z-50 h-[calc(theme(spacing.7)_-_1px)] gap-1 rounded-[6px] px-0 text-xs"
+			class="h-[calc(theme(spacing.7)_-_1px)] gap-1 rounded-[6px] px-0 text-xs"
 			variant="link"
 		>
 			View source


### PR DESCRIPTION
<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->

The "View source" button was overlapping the header on the [/blocks](https://next.shadcn-svelte.com/blocks) route due to a `z-50` class. Removing it fixes the issue.

![image](https://github.com/user-attachments/assets/770490a7-dcbf-4291-8f60-b4a47f810eae)
