### PR TITLE
fix(cli): update failing on recent Node versions

### DIFF
--- a/.changeset/fine-drinks-marry.md
+++ b/.changeset/fine-drinks-marry.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": patch
+---
+
+fix: `update` failing in Node 24+

--- a/packages/cli/src/commands/update/index.ts
+++ b/packages/cli/src/commands/update/index.ts
@@ -212,7 +212,7 @@ async function runUpdate(cwd: string, config: cliConfig.ResolvedConfig, options:
 
 					const installedFiles = await fs.readdir(itemDir, { withFileTypes: true });
 					const filesToDelete = installedFiles
-						.map((file) => path.resolve(file.path, file.name))
+						.map((file) => path.resolve(file.parentPath, file.name))
 						.filter((filepath) => !remoteFiles.includes(filepath));
 
 					if (filesToDelete.length > 0) {

--- a/registry-template/src/lib/registry/ui/card/card-footer.svelte
+++ b/registry-template/src/lib/registry/ui/card/card-footer.svelte
@@ -7,7 +7,7 @@
 
 <div
 	data-slot="card-footer"
-	class={cn("[.border-t]:pt-6 flex items-center px-6", className)}
+	class={cn("flex items-center px-6 [.border-t]:pt-6", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/registry-template/src/lib/registry/ui/card/card-header.svelte
+++ b/registry-template/src/lib/registry/ui/card/card-header.svelte
@@ -7,7 +7,7 @@
 <div
 	data-slot="card-header"
 	class={cn(
-		"@container/card-header has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6 grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6",
+		"@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
 		className
 	)}
 	{...restProps}

--- a/registry-template/src/lib/registry/ui/card/card-title.svelte
+++ b/registry-template/src/lib/registry/ui/card/card-title.svelte
@@ -5,6 +5,6 @@
 	let { class: className, children, ...restProps }: HTMLAttributes<HTMLHeadingElement> = $props();
 </script>
 
-<div data-slot="card-title" class={cn("font-semibold leading-none", className)} {...restProps}>
+<div data-slot="card-title" class={cn("leading-none font-semibold", className)} {...restProps}>
 	{@render children?.()}
 </div>

--- a/registry-template/src/lib/registry/ui/input/input.svelte
+++ b/registry-template/src/lib/registry/ui/input/input.svelte
@@ -9,7 +9,7 @@
 	bind:value
 	data-slot="input"
 	class={cn(
-		"file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input shadow-xs flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base outline-none transition-[color,box-shadow] file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+		"file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
 		"focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
 		"aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
 		className

--- a/registry-template/src/lib/registry/ui/label/label.svelte
+++ b/registry-template/src/lib/registry/ui/label/label.svelte
@@ -13,7 +13,7 @@
 <LabelPrimitive.Root
 	data-slot="label"
 	class={cn(
-		"flex select-none items-center gap-2 text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-50 group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50",
+		"flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
 		className
 	)}
 	{...restProps}

--- a/registry-template/src/lib/registry/ui/textarea/input.svelte
+++ b/registry-template/src/lib/registry/ui/textarea/input.svelte
@@ -13,7 +13,7 @@
 	bind:value
 	data-slot="input"
 	class={cn(
-		"border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 field-sizing-content shadow-xs flex min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+		"border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
 		className
 	)}
 	{...restProps}


### PR DESCRIPTION
<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->

`Dirent.path` is deprecated since Node 20.12.0, and has been replaced since then by `Dirent.parentPath`, which is essentially an alias.

`Dirent.path` seems to have been removed in Node 24, breaking for most recent Node versions in a similar way to #1003.

As shadcn-svelte officially only supports Node 22+, I think it's fair to replace the usage completely.

This is the only instance of `Dirent.path` I found throughout the entire codebase.