### PR TITLE
docs: Update carousel.md to say `setApi`, not `bind:api`

### DIFF
--- a/docs/content/components/carousel.md
+++ b/docs/content/components/carousel.md
@@ -215,7 +215,7 @@ Use reactive state and the `setApi` callback to get an instance of the carousel 
 
 ## Events
 
-You can listen to events using the api instance from `bind:api`.
+You can listen to events using the api instance from `setApi`.
 
 ```svelte showLineNumbers {2,5,7-13,16}
 <script lang="ts">


### PR DESCRIPTION
Changed:

"You can listen to events using the api instance from `bind:api`."

to:

"You can listen to events using the api instance from `setApi`."
