### PR TITLE
fix(calendar-day): enhance dark mode styles for selected state

### DIFF
--- a/sites/docs/src/lib/registry/ui/calendar/calendar-day.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-day.svelte
@@ -17,7 +17,7 @@
 		"size-8 select-none p-0 font-normal",
 		"[&[data-today]:not([data-selected])]:bg-accent [&[data-today]:not([data-selected])]:text-accent-foreground",
 		// Selected
-		"data-selected:bg-primary data-selected:text-primary-foreground data-selected:hover:bg-primary data-selected:hover:text-primary-foreground data-selected:focus:bg-primary data-selected:focus:text-primary-foreground data-selected:opacity-100",
+		"data-selected:bg-primary data-selected:text-primary-foreground data-selected:hover:bg-primary data-selected:hover:text-primary-foreground data-selected:focus:bg-primary data-selected:focus:text-primary-foreground data-selected:opacity-100 dark:data-selected:hover:bg-primary dark:data-selected:focus:bg-primary",
 		// Disabled
 		"data-disabled:text-muted-foreground data-disabled:opacity-50",
 		// Unavailable

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-day.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-day.svelte
@@ -19,9 +19,9 @@
 		"size-8 select-none p-0 font-normal data-[selected]:opacity-100",
 		"[&[data-today]:not([data-selected])]:bg-accent [&[data-today]:not([data-selected])]:text-accent-foreground",
 		// Selection Start
-		"data-[selection-start]:bg-primary data-[selection-start]:text-primary-foreground data-[selection-start]:hover:bg-primary data-[selection-start]:hover:text-primary-foreground data-[selection-start]:focus:bg-primary data-[selection-start]:focus:text-primary-foreground",
+		"data-[selection-start]:bg-primary data-[selection-start]:text-primary-foreground data-[selection-start]:hover:bg-primary data-[selection-start]:hover:text-primary-foreground data-[selection-start]:focus:bg-primary data-[selection-start]:focus:text-primary-foreground dark:data-[selection-start]:hover:bg-primary dark:data-[selection-start]:focus:bg-primary",
 		// Selection End
-		"data-[selection-end]:bg-primary data-[selection-end]:text-primary-foreground data-[selection-end]:hover:bg-primary data-[selection-end]:hover:text-primary-foreground data-[selection-end]:focus:bg-primary data-[selection-end]:focus:text-primary-foreground",
+		"data-[selection-end]:bg-primary data-[selection-end]:text-primary-foreground data-[selection-end]:hover:bg-primary data-[selection-end]:hover:text-primary-foreground data-[selection-end]:focus:bg-primary data-[selection-end]:focus:text-primary-foreground dark:data-[selection-end]:hover:bg-primary dark:data-[selection-end]:focus:bg-primary",
 		// Outside months
 		"data-[outside-month]:text-muted-foreground [&[data-outside-month][data-selected]]:bg-accent/50 [&[data-outside-month][data-selected]]:text-muted-foreground data-[outside-month]:pointer-events-none data-[outside-month]:opacity-50 [&[data-outside-month][data-selected]]:opacity-30",
 		// Disabled


### PR DESCRIPTION
This pull request includes an update to the `calendar-day.svelte` component to fix its behavior in dark mode. Before, hovering on the selected day in dark mode would display `bg-accent/50` due to the `"ghost"` variant of `Button`.

---

### Summary
Added `dark:data-selected:hover:bg-primary` and `dark:data-selected:focus:bg-primary` to the `data-selected` styling.