### PR TITLE
docs: payments data prop

### DIFF
--- a/docs/content/components/data-table.md
+++ b/docs/content/components/data-table.md
@@ -255,7 +255,7 @@ export async function load() {
   let { data } = $props();
 </script>
 
-<DataTable {data} {columns} />
+<DataTable data={data.payments} {columns} />
 ```
 
 </Steps>


### PR DESCRIPTION
Rendered page data prop should be `data={data.payments}` instead of `{data}` because the page data is `{ payments: ...[] }`.

```diff
# routes/payments/+page.svelte
<script lang="ts">
 import DataTable from "./data-table.svelte";
 import { columns } from "./columns.js";
 
 let { data } = $props();
</script>
 
-<DataTable {data} {columns} />
+<DataTable data={data.payments} {columns} />
```