### PR TITLE
fix: Use svelte:element instead of @html

### DIFF
--- a/docs/src/lib/registry/ui/chart/chart-style.svelte
+++ b/docs/src/lib/registry/ui/chart/chart-style.svelte
@@ -29,8 +29,9 @@
 </script>
 
 {#if themeContents}
-	{#key id}
-		<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-		{@html `<style>${themeContents}</style>`}
-	{/key}
+    {#key id}
+        <svelte:element this={'style'}>
+            {themeContents}
+        </svelte:element>
+    {/key}
 {/if}

--- a/docs/src/lib/registry/ui/chart/chart-style.svelte
+++ b/docs/src/lib/registry/ui/chart/chart-style.svelte
@@ -29,9 +29,9 @@
 </script>
 
 {#if themeContents}
-    {#key id}
-        <svelte:element this={'style'}>
-            {themeContents}
-        </svelte:element>
-    {/key}
+	{#key id}
+		<svelte:element this={"style"}>
+			{themeContents}
+		</svelte:element>
+	{/key}
 {/if}


### PR DESCRIPTION
<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->

The `Chart` component was using this old syntax:
```tsx
 {@html `<style>${themeContents}</style>`}
 ```
 making the error `Unknown word themeContents` raise.

I fixed it by using the `<svelte:element this={'style'}>` component instead of the raw `@html`

Discord thread: https://discord.com/channels/1194404141389336576/1393230690245541949