### PR TITLE
docs: fix component source links

### DIFF
--- a/sites/docs/src/content/components/accordion.md
+++ b/sites/docs/src/content/components/accordion.md
@@ -3,7 +3,7 @@ title: Accordion
 description: A vertically stacked set of interactive headings that each reveal a section of content.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/accordion
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/accordion
   doc: https://bits-ui.com/docs/components/accordion
   api: https://bits-ui.com/docs/components/accordion#api-reference
 ---

--- a/sites/docs/src/content/components/alert-dialog.md
+++ b/sites/docs/src/content/components/alert-dialog.md
@@ -3,7 +3,7 @@ title: Alert Dialog
 description: A modal dialog that interrupts the user with important content and expects a response.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/alert-dialog
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/alert-dialog
   doc: https://bits-ui.com/docs/components/alert-dialog
   api: https://bits-ui.com/docs/components/alert-dialog#api-reference
 ---

--- a/sites/docs/src/content/components/alert.md
+++ b/sites/docs/src/content/components/alert.md
@@ -3,7 +3,7 @@ title: Alert
 description: Displays a callout for user attention.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/alert
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/alert
 ---
 
 <script>

--- a/sites/docs/src/content/components/aspect-ratio.md
+++ b/sites/docs/src/content/components/aspect-ratio.md
@@ -3,7 +3,7 @@ title: Aspect Ratio
 description: Displays content within a desired ratio.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/aspect-ratio
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/aspect-ratio
   doc: https://bits-ui.com/docs/components/aspect-ratio
   api: https://bits-ui.com/docs/components/aspect-ratio#api-reference
 ---

--- a/sites/docs/src/content/components/avatar.md
+++ b/sites/docs/src/content/components/avatar.md
@@ -3,7 +3,7 @@ title: Avatar
 description: An image element with a fallback for representing the user.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/avatar
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/avatar
   doc: https://bits-ui.com/docs/components/avatar
   api: https://bits-ui.com/docs/components/avatar#api-reference
 ---

--- a/sites/docs/src/content/components/badge.md
+++ b/sites/docs/src/content/components/badge.md
@@ -2,7 +2,7 @@
 title: Badge
 description: Displays a badge or a component that looks like a badge.
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/badge
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/badge
 ---
 
 <script>

--- a/sites/docs/src/content/components/breadcrumb.md
+++ b/sites/docs/src/content/components/breadcrumb.md
@@ -3,7 +3,7 @@ title: Breadcrumb
 description: Displays the path to the current resource using a hierarchy of links.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/breadcrumb
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/breadcrumb
 ---
 
 <script>

--- a/sites/docs/src/content/components/button.md
+++ b/sites/docs/src/content/components/button.md
@@ -3,7 +3,7 @@ title: Button
 description: Displays a button or a component that looks like a button.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/button
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/button
   doc: https://bits-ui.com/docs/components/button
   api: https://bits-ui.com/docs/components/button#api-reference
 ---

--- a/sites/docs/src/content/components/calendar.md
+++ b/sites/docs/src/content/components/calendar.md
@@ -3,7 +3,7 @@ title: Calendar
 description: A calendar component that allows users to select dates.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/calendar
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/calendar
   doc: https://bits-ui.com/docs/components/calendar
   api: https://bits-ui.com/docs/components/calendar#api-reference
 ---

--- a/sites/docs/src/content/components/card.md
+++ b/sites/docs/src/content/components/card.md
@@ -3,7 +3,7 @@ title: Card
 description: Displays a card with header, content, and footer.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/card
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/card
 ---
 
 <script>

--- a/sites/docs/src/content/components/carousel.md
+++ b/sites/docs/src/content/components/carousel.md
@@ -3,7 +3,7 @@ title: Carousel
 description: A carousel with motion and swipe built using Embla.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/carousel
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/carousel
   doc: https://www.embla-carousel.com/get-started/svelte
   api: https://www.embla-carousel.com/api
 ---

--- a/sites/docs/src/content/components/checkbox.md
+++ b/sites/docs/src/content/components/checkbox.md
@@ -3,7 +3,7 @@ title: Checkbox
 description: A control that allows the user to toggle between checked and not checked.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/checkbox
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/checkbox
   doc: https://bits-ui.com/docs/components/checkbox
   api: https://bits-ui.com/docs/components/checkbox#api-reference
 ---

