### PR TITLE
docs: fix resizable handle not clickable in block viewer

### DIFF
--- a/docs/src/lib/components/block-viewer-view.svelte
+++ b/docs/src/lib/components/block-viewer-view.svelte
@@ -26,7 +26,7 @@
 				<BlockViewerIframe />
 			</Resizable.Pane>
 			<Resizable.Handle
-				class="after:bg-border relative hidden w-3 bg-transparent p-0 after:absolute after:right-0 after:top-1/2 after:h-8 after:w-[6px] after:-translate-y-1/2 after:translate-x-[-1px] after:rounded-full after:transition-all after:hover:h-10 md:block"
+				class="after:bg-border relative z-20 hidden w-3 bg-transparent p-0 after:absolute after:right-0 after:top-1/2 after:h-8 after:w-[6px] after:-translate-y-1/2 after:translate-x-[-1px] after:rounded-full after:transition-all after:hover:h-10 md:block"
 			/>
 			<Resizable.Pane defaultSize={0} minSize={0} />
 		</Resizable.PaneGroup>


### PR DESCRIPTION
### Fixed resizable handle becoming unclickable when dragged inward in docs block viewer

When the resizable handle was dragged to the left, it became unclickable due to being covered by a background element.

Added `z-20` to the resizable handle to keep it above other elements.
