### PR TITLE
Docs: Updated calendar component description

### DIFF
--- a/docs/content/components/calendar.md
+++ b/docs/content/components/calendar.md
@@ -1,6 +1,6 @@
 ---
 title: Calendar
-description: A calendar component that allows users to select dates.
+description: A date field component that allows users to enter and edit date.
 component: true
 links:
   source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/calendar


### PR DESCRIPTION
Simple fix of description in the Calendar component docs page, where Shadcn Ui had a different term.