### PR TITLE
docs: fix navigation menu links to use correct component routes

### DIFF
--- a/docs/src/lib/registry/examples/navigation-menu-demo.svelte
+++ b/docs/src/lib/registry/examples/navigation-menu-demo.svelte
@@ -10,35 +10,35 @@
 	const components: { title: string; href: string; description: string }[] = [
 		{
 			title: "Alert Dialog",
-			href: "/docs/primitives/alert-dialog",
+			href: "/docs/components/alert-dialog",
 			description:
 				"A modal dialog that interrupts the user with important content and expects a response.",
 		},
 		{
 			title: "Hover Card",
-			href: "/docs/primitives/hover-card",
+			href: "/docs/components/hover-card",
 			description: "For sighted users to preview content available behind a link.",
 		},
 		{
 			title: "Progress",
-			href: "/docs/primitives/progress",
+			href: "/docs/components/progress",
 			description:
 				"Displays an indicator showing the completion progress of a task, typically displayed as a progress bar.",
 		},
 		{
 			title: "Scroll-area",
-			href: "/docs/primitives/scroll-area",
+			href: "/docs/components/scroll-area",
 			description: "Visually or semantically separates content.",
 		},
 		{
 			title: "Tabs",
-			href: "/docs/primitives/tabs",
+			href: "/docs/components/tabs",
 			description:
 				"A set of layered sections of content—known as tab panels—that are displayed one at a time.",
 		},
 		{
 			title: "Tooltip",
-			href: "/docs/primitives/tooltip",
+			href: "/docs/components/tooltip",
 			description:
 				"A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.",
 		},
@@ -104,7 +104,7 @@
 						content: "How to install dependencies and structure your app.",
 					})}
 					{@render ListItem({
-						href: "/docs/primitives/typography",
+						href: "/docs/components/typography",
 						title: "Typography",
 						content: "Styles for headings, paragraphs, lists...etc",
 					})}


### PR DESCRIPTION
In the preview of the Navigation Menu several entries were pointing to non-existent or outdated routes. This PR updates those links so that each menu item now navigates to the actual route of its corresponding component.