### PR TITLE
feat(tw4-next): transform registry aliases into alias placeholders

### DIFF
--- a/packages/cli/src/commands/registry/build.ts
+++ b/packages/cli/src/commands/registry/build.ts
@@ -119,7 +119,7 @@ async function runBuild(options: BuildOptions) {
 			 * Transforms registry import aliases into a standardized format.
 			 *
 			 * ```
-			 * import Button from "$lib/registry/ui/button/index.js`
+			 * import Button from "$lib/registry/ui/button/index.js"
 			 * ```
 			 * transforms into:
 			 * ```

--- a/packages/cli/src/commands/registry/build.ts
+++ b/packages/cli/src/commands/registry/build.ts
@@ -7,11 +7,10 @@ import * as v from "valibot";
 import * as schema from "@shadcn-svelte/registry";
 import * as p from "@clack/prompts";
 import { intro } from "../../utils/prompt-helpers.js";
-import { parseDependency, toArray } from "../../utils/utils.js";
 import { error, handleError } from "../../utils/errors.js";
+import { parseDependency, toArray } from "../../utils/utils.js";
+import { ALIAS_DEFAULTS, ALIASES, SITE_BASE_URL } from "../../constants.js";
 import { getFileDependencies, resolveProjectDeps } from "./deps-resolver.js";
-import { SITE_BASE_URL } from "../../constants.js";
-import { ALIAS_PLACEHOLDERS, ALIASES } from "../../utils/transformers.js";
 
 // TODO: perhaps a `--mini` flag to remove spacing?
 const SPACER = "\t";
@@ -116,12 +115,23 @@ async function runBuild(options: BuildOptions) {
 				}
 			}
 
