### PR TITLE
fix: remove `mx-2 w-auto` from `Sidebar.Separator`

### DIFF
--- a/docs/src/lib/registry/ui/sidebar/sidebar-separator.svelte
+++ b/docs/src/lib/registry/ui/sidebar/sidebar-separator.svelte
@@ -14,6 +14,6 @@
 	bind:ref
 	data-slot="sidebar-separator"
 	data-sidebar="separator"
-	class={cn("bg-sidebar-border mx-2 w-auto", className)}
+	class={cn("bg-sidebar-border", className)}
 	{...restProps}
 />


### PR DESCRIPTION
Fixes #2128 

As mentioned in https://github.com/huntabyte/shadcn-svelte/issues/2128#issuecomment-2967939220 with a quick search through the codebase we are applying `mx-0` to reset these styles everywhere they are applied. It may be better to just remove them as I have done in this PR.

Original Style: https://github.com/shadcn-ui/ui/blob/main/apps/www/registry/default/ui/sidebar.tsx#L393