--- a/sites/docs/src/content/components/collapsible.md
+++ b/sites/docs/src/content/components/collapsible.md
@@ -3,7 +3,7 @@ title: Collapsible
 description: An interactive component which expands/collapses a panel.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/collapsible
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/collapsible
   doc: https://bits-ui.com/docs/components/collapsible
   api: https://bits-ui.com/docs/components/collapsible#api-reference
 ---

--- a/sites/docs/src/content/components/command.md
+++ b/sites/docs/src/content/components/command.md
@@ -3,7 +3,7 @@ title: Command
 description: Fast, composable, unstyled command menu for Svelte.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/command
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/command
   doc: https://bits-ui.com/docs/components/command
   api: https://bits-ui.com/docs/components/command#api-reference
 ---

--- a/sites/docs/src/content/components/context-menu.md
+++ b/sites/docs/src/content/components/context-menu.md
@@ -3,7 +3,7 @@ title: Context Menu
 description: Displays a menu to the user — such as a set of actions or functions — triggered by right click.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/context-menu
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/context-menu
   doc: https://bits-ui.com/docs/components/context-menu
   api: https://bits-ui.com/docs/components/context-menu#api-reference
 ---

--- a/sites/docs/src/content/components/date-picker.md
+++ b/sites/docs/src/content/components/date-picker.md
@@ -3,7 +3,7 @@ title: Date Picker
 description: A date picker component with range and presets.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/blob/main/sites/docs/src/lib/registry/examples/date-picker-demo.svelte
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/examples/date-picker-demo.svelte
 ---
 
 <script>

--- a/sites/docs/src/content/components/dialog.md
+++ b/sites/docs/src/content/components/dialog.md
@@ -3,7 +3,7 @@ title: Dialog
 description: A window overlaid on either the primary window or another dialog window, rendering the content underneath inert.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/dialog
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/dialog
   doc: https://bits-ui.com/docs/components/dialog
   api: https://bits-ui.com/docs/components/dialog#api-reference
 ---

--- a/sites/docs/src/content/components/drawer.md
+++ b/sites/docs/src/content/components/drawer.md
@@ -3,7 +3,7 @@ title: Drawer
 description: A drawer component for Svelte.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/drawer
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/drawer
   doc: https://github.com/huntabyte/vaul-svelte
 ---
 

--- a/sites/docs/src/content/components/dropdown-menu.md
+++ b/sites/docs/src/content/components/dropdown-menu.md
@@ -3,7 +3,7 @@ title: Dropdown Menu
 description: Displays a menu to the user — such as a set of actions or functions — triggered by a button.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/dropdown-menu
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/dropdown-menu
   doc: https://bits-ui.com/docs/components/dropdown-menu
   api: https://bits-ui.com/docs/components/dropdown-menu#api-reference
 ---

--- a/sites/docs/src/content/components/form.md
+++ b/sites/docs/src/content/components/form.md
@@ -3,6 +3,7 @@ title: Formsnap & Superforms
 description: Building forms with Formsnap, Superforms, & Zod.
 links:
   doc: https://formsnap.dev
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/form
 ---
 
 <script>

--- a/sites/docs/src/content/components/hover-card.md
+++ b/sites/docs/src/content/components/hover-card.md
@@ -3,7 +3,7 @@ title: Hover Card
 description: For sighted users to preview content available behind a link.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/link-preview
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/link-preview
   doc: https://bits-ui.com/docs/components/link-preview
   api: https://bits-ui.com/docs/components/link-preview#api-reference
 ---

--- a/sites/docs/src/content/components/input-otp.md
+++ b/sites/docs/src/content/components/input-otp.md
@@ -3,7 +3,7 @@ title: Input OTP
 description: Accessible one-time password component with copy paste functionality.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/input-otp
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/input-otp
   doc: https://bits-ui.com/docs/components/pin-input
   api: https://bits-ui.com/docs/components/pin-input#api-reference
 ---

--- a/sites/docs/src/content/components/input.md
+++ b/sites/docs/src/content/components/input.md
@@ -3,7 +3,7 @@ title: Input
 description: Displays a form input field or a component that looks like an input field.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/input
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/input
 ---
 
 <script>

--- a/sites/docs/src/content/components/label.md
+++ b/sites/docs/src/content/components/label.md
@@ -3,7 +3,7 @@ title: Label
 description: Renders an accessible label associated with controls.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/label
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/label
   doc: https://bits-ui.com/docs/components/label
   api: https://bits-ui.com/docs/components/label#api-reference
 ---

