### PR TITLE
fix(sidebar): prevent sidebar content from excessive shrinking

### DIFF
--- a/sites/docs/src/lib/registry/ui/sidebar/sidebar-inset.svelte
+++ b/sites/docs/src/lib/registry/ui/sidebar/sidebar-inset.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="sidebar-inset"
 	class={cn(
-		"bg-background relative flex w-full flex-1 flex-col",
+		"bg-background relative flex w-full flex-1 flex-col min-w-0",
 		"md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm",
 		className
 	)}

--- a/v4/src/lib/registry/ui/sidebar/sidebar-inset.svelte
+++ b/v4/src/lib/registry/ui/sidebar/sidebar-inset.svelte
@@ -15,7 +15,7 @@
 	bind:this={ref}
 	data-slot="sidebar-inset"
 	class={cn(
-		"bg-background relative flex w-full flex-1 flex-col",
+		"bg-background relative flex w-full flex-1 flex-col min-w-0",
 		"md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm",
 		className
 	)}


### PR DESCRIPTION
Add `min-w-0` to sidebar-inset to ensure proper flex layout behavior

- Prevents sidebar from shrinking more than intended in flex containers
- Allows main content to resize correctly without being constrained
- Resolves potential layout issues with responsive sidebar design

fixes #2008 

Before:
![Screenshot 2025-06-01 at 11 23 07](https://github.com/user-attachments/assets/ef419438-e4d1-4041-857f-37b7fffa3b6f)

After:
![Screenshot 2025-06-01 at 11 23 21](https://github.com/user-attachments/assets/e1a86a66-376d-4053-ad1a-d77cd02d6c21)
