### PR TITLE
fix: chat card font size

### DIFF
--- a/docs/src/lib/components/cards/chat.svelte
+++ b/docs/src/lib/components/cards/chat.svelte
@@ -76,7 +76,7 @@
 			</Avatar.Root>
 			<div class="flex flex-col gap-0.5">
 				<p class="text-sm font-medium leading-none">Sofia Davis</p>
-				<p class="text-muted-foreground text-sm">m@example.com</p>
+				<p class="text-muted-foreground text-xs">m@example.com</p>
 			</div>
 		</div>
 		<Tooltip.Provider delayDuration={0}>


### PR DESCRIPTION
Original [reference](https://github.com/shadcn-ui/ui/blob/84d6c83bad10e995bd648d59403f402ce7728444/apps/v4/components/cards/chat.tsx#L109)
