### PR TITLE
fix(next): Drawer padding consistency

### DIFF
--- a/sites/docs/src/lib/registry/ui/drawer/drawer-content.svelte
+++ b/sites/docs/src/lib/registry/ui/drawer/drawer-content.svelte
@@ -20,7 +20,7 @@
 		bind:ref
 		data-slot="drawer-content"
 		class={cn(
-			"group/drawer-content bg-background fixed z-50 flex h-auto flex-col gap-4 p-6",
+			"group/drawer-content bg-background fixed z-50 flex h-auto flex-col gap-4 p-4",
 			"data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
 			"data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
 			"data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",

--- a/sites/docs/src/lib/registry/ui/drawer/drawer-content.svelte
+++ b/sites/docs/src/lib/registry/ui/drawer/drawer-content.svelte
@@ -20,7 +20,7 @@
 		bind:ref
 		data-slot="drawer-content"
 		class={cn(
-			"group/drawer-content bg-background fixed z-50 flex h-auto flex-col p-6 gap-4",
+			"group/drawer-content bg-background fixed z-50 flex h-auto flex-col gap-4 p-6",
 			"data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
 			"data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
 			"data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",

--- a/sites/docs/src/lib/registry/ui/drawer/drawer-content.svelte
+++ b/sites/docs/src/lib/registry/ui/drawer/drawer-content.svelte
@@ -20,7 +20,7 @@
 		bind:ref
 		data-slot="drawer-content"
 		class={cn(
-			"group/drawer-content bg-background fixed z-50 flex h-auto flex-col",
+			"group/drawer-content bg-background fixed z-50 flex h-auto flex-col p-6 gap-4",
 			"data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
 			"data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
 			"data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",

--- a/sites/docs/src/lib/registry/ui/drawer/drawer-footer.svelte
+++ b/sites/docs/src/lib/registry/ui/drawer/drawer-footer.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="drawer-footer"
-	class={cn("mt-auto flex flex-col gap-2 p-4", className)}
+	class={cn("mt-auto flex flex-col gap-2", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/sites/docs/src/lib/registry/ui/drawer/drawer-header.svelte
+++ b/sites/docs/src/lib/registry/ui/drawer/drawer-header.svelte
@@ -13,7 +13,7 @@
 <div
 	bind:this={ref}
 	data-slot="drawer-header"
-	class={cn("flex flex-col gap-1.5 p-4", className)}
+	class={cn("flex flex-col gap-1.5", className)}
 	{...restProps}
 >
 	{@render children?.()}


### PR DESCRIPTION
This PR updates the drawer padding to be more consistent with the way that the dialog header and footer works.

It's worth noting that this is NOT how the original is styled. But to me it makes more sense this way.

![CleanShot 2025-05-29 at 10 19 46](https://github.com/user-attachments/assets/f8842975-3721-4938-bac5-ac7d756b312b)
