### PR TITLE
chore(v4): Docs fixes

### DIFF
--- a/sites/docs/src/content/components-json.md
+++ b/sites/docs/src/content/components-json.md
@@ -55,18 +55,6 @@ Configuration to help the CLI understand how Tailwind CSS is set up in your proj
 
 See the [installation section](/docs/installation) for how to set up Tailwind CSS.
 
-### tailwind.config
-
-Path to where your `tailwind.config.js` file is located.
-
-```json title="components.json"
-{
-  "tailwind": {
-    "config": "tailwind.config.js" | "tailwind.config.ts"
-  }
-}
-```
-
 ### tailwind.css
 
 Path to the CSS file that imports Tailwind CSS into your project.

--- a/sites/docs/src/content/dark-mode/svelte.md
+++ b/sites/docs/src/content/dark-mode/svelte.md
@@ -27,6 +27,7 @@ Import the `ModeWatcher` component and use it in your root layout:
 
 ```svelte title="src/routes/+layout.svelte"
 <script lang="ts">
+  import "../app.css";
   import { ModeWatcher } from "mode-watcher";
   let { children } = $props();
 </script>

--- a/sites/docs/src/styles/globals.css
+++ b/sites/docs/src/styles/globals.css
@@ -125,10 +125,13 @@
 	}
 }
 
-@layer utilities {
-	.container {
-		@apply mx-auto max-w-screen-2xl border-dashed px-8 pb-8 2xl:border-x;
-	}
+@utility step {
+	@apply before:border-background before:bg-muted before:absolute before:ml-[-50px] before:mt-[-4px] before:inline-flex before:size-9 before:items-center before:justify-center before:rounded-full before:border-4 before:text-center before:-indent-px before:font-mono before:text-base before:font-medium before:content-[counter(step)];
+	counter-increment: step;
+}
+
+@utility container {
+	@apply mx-auto max-w-screen-2xl border-dashed px-8 pb-8 2xl:border-x;
 }
 
 .markdown code {


### PR DESCRIPTION
Fixes #1823

- Fixes `<Steps/>` so that the numbers show up next to the headings again
- Removes `tailwind.config` section of docs since we don't use it anymore
