### PR TITLE
feat(drawer): enable drawer content scroll on overflow

### DIFF
--- a/docs/src/lib/registry/ui/drawer/drawer-content.svelte
+++ b/docs/src/lib/registry/ui/drawer/drawer-content.svelte
@@ -32,6 +32,8 @@
 		<div
 			class="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block"
 		></div>
-		{@render children?.()}
+		<div class="flex-1 overflow-y-auto">
+			{@render children?.()}
+		</div>
 	</DrawerPrimitive.Content>
 </DrawerPrimitive.Portal>


### PR DESCRIPTION
This change enables proper vertical scrolling for drawer components when content exceeds the drawer height, inspired by @huntabyte 's [implementation in the `vaul-svelte` docs](https://stackblitz.com/edit/vaul-svelte-scrollable-with-inputs?file=src%2Froutes%2F%2Bpage.svelte). Previously, drawers with long content could overflow without proper scrolling behavior, making it difficult for users to access all content and resulting in poor mobile UX.

To accomplish this, I wrapped the `{@render children?.()}` in a `<div class="flex-1 overflow-y-auto">` container. The `flex-1` class ensures the content takes up remaining space after the drag handle at the top, while `overflow-y-auto` enables vertical scrolling.