### PR TITLE
fix(Tooltip): use `data-side` attrs

### DIFF
--- a/sites/docs/src/lib/registry/ui/tooltip/tooltip-content.svelte
+++ b/sites/docs/src/lib/registry/ui/tooltip/tooltip-content.svelte
@@ -33,10 +33,10 @@
 				<div
 					class={cn(
 						"bg-primary z-50 size-2.5 rotate-45 rounded-[2px]",
-						side === "top" && "translate-x-1/2 translate-y-[calc(-50%_+_2px)]",
-						side === "bottom" && "-translate-x-1/2 -translate-y-[calc(-50%_+_1px)]",
-						side === "right" && "translate-x-[calc(50%_+_2px)] translate-y-1/2",
-						side === "left" && "-translate-y-[calc(50%_-_3px)]",
+						"data-[side=top]:translate-x-1/2 data-[side=top]:translate-y-[calc(-50%_+_2px)]",
+						"data-[side=bottom]:-translate-y-[calc(-50%_+_1px)] data-[side=bottom]:translate-x-1/2",
+						"data-[side=right]:translate-x-[calc(50%_+_2px)] data-[side=right]:translate-y-1/2",
+						"data-[side=left]:translate-y-[calc(50%_-_3px)]",
 						arrowClasses
 					)}
 					{...props}


### PR DESCRIPTION
This pull request updates the tooltip alignment logic in `tooltip-content.svelte` to use `data-*` attributes for conditional styling instead of JavaScript-based conditional classes. This change simplifies the code and improves maintainability.

Styling improvements:

* [`sites/docs/src/lib/registry/ui/tooltip/tooltip-content.svelte`](diffhunk://#diff-b63e09bd98361a0f403080d9e129ce647b015358f8e7c01583bc0ef16c951994L36-R39): Replaced conditional class logic based on `side` with `data-*` attributes for styling, enabling the styles to adapt as the tooltip content flips due to spacing limitations
