### PR TITLE
fix(docs): update component code viewer to use grid to prevent overflow

### DIFF
--- a/docs/src/lib/components/component-code-viewer/component-code-viewer-code.svelte
+++ b/docs/src/lib/components/component-code-viewer/component-code-viewer-code.svelte
@@ -9,14 +9,14 @@
 
 {#if file}
 	<div
-		class="bg-code text-code-foreground h-(--height) flex overflow-hidden rounded-xl border group-data-[view=preview]/block-view-wrapper:hidden"
+		class="bg-code text-code-foreground h-(--height) grid grid-cols-[auto_1fr] overflow-hidden rounded-xl border group-data-[view=preview]/block-view-wrapper:hidden"
 	>
 		<div class="hidden w-72 md:block">
 			<ComponentCodeViewerFileTree />
 		</div>
 		<figure
 			data-rehype-pretty-code-figure
-			class="mt-0 flex min-w-0 flex-1 flex-col rounded-xl border-none"
+			class="mt-0 flex w-full min-w-0 flex-1 flex-col rounded-xl border-none"
 		>
 			<ComponentCodeViewerCodeTitle />
 			<div class="no-scrollbar overflow-y-auto">


### PR DESCRIPTION
Fixes the overflowing code issue in the component source code viewer.

Makes use of the CSS grid layout mode, which handles width more intuitively in some cases.

Fixes #2095