### PR TITLE
fix: Only pad left side of sidebar submenu items for better UX

### DIFF
--- a/docs/src/lib/registry/ui/sidebar/sidebar-menu-sub.svelte
+++ b/docs/src/lib/registry/ui/sidebar/sidebar-menu-sub.svelte
@@ -15,7 +15,7 @@
 	data-slot="sidebar-menu-sub"
 	data-sidebar="menu-sub"
 	class={cn(
-		"border-sidebar-border mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l px-2.5 py-0.5",
+		"border-sidebar-border ml-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l pl-2.5 py-0.5",
 		"group-data-[collapsible=icon]:hidden",
 		className
 	)}


### PR DESCRIPTION
The submenu items being padded on both sides makes the user click on an absent part of the sidebar when they want to select a menu subitem.
I think it would be better if subitems still are padded on the left side but extends all the way to the right.