--- a/sites/docs/src/content/components/menubar.md
+++ b/sites/docs/src/content/components/menubar.md
@@ -3,7 +3,7 @@ title: Menubar
 description: A visually persistent menu common in desktop applications that provides quick access to a consistent set of commands.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/menubar
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/menubar
   doc: https://bits-ui.com/docs/components/menubar
   api: https://bits-ui.com/docs/components/menubar#api-reference
 ---

--- a/sites/docs/src/content/components/pagination.md
+++ b/sites/docs/src/content/components/pagination.md
@@ -3,7 +3,7 @@ title: Pagination
 description: Pagination with page navigation, next and previous links.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/pagination
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/pagination
   doc: https://bits-ui.com/docs/components/pagination
   api: https://bits-ui.com/docs/components/pagination#api-reference
 ---

--- a/sites/docs/src/content/components/popover.md
+++ b/sites/docs/src/content/components/popover.md
@@ -3,7 +3,7 @@ title: Popover
 description: Displays rich content in a portal, triggered by a button.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/popover
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/popover
   doc: https://bits-ui.com/docs/components/popover
   api: https://bits-ui.com/docs/components/popover#api-reference
 ---

--- a/sites/docs/src/content/components/progress.md
+++ b/sites/docs/src/content/components/progress.md
@@ -3,7 +3,7 @@ title: Progress
 description: Displays an indicator showing the completion progress of a task, typically displayed as a progress bar.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/progress
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/progress
   doc: https://bits-ui.com/docs/components/progress
   api: https://bits-ui.com/docs/components/progress#api-reference
 ---

--- a/sites/docs/src/content/components/radio-group.md
+++ b/sites/docs/src/content/components/radio-group.md
@@ -3,7 +3,7 @@ title: Radio Group
 description: A set of checkable buttons—known as radio buttons—where no more than one of the buttons can be checked at a time.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/radio-group
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/radio-group
   doc: https://bits-ui.com/docs/components/radio-group
   api: https://bits-ui.com/docs/components/radio-group#api-reference
 ---

--- a/sites/docs/src/content/components/range-calendar.md
+++ b/sites/docs/src/content/components/range-calendar.md
@@ -3,7 +3,7 @@ title: Range Calendar
 description: A calendar component that allows users to select a range of dates.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/range-calendar
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/range-calendar
   doc: https://bits-ui.com/docs/components/range-calendar
   api: https://bits-ui.com/docs/components/range-calendar#api-reference
 ---

--- a/sites/docs/src/content/components/resizable.md
+++ b/sites/docs/src/content/components/resizable.md
@@ -3,7 +3,7 @@ title: Resizable
 description: Accessible resizable panel groups and layouts with keyboard support.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/resizable
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/resizable
   doc: https://www.paneforge.com
 ---
 

--- a/sites/docs/src/content/components/scroll-area.md
+++ b/sites/docs/src/content/components/scroll-area.md
@@ -3,7 +3,7 @@ title: Scroll Area
 description: Augments native scroll functionality for custom, cross-browser styling.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/scroll-area
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/scroll-area
   doc: https://bits-ui.com/docs/components/scroll-area
   api: https://bits-ui.com/docs/components/scroll-area#api-reference
 ---

--- a/sites/docs/src/content/components/select.md
+++ b/sites/docs/src/content/components/select.md
@@ -3,7 +3,7 @@ title: Select
 description: Displays a list of options for the user to pick from—triggered by a button.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/select
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/select
   doc: https://bits-ui.com/docs/components/select
   api: https://bits-ui.com/docs/components/select#api-reference
 ---

--- a/sites/docs/src/content/components/separator.md
+++ b/sites/docs/src/content/components/separator.md
@@ -3,7 +3,7 @@ title: Separator
 description: Visually or semantically separates content.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/separator
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/separator
   doc: https://bits-ui.com/docs/components/separator
   api: https://bits-ui.com/docs/components/separator#api-reference
 ---

--- a/sites/docs/src/content/components/sheet.md
+++ b/sites/docs/src/content/components/sheet.md
@@ -3,7 +3,7 @@ title: Sheet
 description: Extends the Dialog component to display content that complements the main content of the screen.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/sheet
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/sheet
   doc: https://bits-ui.com/docs/components/dialog
   api: https://bits-ui.com/docs/components/dialog#api-reference
 ---

