### PR TITLE
feat(next): make components more JSDoc friendly

### DIFF
--- a/sites/docs/src/lib/registry/ui/accordion/accordion-content.svelte
+++ b/sites/docs/src/lib/registry/ui/accordion/accordion-content.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithoutChild<AccordionPrimitive.ContentProps> = $props();

--- a/sites/docs/src/lib/registry/ui/accordion/accordion-content.svelte
+++ b/sites/docs/src/lib/registry/ui/accordion/accordion-content.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithoutChild<AccordionPrimitive.ContentProps> = $props();

--- a/sites/docs/src/lib/registry/ui/accordion/accordion-item.svelte
+++ b/sites/docs/src/lib/registry/ui/accordion/accordion-item.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: AccordionPrimitive.ItemProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/accordion/accordion-item.svelte
+++ b/sites/docs/src/lib/registry/ui/accordion/accordion-item.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: AccordionPrimitive.ItemProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/accordion/accordion-trigger.svelte
+++ b/sites/docs/src/lib/registry/ui/accordion/accordion-trigger.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		level = 3,
 		children,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/accordion/accordion-trigger.svelte
+++ b/sites/docs/src/lib/registry/ui/accordion/accordion-trigger.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		level = 3,
 		children,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-action.svelte
+++ b/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-action.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: AlertDialogPrimitive.ActionProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-action.svelte
+++ b/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-action.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: AlertDialogPrimitive.ActionProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-cancel.svelte
+++ b/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-cancel.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: AlertDialogPrimitive.CancelProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-cancel.svelte
+++ b/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-cancel.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: AlertDialogPrimitive.CancelProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-content.svelte
+++ b/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-content.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		portalProps,
 		...restProps
 	}: WithoutChild<AlertDialogPrimitive.ContentProps> & {

--- a/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-content.svelte
+++ b/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-content.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		portalProps,
 		...restProps
 	}: WithoutChild<AlertDialogPrimitive.ContentProps> & {

--- a/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-description.svelte
+++ b/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-description.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: AlertDialogPrimitive.DescriptionProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-description.svelte
+++ b/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-description.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: AlertDialogPrimitive.DescriptionProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-footer.svelte
+++ b/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-footer.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-footer.svelte
+++ b/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-footer.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-header.svelte
+++ b/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-header.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-header.svelte
+++ b/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-header.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-overlay.svelte
+++ b/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-overlay.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: AlertDialogPrimitive.OverlayProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-overlay.svelte
+++ b/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-overlay.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: AlertDialogPrimitive.OverlayProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-title.svelte
+++ b/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-title.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: AlertDialogPrimitive.TitleProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-title.svelte
+++ b/sites/docs/src/lib/registry/ui/alert-dialog/alert-dialog-title.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: AlertDialogPrimitive.TitleProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/alert/alert-description.svelte
+++ b/sites/docs/src/lib/registry/ui/alert/alert-description.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/alert/alert-description.svelte
+++ b/sites/docs/src/lib/registry/ui/alert/alert-description.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/alert/alert-title.svelte
+++ b/sites/docs/src/lib/registry/ui/alert/alert-title.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/alert/alert-title.svelte
+++ b/sites/docs/src/lib/registry/ui/alert/alert-title.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/alert/alert.svelte
+++ b/sites/docs/src/lib/registry/ui/alert/alert.svelte
@@ -24,7 +24,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		variant = "default",
 		children,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/alert/alert.svelte
+++ b/sites/docs/src/lib/registry/ui/alert/alert.svelte
@@ -24,7 +24,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		variant = "default",
 		children,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/avatar/avatar-fallback.svelte
+++ b/sites/docs/src/lib/registry/ui/avatar/avatar-fallback.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: AvatarPrimitive.FallbackProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/avatar/avatar-fallback.svelte
+++ b/sites/docs/src/lib/registry/ui/avatar/avatar-fallback.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: AvatarPrimitive.FallbackProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/avatar/avatar-image.svelte
+++ b/sites/docs/src/lib/registry/ui/avatar/avatar-image.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: AvatarPrimitive.ImageProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/avatar/avatar-image.svelte
+++ b/sites/docs/src/lib/registry/ui/avatar/avatar-image.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: AvatarPrimitive.ImageProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/avatar/avatar.svelte
+++ b/sites/docs/src/lib/registry/ui/avatar/avatar.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: AvatarPrimitive.RootProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/avatar/avatar.svelte
+++ b/sites/docs/src/lib/registry/ui/avatar/avatar.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: AvatarPrimitive.RootProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/badge/badge.svelte
+++ b/sites/docs/src/lib/registry/ui/badge/badge.svelte
@@ -28,8 +28,8 @@
 
 	let {
 		ref = $bindable(null),
-		href,
-		class: className,
+		href = undefined,
+		class: className = '',
 		variant = "default",
 		children,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/badge/badge.svelte
+++ b/sites/docs/src/lib/registry/ui/badge/badge.svelte
@@ -29,7 +29,7 @@
 	let {
 		ref = $bindable(null),
 		href = undefined,
-		class: className = '',
+		class: className = "",
 		variant = "default",
 		children,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-ellipsis.svelte
+++ b/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-ellipsis.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: WithoutChildren<WithElementRef<HTMLAttributes<HTMLSpanElement>>> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-ellipsis.svelte
+++ b/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-ellipsis.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: WithoutChildren<WithElementRef<HTMLAttributes<HTMLSpanElement>>> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-item.svelte
+++ b/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-item.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLLiAttributes> = $props();

--- a/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-item.svelte
+++ b/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-item.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLLiAttributes> = $props();

--- a/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-link.svelte
+++ b/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-link.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		href = undefined,
 		child = undefined,
 		children,

--- a/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-link.svelte
+++ b/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-link.svelte
@@ -5,9 +5,9 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		href = undefined,
-		child,
+		child = undefined,
 		children,
 		...restProps
 	}: WithElementRef<HTMLAnchorAttributes> & {

--- a/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-list.svelte
+++ b/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-list.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLOlAttributes> = $props();

--- a/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-list.svelte
+++ b/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-list.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLOlAttributes> = $props();

--- a/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-page.svelte
+++ b/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-page.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLSpanElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-page.svelte
+++ b/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-page.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLSpanElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-separator.svelte
+++ b/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-separator.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLLiAttributes> = $props();

--- a/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-separator.svelte
+++ b/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb-separator.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLLiAttributes> = $props();

--- a/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb.svelte
+++ b/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb.svelte
+++ b/sites/docs/src/lib/registry/ui/breadcrumb/breadcrumb.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/button/button.svelte
+++ b/sites/docs/src/lib/registry/ui/button/button.svelte
@@ -41,13 +41,13 @@
 
 <script lang="ts">
 	let {
-		class: className,
+		class: className = '',
 		variant = "default",
 		size = "default",
 		ref = $bindable(null),
 		href = undefined,
 		type = "button",
-		disabled,
+		disabled = false,
 		children,
 		...restProps
 	}: ButtonProps = $props();

--- a/sites/docs/src/lib/registry/ui/button/button.svelte
+++ b/sites/docs/src/lib/registry/ui/button/button.svelte
@@ -41,7 +41,7 @@
 
 <script lang="ts">
 	let {
-		class: className = '',
+		class: className = "",
 		variant = "default",
 		size = "default",
 		ref = $bindable(null),

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-cell.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-cell.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: CalendarPrimitive.CellProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-cell.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-cell.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: CalendarPrimitive.CellProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-day.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-day.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: CalendarPrimitive.DayProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-day.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-day.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: CalendarPrimitive.DayProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-grid-body.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-grid-body.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: CalendarPrimitive.GridBodyProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-grid-body.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-grid-body.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: CalendarPrimitive.GridBodyProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-grid-head.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-grid-head.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: CalendarPrimitive.GridHeadProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-grid-head.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-grid-head.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: CalendarPrimitive.GridHeadProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-grid-row.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-grid-row.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: CalendarPrimitive.GridRowProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-grid-row.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-grid-row.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: CalendarPrimitive.GridRowProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-grid.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-grid.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: CalendarPrimitive.GridProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-grid.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-grid.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: CalendarPrimitive.GridProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-head-cell.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-head-cell.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: CalendarPrimitive.HeadCellProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-head-cell.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-head-cell.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: CalendarPrimitive.HeadCellProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-header.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-header.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: CalendarPrimitive.HeaderProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-header.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-header.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: CalendarPrimitive.HeaderProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-heading.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-heading.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: CalendarPrimitive.HeadingProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-heading.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-heading.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: CalendarPrimitive.HeadingProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-months.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-months.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-months.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-months.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-next-button.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-next-button.svelte
@@ -6,7 +6,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: CalendarPrimitive.PrevButtonProps = $props();

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-next-button.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-next-button.svelte
@@ -6,7 +6,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: CalendarPrimitive.PrevButtonProps = $props();

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-prev-button.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-prev-button.svelte
@@ -6,7 +6,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: CalendarPrimitive.PrevButtonProps = $props();

--- a/sites/docs/src/lib/registry/ui/calendar/calendar-prev-button.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar-prev-button.svelte
@@ -6,7 +6,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: CalendarPrimitive.PrevButtonProps = $props();

--- a/sites/docs/src/lib/registry/ui/calendar/calendar.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar.svelte
@@ -7,7 +7,7 @@
 		ref = $bindable(null),
 		value = $bindable(),
 		placeholder = $bindable(),
-		class: className = '',
+		class: className = "",
 		weekdayFormat = "short",
 		...restProps
 	}: WithoutChildrenOrChild<CalendarPrimitive.RootProps> = $props();

--- a/sites/docs/src/lib/registry/ui/calendar/calendar.svelte
+++ b/sites/docs/src/lib/registry/ui/calendar/calendar.svelte
@@ -7,7 +7,7 @@
 		ref = $bindable(null),
 		value = $bindable(),
 		placeholder = $bindable(),
-		class: className,
+		class: className = '',
 		weekdayFormat = "short",
 		...restProps
 	}: WithoutChildrenOrChild<CalendarPrimitive.RootProps> = $props();

--- a/sites/docs/src/lib/registry/ui/card/card-action.svelte
+++ b/sites/docs/src/lib/registry/ui/card/card-action.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/card/card-action.svelte
+++ b/sites/docs/src/lib/registry/ui/card/card-action.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/card/card-content.svelte
+++ b/sites/docs/src/lib/registry/ui/card/card-content.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/card/card-content.svelte
+++ b/sites/docs/src/lib/registry/ui/card/card-content.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/card/card-description.svelte
+++ b/sites/docs/src/lib/registry/ui/card/card-description.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLParagraphElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/card/card-description.svelte
+++ b/sites/docs/src/lib/registry/ui/card/card-description.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLParagraphElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/card/card-footer.svelte
+++ b/sites/docs/src/lib/registry/ui/card/card-footer.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/card/card-footer.svelte
+++ b/sites/docs/src/lib/registry/ui/card/card-footer.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/card/card-header.svelte
+++ b/sites/docs/src/lib/registry/ui/card/card-header.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/card/card-header.svelte
+++ b/sites/docs/src/lib/registry/ui/card/card-header.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/card/card-title.svelte
+++ b/sites/docs/src/lib/registry/ui/card/card-title.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/card/card-title.svelte
+++ b/sites/docs/src/lib/registry/ui/card/card-title.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/card/card.svelte
+++ b/sites/docs/src/lib/registry/ui/card/card.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/card/card.svelte
+++ b/sites/docs/src/lib/registry/ui/card/card.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/carousel/carousel-content.svelte
+++ b/sites/docs/src/lib/registry/ui/carousel/carousel-content.svelte
@@ -6,7 +6,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/carousel/carousel-content.svelte
+++ b/sites/docs/src/lib/registry/ui/carousel/carousel-content.svelte
@@ -6,7 +6,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/carousel/carousel-item.svelte
+++ b/sites/docs/src/lib/registry/ui/carousel/carousel-item.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/carousel/carousel-item.svelte
+++ b/sites/docs/src/lib/registry/ui/carousel/carousel-item.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/carousel/carousel-next.svelte
+++ b/sites/docs/src/lib/registry/ui/carousel/carousel-next.svelte
@@ -7,7 +7,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		variant = "outline",
 		size = "icon",
 		...restProps

--- a/sites/docs/src/lib/registry/ui/carousel/carousel-next.svelte
+++ b/sites/docs/src/lib/registry/ui/carousel/carousel-next.svelte
@@ -7,7 +7,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		variant = "outline",
 		size = "icon",
 		...restProps

--- a/sites/docs/src/lib/registry/ui/carousel/carousel-previous.svelte
+++ b/sites/docs/src/lib/registry/ui/carousel/carousel-previous.svelte
@@ -7,7 +7,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		variant = "outline",
 		size = "icon",
 		...restProps

--- a/sites/docs/src/lib/registry/ui/carousel/carousel-previous.svelte
+++ b/sites/docs/src/lib/registry/ui/carousel/carousel-previous.svelte
@@ -7,7 +7,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		variant = "outline",
 		size = "icon",
 		...restProps

--- a/sites/docs/src/lib/registry/ui/carousel/carousel.svelte
+++ b/sites/docs/src/lib/registry/ui/carousel/carousel.svelte
@@ -13,7 +13,7 @@
 		plugins = [],
 		setApi = () => {},
 		orientation = "horizontal",
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<CarouselProps> = $props();

--- a/sites/docs/src/lib/registry/ui/carousel/carousel.svelte
+++ b/sites/docs/src/lib/registry/ui/carousel/carousel.svelte
@@ -13,7 +13,7 @@
 		plugins = [],
 		setApi = () => {},
 		orientation = "horizontal",
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<CarouselProps> = $props();

--- a/sites/docs/src/lib/registry/ui/chart/chart-container.svelte
+++ b/sites/docs/src/lib/registry/ui/chart/chart-container.svelte
@@ -9,7 +9,7 @@
 	let {
 		ref = $bindable(null),
 		id = uid,
-		class: className = '',
+		class: className = "",
 		children,
 		config,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/chart/chart-container.svelte
+++ b/sites/docs/src/lib/registry/ui/chart/chart-container.svelte
@@ -9,7 +9,7 @@
 	let {
 		ref = $bindable(null),
 		id = uid,
-		class: className,
+		class: className = '',
 		children,
 		config,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/chart/chart-tooltip.svelte
+++ b/sites/docs/src/lib/registry/ui/chart/chart-tooltip.svelte
@@ -12,17 +12,17 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		hideLabel = false,
 		indicator = "dot",
 		hideIndicator = false,
-		labelKey,
-		label,
+		labelKey = undefined,
+		label = undefined,
 		labelFormatter = defaultFormatter,
-		labelClassName,
-		formatter,
-		nameKey,
-		color,
+		labelClassName = '',
+		formatter = undefined,
+		nameKey = undefined,
+		color = undefined,
 		...restProps
 	}: WithoutChildren<WithElementRef<HTMLAttributes<HTMLDivElement>>> & {
 		hideLabel?: boolean;

--- a/sites/docs/src/lib/registry/ui/chart/chart-tooltip.svelte
+++ b/sites/docs/src/lib/registry/ui/chart/chart-tooltip.svelte
@@ -12,14 +12,14 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		hideLabel = false,
 		indicator = "dot",
 		hideIndicator = false,
 		labelKey = undefined,
 		label = undefined,
 		labelFormatter = defaultFormatter,
-		labelClassName = '',
+		labelClassName = "",
 		formatter = undefined,
 		nameKey = undefined,
 		color = undefined,

--- a/sites/docs/src/lib/registry/ui/checkbox/checkbox.svelte
+++ b/sites/docs/src/lib/registry/ui/checkbox/checkbox.svelte
@@ -8,7 +8,7 @@
 		ref = $bindable(null),
 		checked = $bindable(false),
 		indeterminate = $bindable(false),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: WithoutChildrenOrChild<CheckboxPrimitive.RootProps> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/checkbox/checkbox.svelte
+++ b/sites/docs/src/lib/registry/ui/checkbox/checkbox.svelte
@@ -8,7 +8,7 @@
 		ref = $bindable(null),
 		checked = $bindable(false),
 		indeterminate = $bindable(false),
-		class: className,
+		class: className = '',
 		...restProps
 	}: WithoutChildrenOrChild<CheckboxPrimitive.RootProps> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/command/command-dialog.svelte
+++ b/sites/docs/src/lib/registry/ui/command/command-dialog.svelte
@@ -11,7 +11,7 @@
 		value = $bindable(""),
 		title = "Command Palette",
 		description = "Search for a command to run",
-		portalProps,
+		portalProps = undefined,
 		children,
 		...restProps
 	}: WithoutChildrenOrChild<DialogPrimitive.RootProps> &

--- a/sites/docs/src/lib/registry/ui/command/command-empty.svelte
+++ b/sites/docs/src/lib/registry/ui/command/command-empty.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: CommandPrimitive.EmptyProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/command/command-empty.svelte
+++ b/sites/docs/src/lib/registry/ui/command/command-empty.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: CommandPrimitive.EmptyProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/command/command-group.svelte
+++ b/sites/docs/src/lib/registry/ui/command/command-group.svelte
@@ -4,10 +4,10 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
-		heading,
-		value,
+		heading = undefined,
+		value = undefined,
 		...restProps
 	}: CommandPrimitive.GroupProps & {
 		heading?: string;

--- a/sites/docs/src/lib/registry/ui/command/command-group.svelte
+++ b/sites/docs/src/lib/registry/ui/command/command-group.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		heading = undefined,
 		value = undefined,

--- a/sites/docs/src/lib/registry/ui/command/command-input.svelte
+++ b/sites/docs/src/lib/registry/ui/command/command-input.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		value = $bindable(""),
 		...restProps
 	}: CommandPrimitive.InputProps = $props();

--- a/sites/docs/src/lib/registry/ui/command/command-input.svelte
+++ b/sites/docs/src/lib/registry/ui/command/command-input.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		value = $bindable(""),
 		...restProps
 	}: CommandPrimitive.InputProps = $props();

