### PR TITLE
feat(cli): `local:` registryDeps

### DIFF
--- a/packages/cli/src/commands/registry/build.ts
+++ b/packages/cli/src/commands/registry/build.ts
@@ -163,20 +163,20 @@ async function runBuild(options: BuildOptions) {
 
 				const dependencies = new Set(item.dependencies);
 				const devDependencies = new Set(item.devDependencies);
-				/**
-				 * Transforms registryDependencies that start with `local:` into a relative path
-				 * that points to the registry json file.
-				 *
-				 * ```
-				 * "local:stepper"
-				 *```
-				 * transforms into:
-				 * ```
-				 * "./stepper.json"
-				 * ```
-				 */
 
 				const registryDependencies = new Set(
+					/**
+					 * Transforms registryDependencies that start with `local:` into a path
+					 * relative to the current registry-item's json file.
+					 *
+					 * ```
+					 * "local:stepper"
+					 *```
+					 * transforms into:
+					 * ```
+					 * "./stepper.json"
+					 * ```
+					 */
 					item.registryDependencies.map((registryDep) => {
 						if (registryDep.startsWith("local:")) {
 							return registryDep.replace(LOCAL_REGEX, "./$1.json");

--- a/packages/cli/src/commands/update/index.ts
+++ b/packages/cli/src/commands/update/index.ts
@@ -153,7 +153,6 @@ async function runUpdate(cwd: string, config: cliConfig.Config, options: UpdateO
 	const tasks: p.Task[] = [];
 
 	const resolvedItems = await registry.resolveRegistryItems({
-		baseUrl: registryUrl,
 		registryIndex: registryIndex,
 		items: selectedComponents.map((comp) => comp.name),
 	});

--- a/packages/cli/src/utils/add-registry-items.ts
+++ b/packages/cli/src/utils/add-registry-items.ts
@@ -30,7 +30,6 @@ export async function addRegistryItems(opts: AddRegistryItemsProps) {
 
 	const registryIndex = await registry.getRegistryIndex(registryUrl);
 	const resolvedItems = await registry.resolveRegistryItems({
-		baseUrl: registryUrl,
 		items: Array.from(selectedItems),
 		registryIndex,
 	});

--- a/packages/cli/src/utils/registry/index.ts
+++ b/packages/cli/src/utils/registry/index.ts
@@ -60,9 +60,10 @@ export async function resolveRegistryItems({
 	baseUrl,
 	items,
 	includeRegDeps = true,
-	remoteUrl,
+	remoteUrl: parentRemoteUrl,
 }: ResolveRegistryItemsProps): Promise<ResolvedRegistryItem[]> {
 	const resolvedItems: ResolvedRegistryItem[] = [];
+	let remoteUrl: URL | undefined;
 
 	for (const item of items) {
 		let resolvedItem: ResolvedRegistryItem | undefined = registryIndex.find(
@@ -79,8 +80,8 @@ export async function resolveRegistryItems({
 				const [result] = await fetchRegistry([item]);
 				resolvedItem = schemas.registryItemSchema.parse(result);
 				remoteUrl = new URL(item);
-			} else if (remoteUrl) {
-				const resolvedUrl = new URL(item, remoteUrl.href);
+			} else if (parentRemoteUrl) {
+				const resolvedUrl = new URL(item, parentRemoteUrl.href);
 				const [result] = await fetchRegistry([resolvedUrl]);
 				resolvedItem = schemas.registryItemSchema.parse(result);
 				remoteUrl = resolvedUrl;

--- a/packages/cli/src/utils/registry/index.ts
+++ b/packages/cli/src/utils/registry/index.ts
@@ -72,15 +72,15 @@ export async function resolveRegistryItems({
 		 * 2. a `local:registryDep` of a _remote_  item (relative path from that item to the dep)
 		 */
 		if (!resolvedItem) {
+			const isRelative = item.startsWith("./") || item.startsWith("../");
 			if (isUrl(item)) {
-				const [result] = await fetchRegistry([item]);
-				resolvedItem = schemas.registryItemSchema.parse(result);
 				remoteUrl = new URL(item);
-			} else if (parentUrl) {
-				const resolvedUrl = new URL(item, parentUrl);
-				const [result] = await fetchRegistry([resolvedUrl]);
+				const [result] = await fetchRegistry([remoteUrl]);
 				resolvedItem = schemas.registryItemSchema.parse(result);
-				remoteUrl = resolvedUrl;
+			} else if (parentUrl && isRelative) {
+				remoteUrl = new URL(item, parentUrl);
+				const [result] = await fetchRegistry([remoteUrl]);
+				resolvedItem = schemas.registryItemSchema.parse(result);
 			} else {
 				throw error(
 					`Registry item '${item}' does not exist in the registry, nor is it a valid URL or a relative path to a registry dependency.`

--- a/packages/cli/src/utils/registry/index.ts
+++ b/packages/cli/src/utils/registry/index.ts
@@ -73,11 +73,7 @@ export async function resolveRegistryItems({
 		 */
 		if (!resolvedItem) {
 			const isRelative = item.startsWith("./") || item.startsWith("../");
-			if (isUrl(item)) {
-				remoteUrl = new URL(item);
-				const [result] = await fetchRegistry([remoteUrl]);
-				resolvedItem = schemas.registryItemSchema.parse(result);
-			} else if (parentUrl && isRelative) {
+			if (isUrl(item) || (parentUrl && isRelative)) {
 				remoteUrl = new URL(item, parentUrl);
 				const [result] = await fetchRegistry([remoteUrl]);
 				resolvedItem = schemas.registryItemSchema.parse(result);

--- a/packages/cli/src/utils/registry/index.ts
+++ b/packages/cli/src/utils/registry/index.ts
@@ -87,7 +87,7 @@ export async function resolveRegistryItems({
 				remoteUrl = resolvedUrl;
 			} else {
 				throw error(
-					`Component item '${item}' does not exist in the registry, nor is it a valid URL/local:registryDep..`
+					`Component item '${item}' does not exist in the registry, nor is it a valid URL/local:registryDep.`
 				);
 			}
 		}

--- a/packages/cli/src/utils/registry/index.ts
+++ b/packages/cli/src/utils/registry/index.ts
@@ -47,59 +47,54 @@ export async function getRegistryBaseColor(baseUrl: string, baseColor: string) {
 }
 
 type ResolveRegistryItemsProps = {
-	baseUrl: string;
 	registryIndex: schemas.RegistryIndex;
 	items: string[];
-	includeRegDeps?: boolean;
-	remoteUrl?: URL;
+	parentUrl?: URL;
 };
 
 type ResolvedRegistryItem = schemas.RegistryItem | schemas.RegistryIndexItem;
 export async function resolveRegistryItems({
 	registryIndex,
-	baseUrl,
 	items,
-	includeRegDeps = true,
-	remoteUrl: parentRemoteUrl,
+	parentUrl,
 }: ResolveRegistryItemsProps): Promise<ResolvedRegistryItem[]> {
 	const resolvedItems: ResolvedRegistryItem[] = [];
-	let remoteUrl: URL | undefined;
 
 	for (const item of items) {
+		let remoteUrl: URL | undefined;
 		let resolvedItem: ResolvedRegistryItem | undefined = registryIndex.find(
 			(entry) => entry.name === item
 		);
 
 		/**
-		 * The `item` doesn't exist in the shadcn-svelte `index`, so it can be one of two things:
-		 * 1. remote registry item (URL)
-		 * 2. local:registryDep of a _remote_  item (relative path from that item to the dep)
+		 * The `item` doesn't exist in the registry's `index`, so it can be one of two things:
+		 * 1. a remote registry item (URL)
+		 * 2. a `local:registryDep` of a _remote_  item (relative path from that item to the dep)
 		 */
 		if (!resolvedItem) {
 			if (isUrl(item)) {
 				const [result] = await fetchRegistry([item]);
 				resolvedItem = schemas.registryItemSchema.parse(result);
 				remoteUrl = new URL(item);
-			} else if (parentRemoteUrl) {
-				const resolvedUrl = new URL(item, parentRemoteUrl.href);
+			} else if (parentUrl) {
+				const resolvedUrl = new URL(item, parentUrl);
 				const [result] = await fetchRegistry([resolvedUrl]);
 				resolvedItem = schemas.registryItemSchema.parse(result);
 				remoteUrl = resolvedUrl;
 			} else {
 				throw error(
-					`Component item '${item}' does not exist in the registry, nor is it a valid URL/local:registryDep.`
+					`Registry item '${item}' does not exist in the registry, nor is it a valid URL or a relative path to a registry dependency.`
 				);
 			}
 		}
 
 		resolvedItems.push(resolvedItem);
 
-		if (includeRegDeps && resolvedItem.registryDependencies?.length) {
+		if (resolvedItem.registryDependencies?.length) {
 			const registryDeps = await resolveRegistryItems({
-				baseUrl,
 				registryIndex: registryIndex,
 				items: resolvedItem.registryDependencies,
-				remoteUrl,
+				parentUrl: remoteUrl,
 			});
 			resolvedItems.push(...registryDeps);
 		}

--- a/registry-template/registry.json
+++ b/registry-template/registry.json
@@ -25,7 +25,7 @@
 			"registryDependencies": ["button", "input", "label", "textarea", "card"],
 			"files": [
 				{
-					"path": "registry/blocks/example-form/example-form.svelte",
+					"path": "src/lib/registry/blocks/example-form/example-form.svelte",
 					"type": "registry:component"
 				}
 			]
@@ -84,15 +84,15 @@
 			"files": [
 				{
 					"path": "src/lib/registry/ui/stepper/stepper.svelte",
-					"type": "registry:component"
+					"type": "registry:file"
 				},
 				{
 					"path": "src/lib/registry/ui/stepper/stepper-item.svelte",
-					"type": "registry:component"
+					"type": "registry:file"
 				},
 				{
 					"path": "src/lib/registry/ui/stepper/index.ts",
-					"type": "registry:lib"
+					"type": "registry:file"
 				}
 			]
 		},

--- a/sites/docs/src/content/registry/registry-item-json.md
+++ b/sites/docs/src/content/registry/registry-item-json.md
@@ -136,10 +136,11 @@ Use `@version` to specify the version of your registry item.
 
 ### registryDependencies
 
-Used for registry dependencies. Can be names or URLs. Use the name of the item to reference shadcn/ui components and urls to reference other registries.
+Specifies the registry dependencies of the registry item, which can be one of the following:
 
-- For `shadcn-svelte` registry items such as `button`, `input`, `select`, etc use the name eg. `['button', 'input', 'select']`.
-- For custom registry items use the URL of the registry item eg. `['https://example.com/r/hello-world.json']`.
+- A name eg. `['button', 'input', 'select']` - which will resolve to the component in the shadcn-svelte registry
+- A URL to a custom registry item eg. `['https://example.com/r/hello-world.json']`
+- A name prefixed with `local:` eg. `local:stepper` - which will resolve to a component in the current registry
 
 ```json title="registry-item.json" showLineNumbers
 {
@@ -147,7 +148,8 @@ Used for registry dependencies. Can be names or URLs. Use the name of the item t
     "button",
     "input",
     "select",
-    "https://example.com/r/editor.json"
+    "https://example.com/r/editor.json",
+    "local:stepper"
   ]
 }
 ```

--- a/sites/docs/src/content/registry/registry-item-json.md
+++ b/sites/docs/src/content/registry/registry-item-json.md
@@ -183,29 +183,13 @@ Which the CLI will convert to the following in the output `registry-item.json` f
 
 #### Relative Path
 
-If you're not using the CLI and defining the item directly in its `registry-item.json` file, you can specify a path relative to the current item to reference another item in the registry (e.g. `./stepper.json`).
+If you're not using the CLI and defining the item directly in its `registry-item.json` file, you can specify a relative path, which is relative to the current item, to reference another item in the registry (e.g. `./stepper.json`).
 
 ```json title="registry-item.json" showLineNumbers
 {
   "registryDependencies": ["./stepper.json"]
 }
 ```
-
-Which the CLI will convert to the following in the output:
-
-```json title="registry-item.json" showLineNumbers
-{
-  "registryDependencies": [
-    "button",
-    "input",
-    "select",
-    "https://example.com/r/editor.json",
-    "./stepper.json"
-  ]
-}
-```
-
-Note: The CLI will automatically resolve remote registry dependencies.
 
 ### files
 
@@ -338,8 +322,4 @@ Use `meta` to add additional metadata to your registry item. You can add any key
 {
   "meta": { "foo": "bar" }
 }
-```
-
-```
-
 ```

--- a/sites/docs/src/content/registry/registry-item-json.md
+++ b/sites/docs/src/content/registry/registry-item-json.md
@@ -136,7 +136,9 @@ Use `@version` to specify the version of your registry item.
 
 ### registryDependencies
 
-Defines other registry items that this item depends on. Each entry may be one of:
+Defines other registry items that this item depends on.
+
+Each entry may be one of the following:
 
 #### shadcn-svelte Registry Item
 

--- a/sites/docs/src/content/registry/registry-item-json.md
+++ b/sites/docs/src/content/registry/registry-item-json.md
@@ -136,11 +136,62 @@ Use `@version` to specify the version of your registry item.
 
 ### registryDependencies
 
-Specifies the registry dependencies of the registry item, which can be one of the following:
+Defines other registry items that this item depends on. Each entry may be one of:
 
-- A name eg. `['button', 'input', 'select']` - which will resolve to the component in the shadcn-svelte registry
-- A URL to a custom registry item eg. `['https://example.com/r/hello-world.json']`
-- A name prefixed with `local:` eg. `local:stepper` - which will resolve to a component in the current registry
+#### shadcn-svelte Registry Item
+
+The name of a shadcn-svelte registry item (e.g., `'button'`, `'input'`, `'select'`), which will resolve to that item in the shadcn-svelte registry.
+
+```json title="registry-item.json" showLineNumbers
+{
+  "registryDependencies": ["button", "input", "select"]
+}
+```
+
+#### Remote URL
+
+A full URL to a custom registry item (e.g. `https://example.com/r/hello-world.json`)
+
+```json title="registry-item.json" showLineNumbers
+{
+  "registryDependencies": ["https://example.com/r/hello-world.json"]
+}
+```
+
+#### Local alias (when building with the CLI)
+
+If you're defining the item in `registry.json` and using the CLI to build the registry, you can use a name prefixed with `local:` (e.g. `local:stepper`) to reference an item in the current registry. The CLI will convert this to a relative path (e.g. `./stepper.json`) in the output `registry-item.json` file.
+
+```json title="registry.json" showLineNumbers
+{
+  "items": [
+    {
+      "name": "hello-world",
+      "registryDependencies": ["local:stepper"]
+    }
+  ]
+}
+```
+
+Which the CLI will convert to the following in the output `registry-item.json` file:
+
+```json title="registry-item.json" showLineNumbers
+{
+  "registryDependencies": ["./stepper.json"]
+}
+```
+
+#### Relative Path
+
+If you're not using the CLI and defining the item directly in its `registry-item.json` file, you can specify a path relative to the current item to reference another item in the registry (e.g. `./stepper.json`).
+
+```json title="registry-item.json" showLineNumbers
+{
+  "registryDependencies": ["./stepper.json"]
+}
+```
+
+Which the CLI will convert to the following in the output:
 
 ```json title="registry-item.json" showLineNumbers
 {
@@ -149,7 +200,7 @@ Specifies the registry dependencies of the registry item, which can be one of th
     "input",
     "select",
     "https://example.com/r/editor.json",
-    "local:stepper"
+    "./stepper.json"
   ]
 }
 ```
@@ -287,4 +338,8 @@ Use `meta` to add additional metadata to your registry item. You can add any key
 {
   "meta": { "foo": "bar" }
 }
+```
+
+```
+
 ```

--- a/sites/docs/src/content/registry/registry-json.md
+++ b/sites/docs/src/content/registry/registry-json.md
@@ -22,7 +22,7 @@ The `registry.json` schema is used to define your custom component registry.
       "description": "A simple hello world component.",
       "files": [
         {
-          "path": "registry/hello-world/hello-world.svelte",
+          "path": "src/lib/registry/blocks/hello-world/hello-world.svelte",
           "type": "registry:component"
         }
       ]
@@ -79,7 +79,7 @@ The `items` in your registry. Each item must implement the [registry-item schema
       "description": "A simple hello world component.",
       "files": [
         {
-          "path": "registry/hello-world/hello-world.svelte",
+          "path": "src/lib/registry/blocks/hello-world/hello-world.svelte",
           "type": "registry:component"
         }
       ]


### PR DESCRIPTION
<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->

Enables custom registries to reference their own components as `registryDependencies` using the `local:<item_name>` shorthand, which resolves to a relative path that we use to grab it.
