### PR TITLE
fix(Command): ensure `LinkItem` and `Item` styles are consistent

### DIFF
--- a/sites/docs/src/lib/registry/default/ui/command/command-link-item.svelte
+++ b/sites/docs/src/lib/registry/default/ui/command/command-link-item.svelte
@@ -11,7 +11,7 @@
 
 <CommandPrimitive.LinkItem
 	class={cn(
-		"aria-selected:bg-accent aria-selected:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+		"aria-selected:bg-accent aria-selected:text-accent-foreground relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
 		className
 	)}
 	bind:ref


### PR DESCRIPTION
Fixes #1872 