### PR TITLE
docs: remove `isVisible` from Pagination usage

### DIFF
--- a/sites/docs/src/content/components/pagination.md
+++ b/sites/docs/src/content/components/pagination.md
@@ -56,7 +56,7 @@ links:
             <Pagination.Ellipsis />
           </Pagination.Item>
         {:else}
-          <Pagination.Item isVisible={currentPage === page.value}>
+          <Pagination.Item>
             <Pagination.Link {page} isActive={currentPage === page.value}>
               {page.value}
             </Pagination.Link>


### PR DESCRIPTION
closes #1681

This is just a documentation error. `isVisible` is not a valid prop in `Pagination.Item`.

<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->
