### PR TITLE
fix: tooltip arrow alignment when side is bottom or left

### DIFF
--- a/docs/src/lib/registry/ui/tooltip/tooltip-content.svelte
+++ b/docs/src/lib/registry/ui/tooltip/tooltip-content.svelte
@@ -34,9 +34,9 @@
 					class={cn(
 						"bg-primary z-50 size-2.5 rotate-45 rounded-[2px]",
 						"data-[side=top]:translate-x-1/2 data-[side=top]:translate-y-[calc(-50%_+_2px)]",
-						"data-[side=bottom]:-translate-y-[calc(-50%_+_1px)] data-[side=bottom]:translate-x-1/2",
+						"data-[side=bottom]:-translate-x-1/2 data-[side=bottom]:-translate-y-[calc(-50%_+_1px)]",
 						"data-[side=right]:translate-x-[calc(50%_+_2px)] data-[side=right]:translate-y-1/2",
-						"data-[side=left]:translate-y-[calc(50%_-_3px)]",
+						"data-[side=left]:-translate-y-[calc(50%_-_3px)]",
 						arrowClasses
 					)}
 					{...props}


### PR DESCRIPTION
Fixes the alignment of tooltip arrows when `side="bottom"` or `side="left"`.

Closes #2165

<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->
