### PR TITLE
docs: pin mode watcher to 0.5

### DIFF
--- a/sites/docs/src/content/dark-mode/astro.md
+++ b/sites/docs/src/content/dark-mode/astro.md
@@ -58,7 +58,7 @@ import "$lib/styles/app.css";
 
 ### Install mode-watcher
 
-<PMInstall command="mode-watcher" />
+<PMInstall command="mode-watcher@0.5.1" />
 
 ### Add the ModeWatcher component
 

--- a/sites/docs/src/content/dark-mode/svelte.md
+++ b/sites/docs/src/content/dark-mode/svelte.md
@@ -19,7 +19,7 @@ How you add the ` dark` class to the `html` element is up to you. In this guide,
 
 Start by installing `mode-watcher`:
 
-<PMInstall command="mode-watcher" />
+<PMInstall command="mode-watcher@0.5.1" />
 
 ### Add the ModeWatcher component
 


### PR DESCRIPTION
We're about to release mode-watcher 1.0 which will be for Svelte 5 only, so pinning 0.5 to the Svelte 4 shadcn-svelte doc install guide.