--- a/sites/docs/src/content/components/sidebar.md
+++ b/sites/docs/src/content/components/sidebar.md
@@ -3,7 +3,7 @@ title: Sidebar
 description: A composable, themeable and customizable sidebar component.
 component: true
 links:
-	source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/sidebar
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/sidebar
 ---
 
 <script>

--- a/sites/docs/src/content/components/sidebar.md
+++ b/sites/docs/src/content/components/sidebar.md
@@ -2,6 +2,8 @@
 title: Sidebar
 description: A composable, themeable and customizable sidebar component.
 component: true
+links:
+	source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/sidebar
 ---
 
 <script>

--- a/sites/docs/src/content/components/skeleton.md
+++ b/sites/docs/src/content/components/skeleton.md
@@ -3,7 +3,7 @@ title: Skeleton
 description: Use to show a placeholder while content is loading.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/skeleton
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/skeleton
 ---
 
 <script>

--- a/sites/docs/src/content/components/slider.md
+++ b/sites/docs/src/content/components/slider.md
@@ -3,7 +3,7 @@ title: Slider
 description: An input where the user selects a value from within a given range.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/slider
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/slider
   doc: https://bits-ui.com/docs/components/slider
   api: https://bits-ui.com/docs/components/slider#api-reference
 ---

--- a/sites/docs/src/content/components/sonner.md
+++ b/sites/docs/src/content/components/sonner.md
@@ -3,7 +3,7 @@ title: Sonner
 description: An opinionated toast component for Svelte.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/sonner
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/sonner
   doc: https://svelte-sonner.vercel.app/
   api: https://github.com/wobsoriano/svelte-sonner
 ---

--- a/sites/docs/src/content/components/switch.md
+++ b/sites/docs/src/content/components/switch.md
@@ -3,7 +3,7 @@ title: Switch
 description: A control that allows the user to toggle between checked and not checked.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/switch
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/switch
   doc: https://bits-ui.com/docs/components/switch
   api: https://bits-ui.com/docs/components/switch#api-reference
 ---

--- a/sites/docs/src/content/components/table.md
+++ b/sites/docs/src/content/components/table.md
@@ -3,7 +3,7 @@ title: Table
 description: A responsive table component.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/table
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/table
 ---
 
 <script>

--- a/sites/docs/src/content/components/tabs.md
+++ b/sites/docs/src/content/components/tabs.md
@@ -3,7 +3,7 @@ title: Tabs
 description: A set of layered sections of content—known as tab panels—that are displayed one at a time.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/tabs
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/tabs
   doc: https://bits-ui.com/docs/components/tabs
   api: https://bits-ui.com/docs/components/tabs#api-reference
 ---

--- a/sites/docs/src/content/components/textarea.md
+++ b/sites/docs/src/content/components/textarea.md
@@ -3,7 +3,7 @@ title: Textarea
 description: Displays a form textarea or a component that looks like a textarea.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/textarea
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/textarea
 ---
 
 <script>

--- a/sites/docs/src/content/components/toggle-group.md
+++ b/sites/docs/src/content/components/toggle-group.md
@@ -3,7 +3,7 @@ title: Toggle Group
 description: A set of two-state buttons that can be toggled on or off.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/toggle-group
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/toggle-group
   doc: https://bits-ui.com/docs/components/toggle-group
   api: https://bits-ui.com/docs/components/toggle-group#api-reference
 ---

--- a/sites/docs/src/content/components/toggle.md
+++ b/sites/docs/src/content/components/toggle.md
@@ -3,7 +3,7 @@ title: Toggle
 description: A two-state button that can be either on or off.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/toggle
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/toggle
   doc: https://bits-ui.com/docs/components/toggle
   api: https://bits-ui.com/docs/components/toggle#api-reference
 ---

--- a/sites/docs/src/content/components/tooltip.md
+++ b/sites/docs/src/content/components/tooltip.md
@@ -3,7 +3,7 @@ title: Tooltip
 description: A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.
 component: true
 links:
-  source: https://github.com/huntabyte/shadcn-svelte/tree/main/sites/docs/src/lib/registry/ui/tooltip
+  source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/tooltip
   doc: https://bits-ui.com/docs/components/tooltip
   api: https://bits-ui.com/docs/components/tooltip#api-reference
 ---


### PR DESCRIPTION
<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->

`Component Source` links on the various doc pages were pointing to the `main` source code rather than `next`.