### PR TITLE
refactor!: remove `overflow-auto` from table wrapper

### DIFF
--- a/sites/docs/src/lib/registry/default/ui/table/table.svelte
+++ b/sites/docs/src/lib/registry/default/ui/table/table.svelte
@@ -8,7 +8,7 @@
 	export { className as class };
 </script>
 
-<div class="relative w-full overflow-auto">
+<div class="relative w-full">
 	<table class={cn("w-full caption-bottom text-sm", className)} {...$$restProps}>
 		<slot />
 	</table>


### PR DESCRIPTION
Using `overflow` breaks `position: sticky` for nested elements (like table header).
Having this in the table component is unintuitive and can lead to a lot of wasted time.
