### PR TITLE
fix: `<Table.Row>` highlight no longer under the row borders

### DIFF
--- a/docs/src/lib/registry/ui/table/table-cell.svelte
+++ b/docs/src/lib/registry/ui/table/table-cell.svelte
@@ -13,7 +13,10 @@
 <td
 	bind:this={ref}
 	data-slot="table-cell"
-	class={cn("whitespace-nowrap p-2 align-middle [&:has([role=checkbox])]:pr-0", className)}
+	class={cn(
+		"whitespace-nowrap bg-clip-padding p-2 align-middle [&:has([role=checkbox])]:pr-0",
+		className
+	)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/docs/src/lib/registry/ui/table/table-head.svelte
+++ b/docs/src/lib/registry/ui/table/table-head.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="table-head"
 	class={cn(
-		"text-foreground h-10 whitespace-nowrap px-2 text-left align-middle font-medium [&:has([role=checkbox])]:pr-0",
+		"text-foreground h-10 whitespace-nowrap bg-clip-padding px-2 text-left align-middle font-medium [&:has([role=checkbox])]:pr-0",
 		className
 	)}
 	{...restProps}

--- a/docs/src/lib/registry/ui/table/table-row.svelte
+++ b/docs/src/lib/registry/ui/table/table-row.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="table-row"
 	class={cn(
-		"hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+		"hover:[&,&>svelte-css-wrapper]:[&>th,td]:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
 		className
 	)}
 	{...restProps}


### PR DESCRIPTION
When hovering over a `<Table.Row>` the highlight would be seen under the row borders.

(Exaggerating border with `[&_tr]:border-b-8`)
Actual:
![Actual](https://github.com/user-attachments/assets/a9a7f222-1316-4570-9956-7f3146aab5f4)

Expected:
![Expected](https://github.com/user-attachments/assets/22a5199b-b125-4396-b6c6-a559d74e8d39)

To fix this, I had to move the highlight from the row to the cells.

The `... :[&,&>svelte-css-wrapper]: ...` selector is to handle the case where you define a CSS variable in a `<Table.Head>` or `<Table.Cell>`, like:
```svelte
<Table.Row>
  <Table.Cell --css-var={someReactiveVar}>
    Row
  </Tabel.Cell>
</Table.Row>
```
which would result in this HTML structure:
```html
<tr>
  <svelte-css-wrapper>
    <td>
      Row
    </td>
  </svelte-css-wrapper>
</tr>
```