+			/**
+			 * Transforms registry import aliases into a standardized format.
+			 *
+			 * ```
+			 * import Button from "$lib/registry/ui/button/index.js`
+			 * ```
+			 * transforms into:
+			 * ```
+			 * import Button from "$UI$/button/index.js"
+			 * ```
+			 */
 			const transformAliases = (content: string) => {
 				registry.aliases ??= {};
 				for (const alias of ALIASES) {
-					registry.aliases[alias] ??= `$lib/registry/${alias}`;
-					const placeholder = ALIAS_PLACEHOLDERS[alias];
-					content = content.replaceAll(registry.aliases[alias], placeholder);
+					const defaults = ALIAS_DEFAULTS[alias];
+					const path = (registry.aliases[alias] ??= defaults.defaultPath);
+					content = content.replaceAll(path, defaults.placeholder);
 				}
 
 				return content;

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -1,2 +1,15 @@
 export const SITE_BASE_URL = "https://next.shadcn-svelte.com";
 export const TW3_SITE_BASE_URL = "https://tw3.shadcn-svelte.com";
+
+export const ALIASES = ["components", "ui", "hooks", "lib", "utils"] as const;
+
+export const ALIAS_DEFAULTS = ALIASES.reduce(
+	(acc, a) => {
+		acc[a] = {
+			placeholder: `$${a.toUpperCase()}$`,
+			defaultPath: a === "utils" ? "$lib/utils" : `$lib/registry/${a}`,
+		};
+		return acc;
+	},
+	{} as Record<(typeof ALIASES)[number], { placeholder: string; defaultPath: string }>
+);

--- a/packages/cli/src/utils/transformers.ts
+++ b/packages/cli/src/utils/transformers.ts
@@ -17,17 +17,17 @@ export async function transformContent(content: string, filename: string, config
 	return content;
 }
 
-const aliases = ["components", "ui", "hooks", "lib"] as const;
+export const ALIASES = ["components", "ui", "hooks", "lib", "utils"] as const;
+export const ALIAS_PLACEHOLDERS = ALIASES.reduce(
+	(acc, a) => ((acc[a] = `$${a.toUpperCase()}$`), acc),
+	{} as Record<(typeof ALIASES)[number], string>
+);
+
 export function transformImports(content: string, config: Config) {
-	// utils is a special case since it points to a single file
-	let str = content.replace(/\$lib\/utils/g, config.aliases.utils);
-
-	for (const alias of aliases) {
-		const regex = new RegExp(`\\$lib/registry.*?(/${alias}/)`, "g");
-		str = str.replace(regex, config.aliases[alias] + "/");
+	for (const alias of ALIASES) {
+		content = content.replaceAll(ALIAS_PLACEHOLDERS[alias], config.aliases[alias]);
 	}
-
-	return str;
+	return content;
 }
 
 export async function stripTypes(content: string, filename: string) {

--- a/packages/cli/src/utils/transformers.ts
+++ b/packages/cli/src/utils/transformers.ts
@@ -2,6 +2,7 @@ import { parse } from "postcss";
 import { transform } from "sucrase";
 import { strip } from "@svecosystem/strip-types";
 import type { CssVars } from "@shadcn-svelte/registry";
+import { ALIASES, ALIAS_DEFAULTS } from "../constants.js";
 import { updateCssVars, updateTailwindPlugins } from "./updaters.js";
 import type { Config } from "./get-config.js";
 
@@ -17,15 +18,9 @@ export async function transformContent(content: string, filename: string, config
 	return content;
 }
 
-export const ALIASES = ["components", "ui", "hooks", "lib", "utils"] as const;
-export const ALIAS_PLACEHOLDERS = ALIASES.reduce(
-	(acc, a) => ((acc[a] = `$${a.toUpperCase()}$`), acc),
-	{} as Record<(typeof ALIASES)[number], string>
-);
-
 export function transformImports(content: string, config: Config) {
 	for (const alias of ALIASES) {
-		content = content.replaceAll(ALIAS_PLACEHOLDERS[alias], config.aliases[alias]);
+		content = content.replaceAll(ALIAS_DEFAULTS[alias].placeholder, config.aliases[alias]);
 	}
 	return content;
 }

--- a/packages/cli/test/utils/transformers.spec.ts
+++ b/packages/cli/test/utils/transformers.spec.ts
@@ -34,35 +34,34 @@ const mockConfig: Config = {
 
 describe("transformImports", () => {
 	it("transforms component imports correctly", () => {
-		const content = 'import { Button } from "$lib/registry/default/components/button";';
+		const content = 'import { Button } from "$COMPONENTS$/button";';
 		const expected = 'import { Button } from "$lib/components/button";';
 		expect(transformImports(content, mockConfig)).toBe(expected);
 	});
 
 	it("transforms UI imports correctly", () => {
-		const content = 'import { Button } from "$lib/registry/default/ui/button";';
+		const content = 'import { Button } from "$UI$/button";';
 		const expected = 'import { Button } from "$lib/components/ui/button";';
 		expect(transformImports(content, mockConfig)).toBe(expected);
 	});
 
 	it("transforms hook imports correctly", () => {
-		const content =
-			'import { IsMobile } from "$lib/registry/default/hooks/is-mobile.svelte.js";';
+		const content = 'import { IsMobile } from "$HOOKS$/is-mobile.svelte.js";';
 		const expected = 'import { IsMobile } from "$lib/hooks/is-mobile.svelte.js";';
 		expect(transformImports(content, mockConfig)).toBe(expected);
 	});
 
 	it("transforms utils imports correctly", () => {
-		const content = 'import { cn } from "$lib/utils/index.js";';
+		const content = 'import { cn } from "$UTILS$/index.js";';
 		const expected = 'import { cn } from "$lib/utils/index.js";';
 		expect(transformImports(content, mockConfig)).toBe(expected);
 	});
 
 	it("handles multiple imports in the same file", () => {
 		const content = `
-      import { Button } from "$lib/registry/default/components/button";
-      import { IsMobile } from "$lib/registry/default/hooks/is-mobile.svelte.js";
-      import { cn } from "$lib/utils";
+      import { Button } from "$COMPONENTS$/button";
+      import { IsMobile } from "$HOOKS$/is-mobile.svelte.js";
+      import { cn } from "$UTILS$";
     `;
 		const expected = `
       import { Button } from "$lib/components/button";
@@ -122,7 +121,7 @@ describe("stripTypes", () => {
 describe("transformContent", () => {
 	it("transforms content with TypeScript enabled", async () => {
 		const content = `
-      import { Button } from "$lib/registry/default/components/button";
+      import { Button } from "$COMPONENTS$/button";
       interface Props {
         name: string;
       }
@@ -137,7 +136,7 @@ describe("transformContent", () => {
 
 	it("transforms content with TypeScript disabled", async () => {
 		const content = `
-      import { Button } from "$lib/registry/default/components/button";
+      import { Button } from "$COMPONENTS$/button";
       interface Props {
         name: string;
       }
@@ -180,35 +179,34 @@ describe("transformImports with more custom paths", () => {
 	};
 
 	it("transforms component imports with custom paths", () => {
-		const content = 'import { Button } from "$lib/registry/default/components/button";';
+		const content = 'import { Button } from "$COMPONENTS$/button";';
 		const expected = 'import { Button } from "@components/button";';
 		expect(transformImports(content, customConfig)).toBe(expected);
 	});
 
 	it("transforms UI imports with custom paths", () => {
-		const content = 'import { Button } from "$lib/registry/default/ui/button";';
+		const content = 'import { Button } from "$UI$/button";';
 		const expected = 'import { Button } from "@ui/button";';
 		expect(transformImports(content, customConfig)).toBe(expected);
 	});
 
 	it("transforms hook imports with custom paths", () => {
-		const content =
-			'import { IsMobile } from "$lib/registry/default/hooks/is-mobile.svelte.js";';
+		const content = 'import { IsMobile } from "$HOOKS$/is-mobile.svelte.js";';
 		const expected = 'import { IsMobile } from "@hooks/is-mobile.svelte.js";';
 		expect(transformImports(content, customConfig)).toBe(expected);
 	});
 
 	it("transforms utils imports with custom paths", () => {
-		const content = 'import { cn } from "$lib/utils/index.js";';
+		const content = 'import { cn } from "$UTILS$/index.js";';
 		const expected = 'import { cn } from "@lib/helpers/index.js";';
 		expect(transformImports(content, customConfig)).toBe(expected);
 	});
 
 	it("handles multiple imports with custom paths", () => {
 		const content = `
-      import { Button } from "$lib/registry/default/components/button";
-      import { IsMobile } from "$lib/registry/default/hooks/is-mobile.svelte.js";
-      import { cn } from "$lib/utils";
+      import { Button } from "$COMPONENTS$/button";
+      import { IsMobile } from "$HOOKS$/is-mobile.svelte.js";
+      import { cn } from "$UTILS$";
     `;
 		const expected = `
       import { Button } from "@components/button";

--- a/packages/registry/src/schemas.ts
+++ b/packages/registry/src/schemas.ts
@@ -104,6 +104,15 @@ export const registrySchema = v.object({
 	homepage: v.string(),
 	// installs specified versions of dependencies during auto-detection
 	overrideDependencies: v.optional(v.array(v.string())),
+	aliases: v.optional(
+		v.object({
+			lib: v.optional(v.string()),
+			ui: v.optional(v.string()),
+			components: v.optional(v.string()),
+			utils: v.optional(v.string()),
+			hooks: v.optional(v.string()),
+		})
+	),
 	items: v.array(
 		v.object({
 			...baseIndexItemSchema.entries,

--- a/sites/docs/registry.json
+++ b/sites/docs/registry.json
@@ -3,6 +3,13 @@
 	"name": "shadcn-svelte",
 	"homepage": "https://shadcn-svelte.com",
 	"overrideDependencies": ["paneforge@next", "vaul-svelte@next"],
+	"aliases": {
+		"lib": "$lib/registry/lib",
+		"ui": "$lib/registry/ui",
+		"components": "$lib/registry/components",
+		"utils": "$lib/utils",
+		"hooks": "$lib/registry/hooks"
+	},
 	"items": [
 		{
 			"name": "init",

--- a/sites/docs/scripts/build-registry.ts
+++ b/sites/docs/scripts/build-registry.ts
@@ -4,7 +4,12 @@ import path from "node:path";
 import * as v from "valibot";
 import prettier from "prettier";
 import { rimraf } from "rimraf";
-import { registrySchema, type RegistryItem, type RegistryItemType } from "@shadcn-svelte/registry";
+import {
+	registrySchema,
+	type Registry,
+	type RegistryItem,
+	type RegistryItemType,
+} from "@shadcn-svelte/registry";
 import { generateBaseColorTemplate, getColorsData } from "../src/lib/components/colors/colors.js";
 import { buildRegistry } from "./registry.js";
 import { baseColors } from "../src/lib/registry/colors.js";
@@ -56,10 +61,17 @@ export async function build() {
 		$schema: "./static/schema/registry.json",
 		name: "shadcn-svelte",
 		homepage: "https://shadcn-svelte.com",
+		aliases: {
+			lib: "$lib/registry/lib",
+			ui: "$lib/registry/ui",
+			components: "$lib/registry/components",
+			hooks: "$lib/registry/hooks",
+			utils: "$lib/utils",
+		},
 		// TODO: remove when moving from `next` to `latest`
 		overrideDependencies: ["paneforge@next", "vaul-svelte@next"],
 		items: [initItem, ...registry],
-	});
+	} as Registry);
 
 	const ITEM_TYPES: RegistryItemType[] = [
 		"registry:ui",


### PR DESCRIPTION
Adds a transformer to the `shadcn-svelte regsitry build` command that transforms import aliases into a standardized format.

So this:
```js
import Button from "$lib/registry/ui/button/index.js"
import isMobile from "$lib/registry/hooks/is-mobile.svelte.js"
```
would be transformed into this:
```js
import Button from "$UI$/button/index.js"
import isMobile from "$HOOKS$/is-mobile.svelte.js"
```

Aliases can be configured in the `registry.json` schema:
```jsonc
{
	"$schema": "...",
	"name": "shadcn-svelte",
	"aliases": {
		"lib": "$lib/registry/lib",
		"ui": "$lib/registry/ui",
		"components": "$lib/registry/components",
		"utils": "$lib/utils",
		"hooks": "$lib/registry/hooks"
	},
	// ...
}
```
