### PR TITLE
Update CSS templates for Tailwind v4

### DIFF
--- a/sites/docs/scripts/templates.ts
+++ b/sites/docs/scripts/templates.ts
@@ -1,6 +1,4 @@
-export const BASE_STYLES = `@tailwind base;
-@tailwind components;
-@tailwind utilities;
+export const BASE_STYLES = `@import tailwindcss;
 `;
 
 export const BASE_STYLES_WITH_VARIABLES = `@tailwind base;
@@ -75,10 +73,10 @@ export const BASE_STYLES_WITH_VARIABLES = `@tailwind base;
  
 @layer base {
   * {
-    @apply border-border;
+    @reference border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @reference bg-background text-foreground;
   }
 }`;
 


### PR DESCRIPTION
Currently the automatic `init` script does not properly configure Tailwind's `app.css` file.

As migration guide states:

1. `@tailwindcss` directives have been removed[^1]
[^1]: https://tailwindcss.com/docs/upgrade-guide#removed-tailwind-directives

2. SvelteKit needs to start using `@reference` instead of `@apply`[^2]
[^2]: https://tailwindcss.com/docs/upgrade-guide#using-apply-with-vue-svelte-or-css-modules