--- a/sites/docs/src/lib/registry/ui/command/command-item.svelte
+++ b/sites/docs/src/lib/registry/ui/command/command-item.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: CommandPrimitive.ItemProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/command/command-item.svelte
+++ b/sites/docs/src/lib/registry/ui/command/command-item.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: CommandPrimitive.ItemProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/command/command-link-item.svelte
+++ b/sites/docs/src/lib/registry/ui/command/command-link-item.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: CommandPrimitive.LinkItemProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/command/command-link-item.svelte
+++ b/sites/docs/src/lib/registry/ui/command/command-link-item.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: CommandPrimitive.LinkItemProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/command/command-list.svelte
+++ b/sites/docs/src/lib/registry/ui/command/command-list.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: CommandPrimitive.ListProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/command/command-list.svelte
+++ b/sites/docs/src/lib/registry/ui/command/command-list.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: CommandPrimitive.ListProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/command/command-separator.svelte
+++ b/sites/docs/src/lib/registry/ui/command/command-separator.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: CommandPrimitive.SeparatorProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/command/command-separator.svelte
+++ b/sites/docs/src/lib/registry/ui/command/command-separator.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: CommandPrimitive.SeparatorProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/command/command-shortcut.svelte
+++ b/sites/docs/src/lib/registry/ui/command/command-shortcut.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLSpanElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/command/command-shortcut.svelte
+++ b/sites/docs/src/lib/registry/ui/command/command-shortcut.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLSpanElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/command/command.svelte
+++ b/sites/docs/src/lib/registry/ui/command/command.svelte
@@ -5,7 +5,7 @@
 	let {
 		ref = $bindable(null),
 		value = $bindable(""),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: CommandPrimitive.RootProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/command/command.svelte
+++ b/sites/docs/src/lib/registry/ui/command/command.svelte
@@ -5,7 +5,7 @@
 	let {
 		ref = $bindable(null),
 		value = $bindable(""),
-		class: className,
+		class: className = '',
 		...restProps
 	}: CommandPrimitive.RootProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/context-menu/context-menu-checkbox-item.svelte
+++ b/sites/docs/src/lib/registry/ui/context-menu/context-menu-checkbox-item.svelte
@@ -8,7 +8,7 @@
 		ref = $bindable(null),
 		checked = $bindable(false),
 		indeterminate = $bindable(false),
-		class: className,
+		class: className = '',
 		children: childrenProp,
 		...restProps
 	}: WithoutChildrenOrChild<ContextMenuPrimitive.CheckboxItemProps> & {

--- a/sites/docs/src/lib/registry/ui/context-menu/context-menu-checkbox-item.svelte
+++ b/sites/docs/src/lib/registry/ui/context-menu/context-menu-checkbox-item.svelte
@@ -8,7 +8,7 @@
 		ref = $bindable(null),
 		checked = $bindable(false),
 		indeterminate = $bindable(false),
-		class: className = '',
+		class: className = "",
 		children: childrenProp,
 		...restProps
 	}: WithoutChildrenOrChild<ContextMenuPrimitive.CheckboxItemProps> & {

--- a/sites/docs/src/lib/registry/ui/context-menu/context-menu-content.svelte
+++ b/sites/docs/src/lib/registry/ui/context-menu/context-menu-content.svelte
@@ -5,7 +5,7 @@
 	let {
 		ref = $bindable(null),
 		portalProps,
-		class: className,
+		class: className = '',
 		...restProps
 	}: ContextMenuPrimitive.ContentProps & {
 		portalProps?: ContextMenuPrimitive.PortalProps;

--- a/sites/docs/src/lib/registry/ui/context-menu/context-menu-content.svelte
+++ b/sites/docs/src/lib/registry/ui/context-menu/context-menu-content.svelte
@@ -5,7 +5,7 @@
 	let {
 		ref = $bindable(null),
 		portalProps,
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: ContextMenuPrimitive.ContentProps & {
 		portalProps?: ContextMenuPrimitive.PortalProps;

--- a/sites/docs/src/lib/registry/ui/context-menu/context-menu-group-heading.svelte
+++ b/sites/docs/src/lib/registry/ui/context-menu/context-menu-group-heading.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		inset = undefined,
 		...restProps
 	}: ContextMenuPrimitive.GroupHeadingProps & {

--- a/sites/docs/src/lib/registry/ui/context-menu/context-menu-group-heading.svelte
+++ b/sites/docs/src/lib/registry/ui/context-menu/context-menu-group-heading.svelte
@@ -4,8 +4,8 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
-		inset,
+		class: className = '',
+		inset = undefined,
 		...restProps
 	}: ContextMenuPrimitive.GroupHeadingProps & {
 		inset?: boolean;

--- a/sites/docs/src/lib/registry/ui/context-menu/context-menu-item.svelte
+++ b/sites/docs/src/lib/registry/ui/context-menu/context-menu-item.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		inset = undefined,
 		variant = "default",
 		...restProps

--- a/sites/docs/src/lib/registry/ui/context-menu/context-menu-item.svelte
+++ b/sites/docs/src/lib/registry/ui/context-menu/context-menu-item.svelte
@@ -4,8 +4,8 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
-		inset,
+		class: className = '',
+		inset = undefined,
 		variant = "default",
 		...restProps
 	}: ContextMenuPrimitive.ItemProps & {

--- a/sites/docs/src/lib/registry/ui/context-menu/context-menu-label.svelte
+++ b/sites/docs/src/lib/registry/ui/context-menu/context-menu-label.svelte
@@ -4,8 +4,8 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
-		inset,
+		class: className = '',
+		inset = undefined,
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {

--- a/sites/docs/src/lib/registry/ui/context-menu/context-menu-label.svelte
+++ b/sites/docs/src/lib/registry/ui/context-menu/context-menu-label.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		inset = undefined,
 		children,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/context-menu/context-menu-radio-item.svelte
+++ b/sites/docs/src/lib/registry/ui/context-menu/context-menu-radio-item.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children: childrenProp,
 		...restProps
 	}: WithoutChild<ContextMenuPrimitive.RadioItemProps> = $props();

--- a/sites/docs/src/lib/registry/ui/context-menu/context-menu-radio-item.svelte
+++ b/sites/docs/src/lib/registry/ui/context-menu/context-menu-radio-item.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children: childrenProp,
 		...restProps
 	}: WithoutChild<ContextMenuPrimitive.RadioItemProps> = $props();

--- a/sites/docs/src/lib/registry/ui/context-menu/context-menu-separator.svelte
+++ b/sites/docs/src/lib/registry/ui/context-menu/context-menu-separator.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: ContextMenuPrimitive.SeparatorProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/context-menu/context-menu-separator.svelte
+++ b/sites/docs/src/lib/registry/ui/context-menu/context-menu-separator.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: ContextMenuPrimitive.SeparatorProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/context-menu/context-menu-shortcut.svelte
+++ b/sites/docs/src/lib/registry/ui/context-menu/context-menu-shortcut.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLSpanElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/context-menu/context-menu-shortcut.svelte
+++ b/sites/docs/src/lib/registry/ui/context-menu/context-menu-shortcut.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLSpanElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/context-menu/context-menu-sub-content.svelte
+++ b/sites/docs/src/lib/registry/ui/context-menu/context-menu-sub-content.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: ContextMenuPrimitive.SubContentProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/context-menu/context-menu-sub-content.svelte
+++ b/sites/docs/src/lib/registry/ui/context-menu/context-menu-sub-content.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: ContextMenuPrimitive.SubContentProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/context-menu/context-menu-sub-trigger.svelte
+++ b/sites/docs/src/lib/registry/ui/context-menu/context-menu-sub-trigger.svelte
@@ -5,8 +5,8 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
-		inset,
+		class: className = '',
+		inset = undefined,
 		children,
 		...restProps
 	}: WithoutChild<ContextMenuPrimitive.SubTriggerProps> & {

--- a/sites/docs/src/lib/registry/ui/context-menu/context-menu-sub-trigger.svelte
+++ b/sites/docs/src/lib/registry/ui/context-menu/context-menu-sub-trigger.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		inset = undefined,
 		children,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/data-table/flex-render.svelte
+++ b/sites/docs/src/lib/registry/ui/data-table/flex-render.svelte
@@ -22,7 +22,7 @@
 		context: TContext;
 	};
 
-	let { content, context }: Props = $props();
+	let { content = undefined, context }: Props = $props();
 </script>
 
 {#if typeof content === "string"}

--- a/sites/docs/src/lib/registry/ui/dialog/dialog-content.svelte
+++ b/sites/docs/src/lib/registry/ui/dialog/dialog-content.svelte
@@ -7,8 +7,8 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
-		portalProps,
+		class: className = '',
+		portalProps = undefined,
 		children,
 		...restProps
 	}: WithoutChildrenOrChild<DialogPrimitive.ContentProps> & {

--- a/sites/docs/src/lib/registry/ui/dialog/dialog-content.svelte
+++ b/sites/docs/src/lib/registry/ui/dialog/dialog-content.svelte
@@ -7,7 +7,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		portalProps = undefined,
 		children,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/dialog/dialog-description.svelte
+++ b/sites/docs/src/lib/registry/ui/dialog/dialog-description.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: DialogPrimitive.DescriptionProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/dialog/dialog-description.svelte
+++ b/sites/docs/src/lib/registry/ui/dialog/dialog-description.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: DialogPrimitive.DescriptionProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/dialog/dialog-footer.svelte
+++ b/sites/docs/src/lib/registry/ui/dialog/dialog-footer.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/dialog/dialog-footer.svelte
+++ b/sites/docs/src/lib/registry/ui/dialog/dialog-footer.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/dialog/dialog-header.svelte
+++ b/sites/docs/src/lib/registry/ui/dialog/dialog-header.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/dialog/dialog-header.svelte
+++ b/sites/docs/src/lib/registry/ui/dialog/dialog-header.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/dialog/dialog-overlay.svelte
+++ b/sites/docs/src/lib/registry/ui/dialog/dialog-overlay.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: DialogPrimitive.OverlayProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/dialog/dialog-overlay.svelte
+++ b/sites/docs/src/lib/registry/ui/dialog/dialog-overlay.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: DialogPrimitive.OverlayProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/dialog/dialog-title.svelte
+++ b/sites/docs/src/lib/registry/ui/dialog/dialog-title.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: DialogPrimitive.TitleProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/dialog/dialog-title.svelte
+++ b/sites/docs/src/lib/registry/ui/dialog/dialog-title.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: DialogPrimitive.TitleProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/drawer/drawer-content.svelte
+++ b/sites/docs/src/lib/registry/ui/drawer/drawer-content.svelte
@@ -5,8 +5,8 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
-		portalProps,
+		class: className = '',
+		portalProps = undefined,
 		children,
 		...restProps
 	}: DrawerPrimitive.ContentProps & {

--- a/sites/docs/src/lib/registry/ui/drawer/drawer-content.svelte
+++ b/sites/docs/src/lib/registry/ui/drawer/drawer-content.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		portalProps = undefined,
 		children,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/drawer/drawer-description.svelte
+++ b/sites/docs/src/lib/registry/ui/drawer/drawer-description.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: DrawerPrimitive.DescriptionProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/drawer/drawer-description.svelte
+++ b/sites/docs/src/lib/registry/ui/drawer/drawer-description.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: DrawerPrimitive.DescriptionProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/drawer/drawer-footer.svelte
+++ b/sites/docs/src/lib/registry/ui/drawer/drawer-footer.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/drawer/drawer-footer.svelte
+++ b/sites/docs/src/lib/registry/ui/drawer/drawer-footer.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/drawer/drawer-header.svelte
+++ b/sites/docs/src/lib/registry/ui/drawer/drawer-header.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/drawer/drawer-header.svelte
+++ b/sites/docs/src/lib/registry/ui/drawer/drawer-header.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/drawer/drawer-overlay.svelte
+++ b/sites/docs/src/lib/registry/ui/drawer/drawer-overlay.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: DrawerPrimitive.OverlayProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/drawer/drawer-overlay.svelte
+++ b/sites/docs/src/lib/registry/ui/drawer/drawer-overlay.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: DrawerPrimitive.OverlayProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/drawer/drawer-title.svelte
+++ b/sites/docs/src/lib/registry/ui/drawer/drawer-title.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: DrawerPrimitive.TitleProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/drawer/drawer-title.svelte
+++ b/sites/docs/src/lib/registry/ui/drawer/drawer-title.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: DrawerPrimitive.TitleProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-checkbox-item.svelte
+++ b/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-checkbox-item.svelte
@@ -9,8 +9,8 @@
 		ref = $bindable(null),
 		checked = $bindable(false),
 		indeterminate = $bindable(false),
-		class: className,
-		children: childrenProp,
+		class: className = '',
+		children: childrenProp = undefined,
 		...restProps
 	}: WithoutChildrenOrChild<DropdownMenuPrimitive.CheckboxItemProps> & {
 		children?: Snippet;

--- a/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-checkbox-item.svelte
+++ b/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-checkbox-item.svelte
@@ -9,7 +9,7 @@
 		ref = $bindable(null),
 		checked = $bindable(false),
 		indeterminate = $bindable(false),
-		class: className = '',
+		class: className = "",
 		children: childrenProp = undefined,
 		...restProps
 	}: WithoutChildrenOrChild<DropdownMenuPrimitive.CheckboxItemProps> & {

--- a/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-content.svelte
+++ b/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-content.svelte
@@ -6,7 +6,7 @@
 		ref = $bindable(null),
 		sideOffset = 4,
 		portalProps = undefined,
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: DropdownMenuPrimitive.ContentProps & {
 		portalProps?: DropdownMenuPrimitive.PortalProps;

--- a/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-content.svelte
+++ b/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-content.svelte
@@ -5,8 +5,8 @@
 	let {
 		ref = $bindable(null),
 		sideOffset = 4,
-		portalProps,
-		class: className,
+		portalProps = undefined,
+		class: className = '',
 		...restProps
 	}: DropdownMenuPrimitive.ContentProps & {
 		portalProps?: DropdownMenuPrimitive.PortalProps;

--- a/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-group-heading.svelte
+++ b/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-group-heading.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		inset = undefined,
 		...restProps
 	}: ComponentProps<typeof DropdownMenuPrimitive.GroupHeading> & {

--- a/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-group-heading.svelte
+++ b/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-group-heading.svelte
@@ -5,8 +5,8 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
-		inset,
+		class: className = '',
+		inset = undefined,
 		...restProps
 	}: ComponentProps<typeof DropdownMenuPrimitive.GroupHeading> & {
 		inset?: boolean;

--- a/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-item.svelte
+++ b/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-item.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		inset = undefined,
 		variant = "default",
 		...restProps

--- a/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-item.svelte
+++ b/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-item.svelte
@@ -4,8 +4,8 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
-		inset,
+		class: className = '',
+		inset = undefined,
 		variant = "default",
 		...restProps
 	}: DropdownMenuPrimitive.ItemProps & {

--- a/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-label.svelte
+++ b/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-label.svelte
@@ -4,8 +4,8 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
-		inset,
+		class: className = '',
+		inset = undefined,
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {

--- a/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-label.svelte
+++ b/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-label.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		inset = undefined,
 		children,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-radio-item.svelte
+++ b/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-radio-item.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children: childrenProp,
 		...restProps
 	}: WithoutChild<DropdownMenuPrimitive.RadioItemProps> = $props();

--- a/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-radio-item.svelte
+++ b/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-radio-item.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children: childrenProp,
 		...restProps
 	}: WithoutChild<DropdownMenuPrimitive.RadioItemProps> = $props();

--- a/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-separator.svelte
+++ b/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-separator.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: DropdownMenuPrimitive.SeparatorProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-separator.svelte
+++ b/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-separator.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: DropdownMenuPrimitive.SeparatorProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-shortcut.svelte
+++ b/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-shortcut.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLSpanElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-shortcut.svelte
+++ b/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-shortcut.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLSpanElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-sub-content.svelte
+++ b/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-sub-content.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: DropdownMenuPrimitive.SubContentProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-sub-content.svelte
+++ b/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-sub-content.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: DropdownMenuPrimitive.SubContentProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-sub-trigger.svelte
+++ b/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-sub-trigger.svelte
@@ -5,8 +5,8 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
-		inset,
+		class: className = '',
+		inset = undefined,
 		children,
 		...restProps
 	}: DropdownMenuPrimitive.SubTriggerProps & {

--- a/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-sub-trigger.svelte
+++ b/sites/docs/src/lib/registry/ui/dropdown-menu/dropdown-menu-sub-trigger.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		inset = undefined,
 		children,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/form/form-description.svelte
+++ b/sites/docs/src/lib/registry/ui/form/form-description.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: WithoutChild<FormPrimitive.DescriptionProps> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/form/form-description.svelte
+++ b/sites/docs/src/lib/registry/ui/form/form-description.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: WithoutChild<FormPrimitive.DescriptionProps> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/form/form-element-field.svelte
+++ b/sites/docs/src/lib/registry/ui/form/form-element-field.svelte
@@ -11,7 +11,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		form,
 		name,
 		children: childrenProp,

--- a/sites/docs/src/lib/registry/ui/form/form-element-field.svelte
+++ b/sites/docs/src/lib/registry/ui/form/form-element-field.svelte
@@ -11,7 +11,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		form,
 		name,
 		children: childrenProp,

--- a/sites/docs/src/lib/registry/ui/form/form-field-errors.svelte
+++ b/sites/docs/src/lib/registry/ui/form/form-field-errors.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		errorClasses = undefined,
 		children: childrenProp,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/form/form-field-errors.svelte
+++ b/sites/docs/src/lib/registry/ui/form/form-field-errors.svelte
@@ -4,8 +4,8 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
-		errorClasses,
+		class: className = '',
+		errorClasses = undefined,
 		children: childrenProp,
 		...restProps
 	}: WithoutChild<FormPrimitive.FieldErrorsProps> & {

--- a/sites/docs/src/lib/registry/ui/form/form-field.svelte
+++ b/sites/docs/src/lib/registry/ui/form/form-field.svelte
@@ -11,7 +11,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		form,
 		name,
 		children: childrenProp,

--- a/sites/docs/src/lib/registry/ui/form/form-field.svelte
+++ b/sites/docs/src/lib/registry/ui/form/form-field.svelte
@@ -11,7 +11,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		form,
 		name,
 		children: childrenProp,

--- a/sites/docs/src/lib/registry/ui/form/form-fieldset.svelte
+++ b/sites/docs/src/lib/registry/ui/form/form-fieldset.svelte
@@ -10,7 +10,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		form,
 		name,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/form/form-fieldset.svelte
+++ b/sites/docs/src/lib/registry/ui/form/form-fieldset.svelte
@@ -10,7 +10,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		form,
 		name,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/form/form-label.svelte
+++ b/sites/docs/src/lib/registry/ui/form/form-label.svelte
@@ -6,7 +6,7 @@
 	let {
 		ref = $bindable(null),
 		children,
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: WithoutChild<FormPrimitive.LabelProps> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/form/form-label.svelte
+++ b/sites/docs/src/lib/registry/ui/form/form-label.svelte
@@ -6,7 +6,7 @@
 	let {
 		ref = $bindable(null),
 		children,
-		class: className,
+		class: className = '',
 		...restProps
 	}: WithoutChild<FormPrimitive.LabelProps> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/form/form-legend.svelte
+++ b/sites/docs/src/lib/registry/ui/form/form-legend.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: WithoutChild<FormPrimitive.LegendProps> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/form/form-legend.svelte
+++ b/sites/docs/src/lib/registry/ui/form/form-legend.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: WithoutChild<FormPrimitive.LegendProps> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/hover-card/hover-card-content.svelte
+++ b/sites/docs/src/lib/registry/ui/hover-card/hover-card-content.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		align = "center",
 		sideOffset = 4,
 		portalProps = undefined,

--- a/sites/docs/src/lib/registry/ui/hover-card/hover-card-content.svelte
+++ b/sites/docs/src/lib/registry/ui/hover-card/hover-card-content.svelte
@@ -4,10 +4,10 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		align = "center",
 		sideOffset = 4,
-		portalProps,
+		portalProps = undefined,
 		...restProps
 	}: HoverCardPrimitive.ContentProps & {
 		portalProps?: HoverCardPrimitive.PortalProps;

--- a/sites/docs/src/lib/registry/ui/input-otp/input-otp-group.svelte
+++ b/sites/docs/src/lib/registry/ui/input-otp/input-otp-group.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/input-otp/input-otp-group.svelte
+++ b/sites/docs/src/lib/registry/ui/input-otp/input-otp-group.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/input-otp/input-otp-slot.svelte
+++ b/sites/docs/src/lib/registry/ui/input-otp/input-otp-slot.svelte
@@ -5,7 +5,7 @@
 	let {
 		ref = $bindable(null),
 		cell,
-		class: className,
+		class: className = '',
 		...restProps
 	}: InputOTPPrimitive.CellProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/input-otp/input-otp-slot.svelte
+++ b/sites/docs/src/lib/registry/ui/input-otp/input-otp-slot.svelte
@@ -5,7 +5,7 @@
 	let {
 		ref = $bindable(null),
 		cell,
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: InputOTPPrimitive.CellProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/input-otp/input-otp.svelte
+++ b/sites/docs/src/lib/registry/ui/input-otp/input-otp.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		value = $bindable(""),
 		...restProps
 	}: InputOTPPrimitive.RootProps = $props();

--- a/sites/docs/src/lib/registry/ui/input-otp/input-otp.svelte
+++ b/sites/docs/src/lib/registry/ui/input-otp/input-otp.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		value = $bindable(""),
 		...restProps
 	}: InputOTPPrimitive.RootProps = $props();

--- a/sites/docs/src/lib/registry/ui/input/input.svelte
+++ b/sites/docs/src/lib/registry/ui/input/input.svelte
@@ -12,9 +12,9 @@
 	let {
 		ref = $bindable(null),
 		value = $bindable(),
-		type,
+		type = undefined,
 		files = $bindable(),
-		class: className,
+		class: className = '',
 		...restProps
 	}: Props = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/input/input.svelte
+++ b/sites/docs/src/lib/registry/ui/input/input.svelte
@@ -14,7 +14,7 @@
 		value = $bindable(),
 		type = undefined,
 		files = $bindable(),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: Props = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/label/label.svelte
+++ b/sites/docs/src/lib/registry/ui/label/label.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: LabelPrimitive.RootProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/label/label.svelte
+++ b/sites/docs/src/lib/registry/ui/label/label.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: LabelPrimitive.RootProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/menubar/menubar-checkbox-item.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar-checkbox-item.svelte
@@ -7,10 +7,10 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		checked = $bindable(false),
 		indeterminate = $bindable(false),
-		children: childrenProp,
+		children: childrenProp = undefined,
 		...restProps
 	}: WithoutChildrenOrChild<MenubarPrimitive.CheckboxItemProps> & {
 		children?: Snippet;

--- a/sites/docs/src/lib/registry/ui/menubar/menubar-checkbox-item.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar-checkbox-item.svelte
@@ -7,7 +7,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		checked = $bindable(false),
 		indeterminate = $bindable(false),
 		children: childrenProp = undefined,

--- a/sites/docs/src/lib/registry/ui/menubar/menubar-content.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar-content.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		sideOffset = 8,
 		alignOffset = -4,
 		align = "start",

--- a/sites/docs/src/lib/registry/ui/menubar/menubar-content.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar-content.svelte
@@ -4,12 +4,12 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		sideOffset = 8,
 		alignOffset = -4,
 		align = "start",
 		side = "bottom",
-		portalProps,
+		portalProps = undefined,
 		...restProps
 	}: MenubarPrimitive.ContentProps & {
 		portalProps?: MenubarPrimitive.PortalProps;

--- a/sites/docs/src/lib/registry/ui/menubar/menubar-group-heading.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar-group-heading.svelte
@@ -5,8 +5,8 @@
 
 	let {
 		ref = $bindable(null),
-		inset,
-		class: className,
+		inset = undefined,
+		class: className = '',
 		...restProps
 	}: ComponentProps<typeof MenubarPrimitive.GroupHeading> & {
 		inset?: boolean;

--- a/sites/docs/src/lib/registry/ui/menubar/menubar-group-heading.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar-group-heading.svelte
@@ -6,7 +6,7 @@
 	let {
 		ref = $bindable(null),
 		inset = undefined,
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: ComponentProps<typeof MenubarPrimitive.GroupHeading> & {
 		inset?: boolean;

--- a/sites/docs/src/lib/registry/ui/menubar/menubar-item.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar-item.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		inset = undefined,
 		variant = "default",
 		...restProps

--- a/sites/docs/src/lib/registry/ui/menubar/menubar-item.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar-item.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		inset = undefined,
 		variant = "default",
 		...restProps

--- a/sites/docs/src/lib/registry/ui/menubar/menubar-label.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar-label.svelte
@@ -5,9 +5,9 @@
 
 	let {
 		ref = $bindable(null),
-		inset,
+		inset = undefined,
 		children,
-		class: className,
+		class: className = '',
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLElement>> & {
 		inset?: boolean;

--- a/sites/docs/src/lib/registry/ui/menubar/menubar-label.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar-label.svelte
@@ -7,7 +7,7 @@
 		ref = $bindable(null),
 		inset = undefined,
 		children,
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLElement>> & {
 		inset?: boolean;

--- a/sites/docs/src/lib/registry/ui/menubar/menubar-radio-item.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar-radio-item.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children: childrenProp,
 		...restProps
 	}: WithoutChild<MenubarPrimitive.RadioItemProps> = $props();

--- a/sites/docs/src/lib/registry/ui/menubar/menubar-radio-item.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar-radio-item.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children: childrenProp,
 		...restProps
 	}: WithoutChild<MenubarPrimitive.RadioItemProps> = $props();

--- a/sites/docs/src/lib/registry/ui/menubar/menubar-separator.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar-separator.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: MenubarPrimitive.SeparatorProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/menubar/menubar-separator.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar-separator.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: MenubarPrimitive.SeparatorProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/menubar/menubar-shortcut.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar-shortcut.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLSpanElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/menubar/menubar-shortcut.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar-shortcut.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLSpanElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/menubar/menubar-sub-content.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar-sub-content.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: MenubarPrimitive.SubContentProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/menubar/menubar-sub-content.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar-sub-content.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: MenubarPrimitive.SubContentProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/menubar/menubar-sub-trigger.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar-sub-trigger.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		inset = undefined,
 		children,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/menubar/menubar-sub-trigger.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar-sub-trigger.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		inset = undefined,
 		children,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/menubar/menubar-trigger.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar-trigger.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: MenubarPrimitive.TriggerProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/menubar/menubar-trigger.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar-trigger.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: MenubarPrimitive.TriggerProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/menubar/menubar.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: MenubarPrimitive.RootProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/menubar/menubar.svelte
+++ b/sites/docs/src/lib/registry/ui/menubar/menubar.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: MenubarPrimitive.RootProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/pagination/pagination-content.svelte
+++ b/sites/docs/src/lib/registry/ui/pagination/pagination-content.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLUListElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/pagination/pagination-content.svelte
+++ b/sites/docs/src/lib/registry/ui/pagination/pagination-content.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLUListElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/pagination/pagination-ellipsis.svelte
+++ b/sites/docs/src/lib/registry/ui/pagination/pagination-ellipsis.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: WithoutChildren<WithElementRef<HTMLAttributes<HTMLSpanElement>>> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/pagination/pagination-ellipsis.svelte
+++ b/sites/docs/src/lib/registry/ui/pagination/pagination-ellipsis.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: WithoutChildren<WithElementRef<HTMLAttributes<HTMLSpanElement>>> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/pagination/pagination-link.svelte
+++ b/sites/docs/src/lib/registry/ui/pagination/pagination-link.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		size = "icon",
 		isActive = false,
 		page,

--- a/sites/docs/src/lib/registry/ui/pagination/pagination-link.svelte
+++ b/sites/docs/src/lib/registry/ui/pagination/pagination-link.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		size = "icon",
 		isActive = false,
 		page,

--- a/sites/docs/src/lib/registry/ui/pagination/pagination-next-button.svelte
+++ b/sites/docs/src/lib/registry/ui/pagination/pagination-next-button.svelte
@@ -6,7 +6,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: PaginationPrimitive.NextButtonProps = $props();

--- a/sites/docs/src/lib/registry/ui/pagination/pagination-next-button.svelte
+++ b/sites/docs/src/lib/registry/ui/pagination/pagination-next-button.svelte
@@ -6,7 +6,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: PaginationPrimitive.NextButtonProps = $props();

--- a/sites/docs/src/lib/registry/ui/pagination/pagination-prev-button.svelte
+++ b/sites/docs/src/lib/registry/ui/pagination/pagination-prev-button.svelte
@@ -6,7 +6,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: PaginationPrimitive.PrevButtonProps = $props();

--- a/sites/docs/src/lib/registry/ui/pagination/pagination-prev-button.svelte
+++ b/sites/docs/src/lib/registry/ui/pagination/pagination-prev-button.svelte
@@ -6,7 +6,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: PaginationPrimitive.PrevButtonProps = $props();

--- a/sites/docs/src/lib/registry/ui/pagination/pagination.svelte
+++ b/sites/docs/src/lib/registry/ui/pagination/pagination.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		count = 0,
 		perPage = 10,
 		page = $bindable(1),

--- a/sites/docs/src/lib/registry/ui/pagination/pagination.svelte
+++ b/sites/docs/src/lib/registry/ui/pagination/pagination.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		count = 0,
 		perPage = 10,
 		page = $bindable(1),

--- a/sites/docs/src/lib/registry/ui/popover/popover-content.svelte
+++ b/sites/docs/src/lib/registry/ui/popover/popover-content.svelte
@@ -4,10 +4,10 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		sideOffset = 4,
 		align = "center",
-		portalProps,
+		portalProps = undefined,
 		...restProps
 	}: PopoverPrimitive.ContentProps & {
 		portalProps?: PopoverPrimitive.PortalProps;

--- a/sites/docs/src/lib/registry/ui/popover/popover-content.svelte
+++ b/sites/docs/src/lib/registry/ui/popover/popover-content.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		sideOffset = 4,
 		align = "center",
 		portalProps = undefined,

--- a/sites/docs/src/lib/registry/ui/popover/popover-trigger.svelte
+++ b/sites/docs/src/lib/registry/ui/popover/popover-trigger.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: PopoverPrimitive.TriggerProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/popover/popover-trigger.svelte
+++ b/sites/docs/src/lib/registry/ui/popover/popover-trigger.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: PopoverPrimitive.TriggerProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/progress/progress.svelte
+++ b/sites/docs/src/lib/registry/ui/progress/progress.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		max = 100,
 		value,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/progress/progress.svelte
+++ b/sites/docs/src/lib/registry/ui/progress/progress.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		max = 100,
 		value,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/radio-group/radio-group-item.svelte
+++ b/sites/docs/src/lib/registry/ui/radio-group/radio-group-item.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: WithoutChildrenOrChild<RadioGroupPrimitive.ItemProps> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/radio-group/radio-group-item.svelte
+++ b/sites/docs/src/lib/registry/ui/radio-group/radio-group-item.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: WithoutChildrenOrChild<RadioGroupPrimitive.ItemProps> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/radio-group/radio-group.svelte
+++ b/sites/docs/src/lib/registry/ui/radio-group/radio-group.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		value = $bindable(""),
 		...restProps
 	}: RadioGroupPrimitive.RootProps = $props();

--- a/sites/docs/src/lib/registry/ui/radio-group/radio-group.svelte
+++ b/sites/docs/src/lib/registry/ui/radio-group/radio-group.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		value = $bindable(""),
 		...restProps
 	}: RadioGroupPrimitive.RootProps = $props();

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-cell.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-cell.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: RangeCalendarPrimitive.CellProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-cell.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-cell.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: RangeCalendarPrimitive.CellProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-day.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-day.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: RangeCalendarPrimitive.DayProps = $props();
 

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-day.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-day.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: RangeCalendarPrimitive.DayProps = $props();
 

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-grid-row.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-grid-row.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: RangeCalendarPrimitive.GridRowProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-grid-row.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-grid-row.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: RangeCalendarPrimitive.GridRowProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-grid.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-grid.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: RangeCalendarPrimitive.GridProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-grid.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-grid.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: RangeCalendarPrimitive.GridProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-head-cell.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-head-cell.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: RangeCalendarPrimitive.HeadCellProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-head-cell.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-head-cell.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: RangeCalendarPrimitive.HeadCellProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-header.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-header.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: RangeCalendarPrimitive.HeaderProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-header.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-header.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: RangeCalendarPrimitive.HeaderProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-heading.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-heading.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: RangeCalendarPrimitive.HeadingProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-heading.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-heading.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: RangeCalendarPrimitive.HeadingProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-months.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-months.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-months.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-months.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-next-button.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-next-button.svelte
@@ -6,7 +6,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: RangeCalendarPrimitive.NextButtonProps = $props();

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-next-button.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-next-button.svelte
@@ -6,7 +6,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: RangeCalendarPrimitive.NextButtonProps = $props();

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-prev-button.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-prev-button.svelte
@@ -6,7 +6,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: RangeCalendarPrimitive.PrevButtonProps = $props();

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-prev-button.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-prev-button.svelte
@@ -6,7 +6,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: RangeCalendarPrimitive.PrevButtonProps = $props();

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar.svelte
@@ -8,7 +8,7 @@
 		value = $bindable(),
 		placeholder = $bindable(),
 		weekdayFormat = "short",
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: WithoutChildrenOrChild<RangeCalendarPrimitive.RootProps> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar.svelte
@@ -8,7 +8,7 @@
 		value = $bindable(),
 		placeholder = $bindable(),
 		weekdayFormat = "short",
-		class: className,
+		class: className = '',
 		...restProps
 	}: WithoutChildrenOrChild<RangeCalendarPrimitive.RootProps> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/resizable/resizable-handle.svelte
+++ b/sites/docs/src/lib/registry/ui/resizable/resizable-handle.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		withHandle = false,
 		...restProps
 	}: WithoutChildrenOrChild<ResizablePrimitive.PaneResizerProps> & {

--- a/sites/docs/src/lib/registry/ui/resizable/resizable-handle.svelte
+++ b/sites/docs/src/lib/registry/ui/resizable/resizable-handle.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		withHandle = false,
 		...restProps
 	}: WithoutChildrenOrChild<ResizablePrimitive.PaneResizerProps> & {

--- a/sites/docs/src/lib/registry/ui/resizable/resizable-pane-group.svelte
+++ b/sites/docs/src/lib/registry/ui/resizable/resizable-pane-group.svelte
@@ -5,7 +5,7 @@
 	let {
 		ref = $bindable(null),
 		this: paneGroup = $bindable(),
-		class: className,
+		class: className = '',
 		...restProps
 	}: ResizablePrimitive.PaneGroupProps & {
 		this?: ResizablePrimitive.PaneGroup;

--- a/sites/docs/src/lib/registry/ui/resizable/resizable-pane-group.svelte
+++ b/sites/docs/src/lib/registry/ui/resizable/resizable-pane-group.svelte
@@ -5,7 +5,7 @@
 	let {
 		ref = $bindable(null),
 		this: paneGroup = $bindable(),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: ResizablePrimitive.PaneGroupProps & {
 		this?: ResizablePrimitive.PaneGroup;

--- a/sites/docs/src/lib/registry/ui/scroll-area/scroll-area-scrollbar.svelte
+++ b/sites/docs/src/lib/registry/ui/scroll-area/scroll-area-scrollbar.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		orientation = "vertical",
 		children,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/scroll-area/scroll-area-scrollbar.svelte
+++ b/sites/docs/src/lib/registry/ui/scroll-area/scroll-area-scrollbar.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		orientation = "vertical",
 		children,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/scroll-area/scroll-area.svelte
+++ b/sites/docs/src/lib/registry/ui/scroll-area/scroll-area.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		orientation = "vertical",
 		scrollbarXClasses = "",
 		scrollbarYClasses = "",

--- a/sites/docs/src/lib/registry/ui/scroll-area/scroll-area.svelte
+++ b/sites/docs/src/lib/registry/ui/scroll-area/scroll-area.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		orientation = "vertical",
 		scrollbarXClasses = "",
 		scrollbarYClasses = "",

--- a/sites/docs/src/lib/registry/ui/select/select-content.svelte
+++ b/sites/docs/src/lib/registry/ui/select/select-content.svelte
@@ -6,9 +6,9 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		sideOffset = 4,
-		portalProps,
+		portalProps = undefined,
 		children,
 		...restProps
 	}: WithoutChild<SelectPrimitive.ContentProps> & {

--- a/sites/docs/src/lib/registry/ui/select/select-content.svelte
+++ b/sites/docs/src/lib/registry/ui/select/select-content.svelte
@@ -6,7 +6,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		sideOffset = 4,
 		portalProps = undefined,
 		children,

--- a/sites/docs/src/lib/registry/ui/select/select-item.svelte
+++ b/sites/docs/src/lib/registry/ui/select/select-item.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		value,
 		label,
 		children: childrenProp,

--- a/sites/docs/src/lib/registry/ui/select/select-item.svelte
+++ b/sites/docs/src/lib/registry/ui/select/select-item.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		value,
 		label,
 		children: childrenProp,

--- a/sites/docs/src/lib/registry/ui/select/select-label.svelte
+++ b/sites/docs/src/lib/registry/ui/select/select-label.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {} = $props();

--- a/sites/docs/src/lib/registry/ui/select/select-label.svelte
+++ b/sites/docs/src/lib/registry/ui/select/select-label.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {} = $props();

--- a/sites/docs/src/lib/registry/ui/select/select-scroll-down-button.svelte
+++ b/sites/docs/src/lib/registry/ui/select/select-scroll-down-button.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: WithoutChildrenOrChild<SelectPrimitive.ScrollDownButtonProps> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/select/select-scroll-down-button.svelte
+++ b/sites/docs/src/lib/registry/ui/select/select-scroll-down-button.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: WithoutChildrenOrChild<SelectPrimitive.ScrollDownButtonProps> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/select/select-scroll-up-button.svelte
+++ b/sites/docs/src/lib/registry/ui/select/select-scroll-up-button.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: WithoutChildrenOrChild<SelectPrimitive.ScrollUpButtonProps> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/select/select-scroll-up-button.svelte
+++ b/sites/docs/src/lib/registry/ui/select/select-scroll-up-button.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: WithoutChildrenOrChild<SelectPrimitive.ScrollUpButtonProps> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/select/select-separator.svelte
+++ b/sites/docs/src/lib/registry/ui/select/select-separator.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: SeparatorPrimitive.RootProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/select/select-separator.svelte
+++ b/sites/docs/src/lib/registry/ui/select/select-separator.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: SeparatorPrimitive.RootProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/select/select-trigger.svelte
+++ b/sites/docs/src/lib/registry/ui/select/select-trigger.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		size = "default",
 		...restProps

--- a/sites/docs/src/lib/registry/ui/select/select-trigger.svelte
+++ b/sites/docs/src/lib/registry/ui/select/select-trigger.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		size = "default",
 		...restProps

--- a/sites/docs/src/lib/registry/ui/separator/separator.svelte
+++ b/sites/docs/src/lib/registry/ui/separator/separator.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: SeparatorPrimitive.RootProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/separator/separator.svelte
+++ b/sites/docs/src/lib/registry/ui/separator/separator.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: SeparatorPrimitive.RootProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/sheet/sheet-content.svelte
+++ b/sites/docs/src/lib/registry/ui/sheet/sheet-content.svelte
@@ -27,7 +27,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		side = "right",
 		portalProps = undefined,
 		children,

--- a/sites/docs/src/lib/registry/ui/sheet/sheet-content.svelte
+++ b/sites/docs/src/lib/registry/ui/sheet/sheet-content.svelte
@@ -27,9 +27,9 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		side = "right",
-		portalProps,
+		portalProps = undefined,
 		children,
 		...restProps
 	}: WithoutChildrenOrChild<SheetPrimitive.ContentProps> & {

--- a/sites/docs/src/lib/registry/ui/sheet/sheet-description.svelte
+++ b/sites/docs/src/lib/registry/ui/sheet/sheet-description.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: SheetPrimitive.DescriptionProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/sheet/sheet-description.svelte
+++ b/sites/docs/src/lib/registry/ui/sheet/sheet-description.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: SheetPrimitive.DescriptionProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/sheet/sheet-footer.svelte
+++ b/sites/docs/src/lib/registry/ui/sheet/sheet-footer.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/sheet/sheet-footer.svelte
+++ b/sites/docs/src/lib/registry/ui/sheet/sheet-footer.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/sheet/sheet-header.svelte
+++ b/sites/docs/src/lib/registry/ui/sheet/sheet-header.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/sheet/sheet-header.svelte
+++ b/sites/docs/src/lib/registry/ui/sheet/sheet-header.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/sheet/sheet-overlay.svelte
+++ b/sites/docs/src/lib/registry/ui/sheet/sheet-overlay.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: SheetPrimitive.OverlayProps = $props();
 

--- a/sites/docs/src/lib/registry/ui/sheet/sheet-overlay.svelte
+++ b/sites/docs/src/lib/registry/ui/sheet/sheet-overlay.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: SheetPrimitive.OverlayProps = $props();
 

--- a/sites/docs/src/lib/registry/ui/sheet/sheet-title.svelte
+++ b/sites/docs/src/lib/registry/ui/sheet/sheet-title.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: SheetPrimitive.TitleProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/sheet/sheet-title.svelte
+++ b/sites/docs/src/lib/registry/ui/sheet/sheet-title.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: SheetPrimitive.TitleProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-content.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-content.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-content.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-content.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-footer.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-footer.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-footer.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-footer.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-group-action.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-group-action.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		child = undefined,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-group-action.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-group-action.svelte
@@ -5,9 +5,9 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
-		child,
+		child = undefined,
 		...restProps
 	}: WithElementRef<HTMLButtonAttributes> & {
 		child?: Snippet<[{ props: Record<string, unknown> }]>;

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-group-content.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-group-content.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-group-content.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-group-content.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-group-label.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-group-label.svelte
@@ -6,8 +6,8 @@
 	let {
 		ref = $bindable(null),
 		children,
-		child,
-		class: className,
+		child = undefined,
+		class: className = '',
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLElement>> & {
 		child?: Snippet<[{ props: Record<string, unknown> }]>;

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-group-label.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-group-label.svelte
@@ -7,7 +7,7 @@
 		ref = $bindable(null),
 		children,
 		child = undefined,
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLElement>> & {
 		child?: Snippet<[{ props: Record<string, unknown> }]>;

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-group.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-group.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-group.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-group.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-header.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-header.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-header.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-header.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-input.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-input.svelte
@@ -6,7 +6,7 @@
 	let {
 		ref = $bindable(null),
 		value = $bindable(""),
-		class: className,
+		class: className = '',
 		...restProps
 	}: ComponentProps<typeof Input> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-input.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-input.svelte
@@ -6,7 +6,7 @@
 	let {
 		ref = $bindable(null),
 		value = $bindable(""),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: ComponentProps<typeof Input> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-inset.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-inset.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-inset.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-inset.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-action.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-action.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		showOnHover = false,
 		children,
 		child = undefined,

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-action.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-action.svelte
@@ -5,10 +5,10 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		showOnHover = false,
 		children,
-		child,
+		child = undefined,
 		...restProps
 	}: WithElementRef<HTMLButtonAttributes> & {
 		child?: Snippet<[{ props: Record<string, unknown> }]>;

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-badge.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-badge.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-badge.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-badge.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-button.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-button.svelte
@@ -37,7 +37,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		child = undefined,
 		variant = "default",

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-button.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-button.svelte
@@ -37,14 +37,14 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
-		child,
+		child = undefined,
 		variant = "default",
 		size = "default",
 		isActive = false,
-		tooltipContent,
-		tooltipContentProps,
+		tooltipContent = undefined,
+		tooltipContentProps = undefined,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLButtonElement>, HTMLButtonElement> & {
 		isActive?: boolean;

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-item.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-item.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLLIElement>, HTMLLIElement> = $props();

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-item.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-item.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLLIElement>, HTMLLIElement> = $props();

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-skeleton.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-skeleton.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		showIcon = false,
 		children,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-skeleton.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-skeleton.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		showIcon = false,
 		children,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-sub-button.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-sub-button.svelte
@@ -6,8 +6,8 @@
 	let {
 		ref = $bindable(null),
 		children,
-		child,
-		class: className,
+		child = undefined,
+		class: className = '',
 		size = "md",
 		isActive = false,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-sub-button.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-sub-button.svelte
@@ -7,7 +7,7 @@
 		ref = $bindable(null),
 		children,
 		child = undefined,
-		class: className = '',
+		class: className = "",
 		size = "md",
 		isActive = false,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-sub-item.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-sub-item.svelte
@@ -5,7 +5,7 @@
 	let {
 		ref = $bindable(null),
 		children,
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLLIElement>> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-sub-item.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-sub-item.svelte
@@ -5,7 +5,7 @@
 	let {
 		ref = $bindable(null),
 		children,
-		class: className,
+		class: className = '',
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLLIElement>> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-sub.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-sub.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLUListElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-sub.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu-sub.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLUListElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLUListElement>, HTMLUListElement> = $props();

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-menu.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLUListElement>, HTMLUListElement> = $props();

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-provider.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-provider.svelte
@@ -14,8 +14,8 @@
 		ref = $bindable(null),
 		open = $bindable(true),
 		onOpenChange = () => {},
-		class: className,
-		style,
+		class: className = '',
+		style = undefined,
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-provider.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-provider.svelte
@@ -14,7 +14,7 @@
 		ref = $bindable(null),
 		open = $bindable(true),
 		onOpenChange = () => {},
-		class: className = '',
+		class: className = "",
 		style = undefined,
 		children,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-rail.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-rail.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLButtonElement>, HTMLButtonElement> = $props();

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-rail.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-rail.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLButtonElement>, HTMLButtonElement> = $props();

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-separator.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-separator.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: ComponentProps<typeof Separator> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-separator.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-separator.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: ComponentProps<typeof Separator> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-trigger.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-trigger.svelte
@@ -7,8 +7,8 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
-		onclick,
+		class: className = '',
+		onclick = undefined,
 		...restProps
 	}: ComponentProps<typeof Button> & {
 		onclick?: (e: MouseEvent) => void;

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-trigger.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-trigger.svelte
@@ -7,7 +7,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		onclick = undefined,
 		...restProps
 	}: ComponentProps<typeof Button> & {

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar.svelte
@@ -10,7 +10,7 @@
 		side = "left",
 		variant = "sidebar",
 		collapsible = "offcanvas",
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {

--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar.svelte
@@ -10,7 +10,7 @@
 		side = "left",
 		variant = "sidebar",
 		collapsible = "offcanvas",
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {

--- a/sites/docs/src/lib/registry/ui/skeleton/skeleton.svelte
+++ b/sites/docs/src/lib/registry/ui/skeleton/skeleton.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: WithoutChildren<WithElementRef<HTMLAttributes<HTMLDivElement>>> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/skeleton/skeleton.svelte
+++ b/sites/docs/src/lib/registry/ui/skeleton/skeleton.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: WithoutChildren<WithElementRef<HTMLAttributes<HTMLDivElement>>> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/slider/slider.svelte
+++ b/sites/docs/src/lib/registry/ui/slider/slider.svelte
@@ -6,7 +6,7 @@
 		ref = $bindable(null),
 		value = $bindable(),
 		orientation = "horizontal",
-		class: className,
+		class: className = '',
 		...restProps
 	}: WithoutChildrenOrChild<SliderPrimitive.RootProps> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/slider/slider.svelte
+++ b/sites/docs/src/lib/registry/ui/slider/slider.svelte
@@ -6,7 +6,7 @@
 		ref = $bindable(null),
 		value = $bindable(),
 		orientation = "horizontal",
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: WithoutChildrenOrChild<SliderPrimitive.RootProps> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/switch/switch.svelte
+++ b/sites/docs/src/lib/registry/ui/switch/switch.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		checked = $bindable(false),
 		...restProps
 	}: WithoutChildrenOrChild<SwitchPrimitive.RootProps> = $props();

--- a/sites/docs/src/lib/registry/ui/switch/switch.svelte
+++ b/sites/docs/src/lib/registry/ui/switch/switch.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		checked = $bindable(false),
 		...restProps
 	}: WithoutChildrenOrChild<SwitchPrimitive.RootProps> = $props();

--- a/sites/docs/src/lib/registry/ui/table/table-body.svelte
+++ b/sites/docs/src/lib/registry/ui/table/table-body.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/table/table-body.svelte
+++ b/sites/docs/src/lib/registry/ui/table/table-body.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/table/table-caption.svelte
+++ b/sites/docs/src/lib/registry/ui/table/table-caption.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/table/table-caption.svelte
+++ b/sites/docs/src/lib/registry/ui/table/table-caption.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/table/table-cell.svelte
+++ b/sites/docs/src/lib/registry/ui/table/table-cell.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLTdAttributes> = $props();

--- a/sites/docs/src/lib/registry/ui/table/table-cell.svelte
+++ b/sites/docs/src/lib/registry/ui/table/table-cell.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLTdAttributes> = $props();

--- a/sites/docs/src/lib/registry/ui/table/table-footer.svelte
+++ b/sites/docs/src/lib/registry/ui/table/table-footer.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/table/table-footer.svelte
+++ b/sites/docs/src/lib/registry/ui/table/table-footer.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/table/table-head.svelte
+++ b/sites/docs/src/lib/registry/ui/table/table-head.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLThAttributes> = $props();

--- a/sites/docs/src/lib/registry/ui/table/table-head.svelte
+++ b/sites/docs/src/lib/registry/ui/table/table-head.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLThAttributes> = $props();

--- a/sites/docs/src/lib/registry/ui/table/table-header.svelte
+++ b/sites/docs/src/lib/registry/ui/table/table-header.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/table/table-header.svelte
+++ b/sites/docs/src/lib/registry/ui/table/table-header.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/table/table-row.svelte
+++ b/sites/docs/src/lib/registry/ui/table/table-row.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLTableRowElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/table/table-row.svelte
+++ b/sites/docs/src/lib/registry/ui/table/table-row.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLTableRowElement>> = $props();

--- a/sites/docs/src/lib/registry/ui/table/table.svelte
+++ b/sites/docs/src/lib/registry/ui/table/table.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		children,
 		...restProps
 	}: WithElementRef<HTMLTableAttributes> = $props();

--- a/sites/docs/src/lib/registry/ui/table/table.svelte
+++ b/sites/docs/src/lib/registry/ui/table/table.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		children,
 		...restProps
 	}: WithElementRef<HTMLTableAttributes> = $props();

--- a/sites/docs/src/lib/registry/ui/tabs/tabs-content.svelte
+++ b/sites/docs/src/lib/registry/ui/tabs/tabs-content.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: TabsPrimitive.ContentProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/tabs/tabs-content.svelte
+++ b/sites/docs/src/lib/registry/ui/tabs/tabs-content.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: TabsPrimitive.ContentProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/tabs/tabs-list.svelte
+++ b/sites/docs/src/lib/registry/ui/tabs/tabs-list.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: TabsPrimitive.ListProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/tabs/tabs-list.svelte
+++ b/sites/docs/src/lib/registry/ui/tabs/tabs-list.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: TabsPrimitive.ListProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/tabs/tabs-trigger.svelte
+++ b/sites/docs/src/lib/registry/ui/tabs/tabs-trigger.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		...restProps
 	}: TabsPrimitive.TriggerProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/tabs/tabs-trigger.svelte
+++ b/sites/docs/src/lib/registry/ui/tabs/tabs-trigger.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: TabsPrimitive.TriggerProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/tabs/tabs.svelte
+++ b/sites/docs/src/lib/registry/ui/tabs/tabs.svelte
@@ -5,7 +5,7 @@
 	let {
 		ref = $bindable(null),
 		value = $bindable(""),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: TabsPrimitive.RootProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/tabs/tabs.svelte
+++ b/sites/docs/src/lib/registry/ui/tabs/tabs.svelte
@@ -5,7 +5,7 @@
 	let {
 		ref = $bindable(null),
 		value = $bindable(""),
-		class: className,
+		class: className = '',
 		...restProps
 	}: TabsPrimitive.RootProps = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/textarea/textarea.svelte
+++ b/sites/docs/src/lib/registry/ui/textarea/textarea.svelte
@@ -5,7 +5,7 @@
 	let {
 		ref = $bindable(null),
 		value = $bindable(),
-		class: className = '',
+		class: className = "",
 		...restProps
 	}: WithoutChildren<WithElementRef<HTMLTextareaAttributes>> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/textarea/textarea.svelte
+++ b/sites/docs/src/lib/registry/ui/textarea/textarea.svelte
@@ -5,7 +5,7 @@
 	let {
 		ref = $bindable(null),
 		value = $bindable(),
-		class: className,
+		class: className = '',
 		...restProps
 	}: WithoutChildren<WithElementRef<HTMLTextareaAttributes>> = $props();
 </script>

--- a/sites/docs/src/lib/registry/ui/toggle-group/toggle-group-item.svelte
+++ b/sites/docs/src/lib/registry/ui/toggle-group/toggle-group-item.svelte
@@ -7,7 +7,7 @@
 	let {
 		ref = $bindable(null),
 		value = $bindable(),
-		class: className = '',
+		class: className = "",
 		size,
 		variant,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/toggle-group/toggle-group-item.svelte
+++ b/sites/docs/src/lib/registry/ui/toggle-group/toggle-group-item.svelte
@@ -7,7 +7,7 @@
 	let {
 		ref = $bindable(null),
 		value = $bindable(),
-		class: className,
+		class: className = '',
 		size,
 		variant,
 		...restProps

--- a/sites/docs/src/lib/registry/ui/toggle-group/toggle-group.svelte
+++ b/sites/docs/src/lib/registry/ui/toggle-group/toggle-group.svelte
@@ -17,7 +17,7 @@
 	let {
 		ref = $bindable(null),
 		value = $bindable(),
-		class: className,
+		class: className = '',
 		size = "default",
 		variant = "default",
 		...restProps

--- a/sites/docs/src/lib/registry/ui/toggle-group/toggle-group.svelte
+++ b/sites/docs/src/lib/registry/ui/toggle-group/toggle-group.svelte
@@ -17,7 +17,7 @@
 	let {
 		ref = $bindable(null),
 		value = $bindable(),
-		class: className = '',
+		class: className = "",
 		size = "default",
 		variant = "default",
 		...restProps

--- a/sites/docs/src/lib/registry/ui/toggle/toggle.svelte
+++ b/sites/docs/src/lib/registry/ui/toggle/toggle.svelte
@@ -33,7 +33,7 @@
 	let {
 		ref = $bindable(null),
 		pressed = $bindable(false),
-		class: className = '',
+		class: className = "",
 		size = "default",
 		variant = "default",
 		...restProps

--- a/sites/docs/src/lib/registry/ui/toggle/toggle.svelte
+++ b/sites/docs/src/lib/registry/ui/toggle/toggle.svelte
@@ -33,7 +33,7 @@
 	let {
 		ref = $bindable(null),
 		pressed = $bindable(false),
-		class: className,
+		class: className = '',
 		size = "default",
 		variant = "default",
 		...restProps

--- a/sites/docs/src/lib/registry/ui/tooltip/tooltip-content.svelte
+++ b/sites/docs/src/lib/registry/ui/tooltip/tooltip-content.svelte
@@ -4,7 +4,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className = '',
+		class: className = "",
 		sideOffset = 0,
 		side = "top",
 		children,

--- a/sites/docs/src/lib/registry/ui/tooltip/tooltip-content.svelte
+++ b/sites/docs/src/lib/registry/ui/tooltip/tooltip-content.svelte
@@ -4,11 +4,11 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = '',
 		sideOffset = 0,
 		side = "top",
 		children,
-		arrowClasses,
+		arrowClasses = undefined,
 		...restProps
 	}: TooltipPrimitive.ContentProps & {
 		arrowClasses?: string;


### PR DESCRIPTION
From discord: https://discord.com/channels/1194404141389336576/1374023382424752248

This PR adds default values to any non-required props for components in the registry. The root of the problem on discord seems to be that JS is expecting a prop without a default value to be passed to the component. By providing a default value that expectation should go away.


