### PR TITLE
fix: Update command-menu.svelte - useMac

### DIFF
--- a/docs/src/lib/components/command-menu/command-menu.svelte
+++ b/docs/src/lib/components/command-menu/command-menu.svelte
@@ -144,7 +144,7 @@
 				<span class="hidden lg:inline-flex">Search documentation...</span>
 				<span class="inline-flex lg:hidden">Search...</span>
 				<div class="absolute right-1.5 top-1.5 hidden gap-1 sm:flex">
-					{@render CommandMenuKbd({ content: isMac ? "⌘" : "Ctrl" })}
+					{@render CommandMenuKbd({ content: isMac.current ? "⌘" : "Ctrl" })}
 					{@render CommandMenuKbd({ content: "K", class: "aspect-square" })}
 				</div>
 			</Button>
@@ -280,7 +280,7 @@
 			{#if copyPayload}
 				<Separator orientation="vertical" class="!h-4" />
 				<div class="flex items-center gap-1">
-					{@render CommandMenuKbd({ content: isMac ? "⌘" : "Ctrl" })}
+					{@render CommandMenuKbd({ content: isMac.current ? "⌘" : "Ctrl" })}
 					{@render CommandMenuKbd({ content: "C" })}
 					{copyPayload}
 				</div>


### PR DESCRIPTION
Fix useMac and add `current`.

If you're using windows, it does not display `ctrl` instead of `⌘` in the search bar.  The `useMac` custom hook does not correctly reference the `current` method.
