### PR TITLE
fix(next): remove redundant `class` export

### DIFF
--- a/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-day.svelte
+++ b/sites/docs/src/lib/registry/ui/range-calendar/range-calendar-day.svelte
@@ -8,8 +8,6 @@
 		class: className,
 		...restProps
 	}: RangeCalendarPrimitive.DayProps = $props();
-
-	export { className as class };
 </script>
 
 <RangeCalendarPrimitive.Day

--- a/sites/docs/src/lib/registry/ui/sheet/sheet-overlay.svelte
+++ b/sites/docs/src/lib/registry/ui/sheet/sheet-overlay.svelte
@@ -7,8 +7,6 @@
 		class: className,
 		...restProps
 	}: SheetPrimitive.OverlayProps = $props();
-
-	export { className as class };
 </script>
 
 <SheetPrimitive.Overlay

--- a/v4/src/lib/registry/ui/range-calendar/range-calendar-day.svelte
+++ b/v4/src/lib/registry/ui/range-calendar/range-calendar-day.svelte
@@ -8,8 +8,6 @@
 		class: className,
 		...restProps
 	}: RangeCalendarPrimitive.DayProps = $props();
-
-	export { className as class };
 </script>
 
 <RangeCalendarPrimitive.Day

--- a/v4/src/lib/registry/ui/sheet/sheet-overlay.svelte
+++ b/v4/src/lib/registry/ui/sheet/sheet-overlay.svelte
@@ -7,8 +7,6 @@
 		class: className,
 		...restProps
 	}: SheetPrimitive.OverlayProps = $props();
-
-	export { className as class };
 </script>
 
 <SheetPrimitive.Overlay


### PR DESCRIPTION
supersedes #1599. 

I tried editing their PR but something about their branch/branch-name was preventing me from doing so. This PR also removes it from a couple of extra places as well.

<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->
