### PR TITLE
docs: added missing dropdown-menu component to installation notice

### DIFF
--- a/docs/content/components/data-table.md
+++ b/docs/content/components/data-table.md
@@ -53,7 +53,7 @@ This guide will show you how to use [TanStack Table](https://tanstack.com/table)
 
 1. Add the `<Table />` component to your project along with the `data-table` helpers. These helpers enable TanStack Table v8 to work with Svelte 5 Snippets, Components, etc.
 
-<PMAddComp name="table data-table" />
+<PMAddComp name="table dropdown-menu data-table" />
 
 2. Add `@tanstack/table-core` as a dependency:
 


### PR DESCRIPTION
well, it's just a tiny fix.

#### Why was that a problem?

Later on this page, the `dropdown-menu` component is used. Not installing it would lead to errors. As `table` and `data-table` are used on this page too, it would be nice to install everything at once.