### PR TITLE
docs: Fix dark mode icon transition

### DIFF
--- a/docs/src/lib/registry/examples/dark-mode-dropdown-menu.svelte
+++ b/docs/src/lib/registry/examples/dark-mode-dropdown-menu.svelte
@@ -10,10 +10,10 @@
 <DropdownMenu.Root>
 	<DropdownMenu.Trigger class={buttonVariants({ variant: "outline", size: "icon" })}>
 		<SunIcon
-			class="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0"
+			class="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 !transition-all dark:-rotate-90 dark:scale-0"
 		/>
 		<MoonIcon
-			class="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100"
+			class="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 !transition-all dark:rotate-0 dark:scale-100"
 		/>
 		<span class="sr-only">Toggle theme</span>
 	</DropdownMenu.Trigger>

--- a/docs/src/lib/registry/examples/dark-mode-light-switch.svelte
+++ b/docs/src/lib/registry/examples/dark-mode-light-switch.svelte
@@ -8,10 +8,10 @@
 
 <Button onclick={toggleMode} variant="outline" size="icon">
 	<SunIcon
-		class="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0"
+		class="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 !transition-all dark:-rotate-90 dark:scale-0"
 	/>
 	<MoonIcon
-		class="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100"
+		class="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 !transition-all dark:rotate-0 dark:scale-100"
 	/>
 	<span class="sr-only">Toggle theme</span>
 </Button>


### PR DESCRIPTION
The styles have always been here for the nice little animation but for whatever reason the `transition-all` was being reset.
