### PR TITLE
tw-4: fix cards preview for better responsiveness

### DIFF
--- a/v4/src/lib/components/card-demo.svelte
+++ b/v4/src/lib/components/card-demo.svelte
@@ -108,7 +108,7 @@
 			<div class="ml-auto font-medium tabular-nums">$135,000</div>
 		</Card.Footer>
 	</Card.Root>
-	<div class="flex w-full flex-wrap items-start gap-8 md:*:data-[slot=card]:basis-1/4">
+	<div class="flex w-full flex-wrap items-start gap-8 [&>*]:data-[slot=card]:basis-1/3 md:[&>*]:data-[slot=card]:basis-1/4">
 		<Card.Root>
 			<Card.Content class="text-sm">Content Only</Card.Content>
 		</Card.Root>

--- a/v4/src/lib/components/card-demo.svelte
+++ b/v4/src/lib/components/card-demo.svelte
@@ -108,7 +108,9 @@
 			<div class="ml-auto font-medium tabular-nums">$135,000</div>
 		</Card.Footer>
 	</Card.Root>
-	<div class="flex w-full flex-wrap items-start gap-8 [&>*]:data-[slot=card]:basis-1/3 md:[&>*]:data-[slot=card]:basis-1/4">
+	<div
+		class="flex w-full flex-wrap items-start gap-8 [&>*]:data-[slot=card]:basis-1/3 md:[&>*]:data-[slot=card]:basis-1/4"
+	>
 		<Card.Root>
 			<Card.Content class="text-sm">Content Only</Card.Content>
 		</Card.Root>


### PR DESCRIPTION
This pull request includes a minor fix to the `card-demo.svelte` file to adjust the layout of card components for better responsiveness.

<details>
<summary>before on mobile</summary>

![image](https://github.com/user-attachments/assets/f0562f63-c4b5-45b8-9a8d-945c52bc2cb5)
</details>
<details>
<summary>after</summary>

![image](https://github.com/user-attachments/assets/4f8ec260-2732-445d-a615-7dec1fec78a2)
</details>

