### PR TITLE
fix: `<Sidebar.Root>` gap width now same as `<Sidebar.Root>` width

### DIFF
--- a/docs/src/lib/registry/ui/sidebar/sidebar.svelte
+++ b/docs/src/lib/registry/ui/sidebar/sidebar.svelte
@@ -73,7 +73,7 @@
 				"group-data-[collapsible=offcanvas]:w-0",
 				"group-data-[side=right]:rotate-180",
 				variant === "floating" || variant === "inset"
-					? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
+					? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
 					: "group-data-[collapsible=icon]:w-(--sidebar-width-icon)"
 			)}
 		></div>


### PR DESCRIPTION
The `<Sidebar.Root>` gap `<div>` doesn't have the same dimensions as the `<Sidebar.Root>` `<div>` when the sidebar is floating/inset and collapsed into icons.

Code for reference:
![image](https://github.com/user-attachments/assets/7cceb256-ab15-4929-98f2-f73f2b8939b1)


Closes: https://github.com/huntabyte/shadcn-svelte/issues/2169
(Didn't have any feedback, but since it's a small fix, I decided to create a PR)