### PR TITLE
fix: tw4 docs style

### DIFF
--- a/sites/docs/src/lib/components/docs/pm-block.svelte
+++ b/sites/docs/src/lib/components/docs/pm-block.svelte
@@ -24,7 +24,7 @@
 </script>
 
 <figure data-rehype-pretty-code-figure>
-	<div class="mt-6 w-full rounded-lg border bg-zinc-900">
+	<div class="bg-accent/50 mt-6 w-full rounded-lg border">
 		<div class="border-border flex place-items-end justify-between border-b p-2 pb-0">
 			<div class="flex place-items-center gap-1">
 				{#each PACKAGE_MANAGERS as pm (pm)}

--- a/sites/docs/src/styles/markdown.css
+++ b/sites/docs/src/styles/markdown.css
@@ -81,7 +81,7 @@
 }
 
 [data-rehype-pretty-code-figure] .line--highlighted {
-	background-color: color-mix(in oklab, var(--color-zinc-700), 50);
+	background-color: color-mix(in oklab, var(--color-zinc-700) 50%, transparent);
 }
 
 [data-rehype-pretty-code-figure] .with--meta {
@@ -94,8 +94,8 @@
 
 [data-rehype-pretty-code-figure] .chars--highlighted {
 	border-radius: var(--radius-md);
-	border-color: color-mix(in oklab, var(--color-zinc-700) / 70);
-	background-color: color-mix(in oklab, var(--color-zinc-500) / 50);
+	border-color: color-mix(in oklab, var(--color-zinc-700) 70%, transparent);
+	background-color: color-mix(in oklab, var(--color-zinc-500) 50%, transparent);
 	padding: var(--spacing);
 }
 


### PR DESCRIPTION
This will fix some problems in #1770 docs.

# 1. PMBLock colors
### Issue
Light theme CLI command is invisible.
### Fix
Fixes by setting background color to `bg-accent/50`.
It works both in light and dark mode. (copied style from current `next`)

| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/d9452639-3eb4-43e7-9c92-ebe056b13088) | ![image](https://github.com/user-attachments/assets/1ac9a3a1-e358-4a9e-a282-ce805b0278ad) |

# 2. Code block highlighted line

### Issue
Highlighted line is invisible, although attiribute is set in html element.
```html
<span class="line--highlighted" data-line="" data-highlighted-line="">
```
### Fix
Fixed `color-mix()` syntax.

| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/fff8a23a-6fc9-46ea-a5c5-7d18f6dfdbd9) | ![image](https://github.com/user-attachments/assets/6e93142a-17a9-481a-8ad9-26e49e7d0666) |
