### PR TITLE
fix: incorrect icon color on sidebar sub items

### DIFF
--- a/sites/docs/src/lib/registry/default/ui/sidebar/sidebar-menu-sub-button.svelte
+++ b/sites/docs/src/lib/registry/default/ui/sidebar/sidebar-menu-sub-button.svelte
@@ -20,7 +20,7 @@
 
 	const mergedProps = $derived({
 		class: cn(
-			"text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+			"text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground active:[&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
 			"data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
 			size === "sm" && "text-xs",
 			size === "md" && "text-sm",


### PR DESCRIPTION
The sidebar sub button icons were always colored the accent color, even when not active. This adds the active modifier.