### PR TITLE
docs:Add Svelte5 repo link to the bug_report.yml.

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/3-bug_report.yml
@@ -27,8 +27,10 @@ body:
       description: |
         Provide a minimal reproduction of the problem. Include a StackBlitz or link to a GitHub repository that we can easily run to recreate the issue. If a report is vague and does not have a reproduction, it will be closed without warning.
 
-        To get started, you can use the following StackBlitz template:
+        To get started, you can use the following StackBlitz template for Svelte 4:
         https://shadcn-svelte.com/repro
+        or for Svelte 5:
+        https://shadcn-svelte.com/repro5
 
         ***Do not simply add a code snippet or a screenshot. We need a reproduction that we can easily run to recreate the issue.***
       placeholder: Reproduction

--- a/sites/docs/src/routes/(app)/repro5/+page.ts
+++ b/sites/docs/src/routes/(app)/repro5/+page.ts
@@ -1,0 +1,6 @@
+import { redirect } from "@sveltejs/kit";
+import type { PageLoad } from "./$types.js";
+
+export const load: PageLoad = async () => {
+	redirect(302, "https://stackblitz.com/github/huntabyte/shadcn-repro-template/tree/next");
+};


### PR DESCRIPTION
Adding a link to a repo Stackblitz for Svelte 5 using Shadcn next.

This would need a branch called "next" in the repo project: https://github.com/huntabyte/shadcn-repro-template