### PR TITLE
docs: example code causes node_invalid_placement_ssr warning. This fixes the issue

### DIFF
--- a/sites/docs/src/lib/components/docs/dashboard/user-nav.svelte
+++ b/sites/docs/src/lib/components/docs/dashboard/user-nav.svelte
@@ -6,12 +6,12 @@
 
 <DropdownMenu.Root>
 	<DropdownMenu.Trigger asChild let:builder>
-		<Button variant="ghost" builders={[builder]} class="relative h-8 w-8 rounded-full">
+		<div variant="ghost" builders={[builder]} class="relative h-8 w-8 rounded-full">
 			<Avatar.Root class="h-8 w-8">
 				<Avatar.Image src="/avatars/01.png" alt="@shadcn" />
 				<Avatar.Fallback>SC</Avatar.Fallback>
 			</Avatar.Root>
-		</Button>
+		</div>
 	</DropdownMenu.Trigger>
 	<DropdownMenu.Content class="w-56" align="end">
 		<DropdownMenu.Label class="font-normal">


### PR DESCRIPTION
this Button element causes this warning: 
```
node_invalid_placement_ssr: `<button>` (src/lib/components/ui/button/button.svelte:60:1) cannot be a child of `<button>` (node_modules/bits-ui/dist/bits/utilities/floating-layer/components/floating-layer-anchor.svelte:34:2)

This can cause content to shift around as the browser repairs the HTML, and will likely result in a `hydration_mismatch` warning.
```

This change fixes #1635

<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->
