### PR TITLE
docs: Use recommended onclick sorting handler in data-table sorting section

### DIFF
--- a/sites/docs/src/content/components/data-table.md
+++ b/sites/docs/src/content/components/data-table.md
@@ -576,7 +576,7 @@ export const columns: ColumnDef<Payment>[] = [
     accessorKey: "email",
     header: ({ column }) =>
       renderComponent(DataTableEmailButton, {
-        onclick: () => column.toggleSorting(column.getIsSorted() === "asc"),
+        onclick: column.getToggleSortingHandler(),
       }),
   },
 ];

--- a/sites/docs/src/lib/registry/default/example/cards/data-table.svelte
+++ b/sites/docs/src/lib/registry/default/example/cards/data-table.svelte
@@ -104,7 +104,7 @@
 			accessorKey: "email",
 			header: ({ column }) =>
 				renderComponent(DataTableEmailButton, {
-					onclick: () => column.toggleSorting(column.getIsSorted() === "asc"),
+					onclick: column.getToggleSortingHandler(),
 				}),
 			cell: ({ row }) => {
 				const emailSnippet = createRawSnippet<[string]>((getEmail) => {

--- a/sites/docs/src/lib/registry/default/example/data-table-demo.svelte
+++ b/sites/docs/src/lib/registry/default/example/data-table-demo.svelte
@@ -104,7 +104,7 @@
 			accessorKey: "email",
 			header: ({ column }) =>
 				renderComponent(DataTableEmailButton, {
-					onclick: () => column.toggleSorting(column.getIsSorted() === "asc"),
+					onclick: column.getToggleSortingHandler(),
 				}),
 			cell: ({ row }) => {
 				const emailSnippet = createRawSnippet<[string]>((getEmail) => {

--- a/sites/docs/src/lib/registry/new-york/example/cards/data-table.svelte
+++ b/sites/docs/src/lib/registry/new-york/example/cards/data-table.svelte
@@ -104,7 +104,7 @@
 			accessorKey: "email",
 			header: ({ column }) =>
 				renderComponent(DataTableEmailButton, {
-					onclick: () => column.toggleSorting(column.getIsSorted() === "asc"),
+					onclick: column.getToggleSortingHandler(),
 				}),
 			cell: ({ row }) => {
 				const emailSnippet = createRawSnippet<[string]>((getEmail) => {

--- a/sites/docs/src/lib/registry/new-york/example/data-table-demo.svelte
+++ b/sites/docs/src/lib/registry/new-york/example/data-table-demo.svelte
@@ -104,7 +104,7 @@
 			accessorKey: "email",
 			header: ({ column }) =>
 				renderComponent(DataTableEmailButton, {
-					onclick: () => column.toggleSorting(column.getIsSorted() === "asc"),
+					onclick: column.getToggleSortingHandler(),
 				}),
 			cell: ({ row }) => {
 				const emailSnippet = createRawSnippet<[string]>((getEmail) => {


### PR DESCRIPTION
This uses `column.getToggleSortingHandler()` instead of `() => column.toggleSorting(column.getIsSorted() === "asc")`.

The main difference here is that getToggleSortingHandler honors settings such as `sortDescFirst`. I verified that this works better in my own project.

Reference: https://tanstack.com/table/latest/docs/guide/sorting#sorting-apis

Closes #1857 

<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->
