### PR TITLE
fix:Copy button in charts toolbar

### DIFF
--- a/docs/src/lib/components/chart-toolbar.svelte
+++ b/docs/src/lib/components/chart-toolbar.svelte
@@ -12,7 +12,7 @@
 	import ChartCopyButton from "./chart-copy-button.svelte";
 	import type { HTMLAttributes } from "svelte/elements";
 	import type { HighlightedBlock } from "../../routes/api/block/[block]/+server.js";
-
+	import { browser } from "$app/environment";
 	let {
 		chart,
 		class: className,
@@ -20,6 +20,8 @@
 	}: HTMLAttributes<HTMLDivElement> & { chart: HighlightedBlock } = $props();
 
 	let code = $derived.by(() => {
+		if (!browser) return "";
+
 		const pre = document.createElement("pre");
 		pre.innerHTML = chart.files?.[0]?.highlightedContent ?? "";
 		return pre.innerText;

--- a/docs/src/lib/components/chart-toolbar.svelte
+++ b/docs/src/lib/components/chart-toolbar.svelte
@@ -12,7 +12,6 @@
 	import ChartCopyButton from "./chart-copy-button.svelte";
 	import type { HTMLAttributes } from "svelte/elements";
 	import type { HighlightedBlock } from "../../routes/api/block/[block]/+server.js";
-	import { onMount } from "svelte";
 
 	let {
 		chart,
@@ -20,12 +19,10 @@
 		children,
 	}: HTMLAttributes<HTMLDivElement> & { chart: HighlightedBlock } = $props();
 
-	let code = $state("");
-
-	onMount(() => {
+	let code = $derived.by(() => {
 		const pre = document.createElement("pre");
 		pre.innerHTML = chart.files?.[0]?.highlightedContent ?? "";
-		code = pre.innerText;
+		return pre.innerText;
 	});
 </script>
 

--- a/docs/src/lib/components/chart-toolbar.svelte
+++ b/docs/src/lib/components/chart-toolbar.svelte
@@ -13,18 +13,24 @@
 	import type { HTMLAttributes } from "svelte/elements";
 	import type { HighlightedBlock } from "../../routes/api/block/[block]/+server.js";
 	import { browser } from "$app/environment";
+
 	let {
 		chart,
 		class: className,
 		children,
 	}: HTMLAttributes<HTMLDivElement> & { chart: HighlightedBlock } = $props();
 
-	let code = $derived.by(() => {
-		if (!browser) return "";
+	let code = $state("");
+
+	$effect(() => {
+		if (!browser || !chart.files?.[0]?.highlightedContent) {
+			code = "";
+			return;
+		}
 
 		const pre = document.createElement("pre");
-		pre.innerHTML = chart.files?.[0]?.highlightedContent ?? "";
-		return pre.innerText;
+		pre.innerHTML = chart.files[0].highlightedContent;
+		code = pre.innerText ?? "";
 	});
 </script>
 


### PR DESCRIPTION
<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->

As pointed out in https://github.com/huntabyte/shadcn-svelte/discussions/2244#discussioncomment-13935080, the copy button was not working as expected. 

The copy button only copies the code of the charts that we first land on. By default the charts page lands on `/charts/area`, so when a user navigates to `/charts/bar` and tries to copy any variant of the bar chart, it will still copy the code for area charts. 

I have fixed  it by changing the onMount directive to effect to track the change in chart data and update the code state accordingly.

closes #2258 