### PR TITLE
docs: handle `header.colSpan` in `<DataTable />` component

### DIFF
--- a/docs/content/components/data-table.md
+++ b/docs/content/components/data-table.md
@@ -189,7 +189,7 @@ Next, we'll create a `<DataTable />` component to render our table.
       {#each table.getHeaderGroups() as headerGroup (headerGroup.id)}
         <Table.Row>
           {#each headerGroup.headers as header (header.id)}
-            <Table.Head>
+            <Table.Head colspan={header.colSpan}>
               {#if !header.isPlaceholder}
                 <FlexRender
                   content={header.column.columnDef.header}


### PR DESCRIPTION
The `<DataTable />` component in the Data Table docs now handles the `<Table.Head>` column span.

(Closes https://github.com/huntabyte/shadcn-svelte/issues/2168)