### PR TITLE
fix: add chart context and legend components to fix chart legend horizontal overflow; refactor chart container

### DIFF
--- a/docs/registry.json
+++ b/docs/registry.json
@@ -390,6 +390,14 @@
 				},
 				{
 					"type": "registry:file",
+					"path": "src/lib/registry/ui/chart/chart-context.svelte"
+				},
+				{
+					"type": "registry:file",
+					"path": "src/lib/registry/ui/chart/chart-legend.svelte"
+				},
+				{
+					"type": "registry:file",
 					"path": "src/lib/registry/ui/chart/chart-style.svelte"
 				},
 				{

--- a/docs/src/lib/registry/blocks/chart-pie-legend.svelte
+++ b/docs/src/lib/registry/blocks/chart-pie-legend.svelte
@@ -28,29 +28,35 @@
 		<Card.Description>January - June 2024</Card.Description>
 	</Card.Header>
 	<Card.Content class="flex-1">
-		<Chart.Container config={chartConfig} class="mx-auto aspect-square max-h-[250px]">
-			<PieChart
-				data={chartData}
-				key="browser"
-				value="visitors"
-				label={(d) =>
-					d.browser
-						.split("")
-						.map((c, i) => (i === 0 ? c.toUpperCase() : c))
-						.join("")}
-				cRange={chartData.map((d) => d.color)}
-				props={{
-					pie: {
-						motion: "tween",
-					},
-				}}
-				legend
-			>
-				{#snippet tooltip()}
-					<Chart.Tooltip hideLabel />
-				{/snippet}
-			</PieChart>
-		</Chart.Container>
+		<Chart.Context config={chartConfig} class="flex flex-col h-[250px]">
+			<Chart.Container class="mx-auto aspect-square flex-1 min-h-0">
+				<PieChart
+					data={chartData}
+					key="browser"
+					value="visitors"
+					label={(d) =>
+						d.browser
+							.split("")
+							.map((c, i) => (i === 0 ? c.toUpperCase() : c))
+							.join("")}
+					cRange={chartData.map((d) => d.color)}
+					props={{
+						pie: {
+							motion: "tween",
+						},
+					}}
+					legend={false}
+				>
+					{#snippet tooltip()}
+						<Chart.Tooltip hideLabel />
+					{/snippet}
+				</PieChart>
+			</Chart.Container>
+			
+			<!-- Custom legend positioned outside chart container to prevent overflow (issue #2038) -->
+			<!-- LayerChart's built-in legend can overflow when chart space is constrained -->
+			<Chart.Legend class="mt-2" />
+		</Chart.Context>
 	</Card.Content>
 	<Card.Footer class="flex-col gap-2 text-sm">
 		<div class="flex items-center gap-2 font-medium leading-none">

--- a/docs/src/lib/registry/blocks/chart-pie-legend.svelte
+++ b/docs/src/lib/registry/blocks/chart-pie-legend.svelte
@@ -28,8 +28,8 @@
 		<Card.Description>January - June 2024</Card.Description>
 	</Card.Header>
 	<Card.Content class="flex-1">
-		<Chart.Context config={chartConfig} class="flex flex-col h-[250px]">
-			<Chart.Container class="mx-auto aspect-square flex-1 min-h-0">
+		<Chart.Context config={chartConfig} class="flex h-[250px] flex-col">
+			<Chart.Container class="mx-auto aspect-square min-h-0 flex-1">
 				<PieChart
 					data={chartData}
 					key="browser"
@@ -52,7 +52,7 @@
 					{/snippet}
 				</PieChart>
 			</Chart.Container>
-			
+
 			<!-- Custom legend positioned outside chart container to prevent overflow (issue #2038) -->
 			<!-- LayerChart's built-in legend can overflow when chart space is constrained -->
 			<Chart.Legend class="mt-2" />

--- a/docs/src/lib/registry/ui/chart/chart-context.svelte
+++ b/docs/src/lib/registry/ui/chart/chart-context.svelte
@@ -21,4 +21,4 @@
 
 <div class={cn(className)} {...restProps}>
 	{@render children()}
-</div> 
+</div>

--- a/docs/src/lib/registry/ui/chart/chart-context.svelte
+++ b/docs/src/lib/registry/ui/chart/chart-context.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import { setChartContext, type ChartConfig } from "./chart-utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+	import type { Snippet } from "svelte";
+
+	interface Props extends HTMLAttributes<HTMLElement> {
+		config: ChartConfig;
+		children: Snippet;
+		class?: string;
+	}
+
+	let { config, children, class: className, ...restProps }: Props = $props();
+
+	setChartContext({
+		get config() {
+			return config;
+		},
+	});
+</script>
+
+<div class={cn(className)} {...restProps}>
+	{@render children()}
+</div> 

--- a/docs/src/lib/registry/ui/chart/chart-legend.svelte
+++ b/docs/src/lib/registry/ui/chart/chart-legend.svelte
@@ -40,7 +40,7 @@
 	{@render children({ items: legendItems })}
 {:else}
 	<div class={cn("flex flex-wrap justify-center gap-2 px-4", className)} {...restProps}>
-		{#each legendItems as item}
+		{#each legendItems as item (item.key)}
 			<div class="flex items-center gap-1.5 text-xs">
 				<div
 					class="size-2.5 flex-shrink-0 rounded-[2px]"

--- a/docs/src/lib/registry/ui/chart/chart-legend.svelte
+++ b/docs/src/lib/registry/ui/chart/chart-legend.svelte
@@ -15,12 +15,7 @@
 		class?: string;
 	}
 
-	let {
-		items = [],
-		children,
-		class: className,
-		...restProps
-	}: Props = $props();
+	let { items = [], children, class: className, ...restProps }: Props = $props();
 
 	const { config } = useChart();
 
@@ -44,17 +39,11 @@
 {#if children}
 	{@render children({ items: legendItems })}
 {:else}
-	<div
-		class={cn(
-			"flex flex-wrap justify-center gap-2 px-4",
-			className
-		)}
-		{...restProps}
-	>
+	<div class={cn("flex flex-wrap justify-center gap-2 px-4", className)} {...restProps}>
 		{#each legendItems as item}
 			<div class="flex items-center gap-1.5 text-xs">
-				<div 
-					class="size-2.5 rounded-[2px] flex-shrink-0" 
+				<div
+					class="size-2.5 flex-shrink-0 rounded-[2px]"
 					style="background-color: {item.color}"
 				></div>
 				<span class="text-muted-foreground whitespace-nowrap">
@@ -63,4 +52,4 @@
 			</div>
 		{/each}
 	</div>
-{/if} 
+{/if}

--- a/docs/src/lib/registry/ui/chart/chart-legend.svelte
+++ b/docs/src/lib/registry/ui/chart/chart-legend.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import { useChart } from "./chart-utils.js";
+	import type { Snippet } from "svelte";
+
+	interface LegendItem {
+		key: string;
+		label: string;
+		color: string;
+	}
+
+	interface Props {
+		items?: LegendItem[];
+		children?: Snippet<[{ items: LegendItem[] }]>;
+		class?: string;
+	}
+
+	let {
+		items = [],
+		children,
+		class: className,
+		...restProps
+	}: Props = $props();
+
+	const { config } = useChart();
+
+	// Convert config to legend items if no items provided
+	const legendItems = $derived.by(() => {
+		if (items.length > 0) {
+			return items;
+		}
+
+		// Generate from config
+		return Object.entries(config)
+			.filter(([_, value]) => value.label && value.color)
+			.map(([key, value]) => ({
+				key,
+				label: value.label!,
+				color: value.color!,
+			}));
+	});
+</script>
+
+{#if children}
+	{@render children({ items: legendItems })}
+{:else}
+	<div
+		class={cn(
+			"flex flex-wrap justify-center gap-2 px-4",
+			className
+		)}
+		{...restProps}
+	>
+		{#each legendItems as item}
+			<div class="flex items-center gap-1.5 text-xs">
+				<div 
+					class="size-2.5 rounded-[2px] flex-shrink-0" 
+					style="background-color: {item.color}"
+				></div>
+				<span class="text-muted-foreground whitespace-nowrap">
+					{item.label}
+				</span>
+			</div>
+		{/each}
+	</div>
+{/if} 

--- a/docs/src/lib/registry/ui/chart/index.ts
+++ b/docs/src/lib/registry/ui/chart/index.ts
@@ -5,13 +5,13 @@ import ChartContext from "./chart-context.svelte";
 
 export { getPayloadConfigFromPayload, type ChartConfig } from "./chart-utils.js";
 
-export { 
-	ChartContainer, 
-	ChartTooltip, 
+export {
+	ChartContainer,
+	ChartTooltip,
 	ChartLegend,
 	ChartContext,
-	ChartContainer as Container, 
+	ChartContainer as Container,
 	ChartTooltip as Tooltip,
 	ChartLegend as Legend,
-	ChartContext as Context
+	ChartContext as Context,
 };

--- a/docs/src/lib/registry/ui/chart/index.ts
+++ b/docs/src/lib/registry/ui/chart/index.ts
@@ -1,6 +1,17 @@
 import ChartContainer from "./chart-container.svelte";
 import ChartTooltip from "./chart-tooltip.svelte";
+import ChartLegend from "./chart-legend.svelte";
+import ChartContext from "./chart-context.svelte";
 
 export { getPayloadConfigFromPayload, type ChartConfig } from "./chart-utils.js";
 
-export { ChartContainer, ChartTooltip, ChartContainer as Container, ChartTooltip as Tooltip };
+export { 
+	ChartContainer, 
+	ChartTooltip, 
+	ChartLegend,
+	ChartContext,
+	ChartContainer as Container, 
+	ChartTooltip as Tooltip,
+	ChartLegend as Legend,
+	ChartContext as Context
+};


### PR DESCRIPTION
## Problem
Chart legends were overflowing and overlapping with chart content when space was constrained. LayerChart's built-in legend positioning caused visual issues where legend items would bleed into the chart area or card footer, making charts unreadable in compact layouts. This directly references #2038 

## Solution
Implemented a temporary workaround using a flexible chart context system with external legend positioning until LayerChart addresses their legend overflow issues upstream.
### Temporary Components Added:
- ChartContext - Provides chart configuration to child components as a workaround
- ChartLegend - Auto-generates legend items from chart config (bypassing LayerChart's built-in legend)
- Updated ChartContainer - Works with or without context
### This approach allows us to:
- Immediately resolve legend overflow issues for users
- Maintain clean, type-safe APIs while waiting for upstream fixes
- Easily migrate back to LayerChart's native legend once their positioning is fixed
- Preserve backward compatibility during the transition
### Future Migration Path:
Once LayerChart resolves their legend positioning, we can deprecate `ChartLegend`, reverting to the simpler native `legend={true}` approach. 

## Key Features:
Auto-generation: Legends automatically derive items from chartConfig without manual data passing
Type Safety: Full TypeScript support with proper inference
Flexible Positioning: Legends can be positioned outside chart containers

## Usage Patterns
### Existing usage (still works):
```svelte
<Chart.Container config={chartConfig}>
  <BarChart legend={true} /> <!-- LayerChart's native legend -->
</Chart.Container>
```
### New workaround for overflow issues:
```svelte
<Chart.Context config={chartConfig}>
  <Chart.Container>
    <!-- Chart content -->
  </Chart.Container>
  <Chart.Legend /> <!-- Positioned outside, no overflow -->
</Chart.Context>
```

### Alternative Approaches Considered
- CSS-only fixes - Attempted padding/margin adjustments, but LayerChart's absolute positioning made this unreliable across different chart types and screen sizes.
- Overriding LayerChart styles - Complex CSS overrides conflicted with LayerChart's internal layout calculations and broke responsiveness.