### PR TITLE
fix: Reorder ALIASES const so that replacements run in a more sensical order

### DIFF
--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -1,7 +1,7 @@
 export const SITE_BASE_URL = "https://shadcn-svelte.com";
 export const TW3_SITE_BASE_URL = "https://tw3.shadcn-svelte.com";
 
-export const ALIASES = ["components", "ui", "hooks", "lib", "utils"] as const;
+export const ALIASES = ["components", "ui", "hooks", "utils", "lib"] as const;
 
 export const ALIAS_DEFAULTS = ALIASES.reduce(
 	(acc, a) => {


### PR DESCRIPTION
Since `lib` is typically a parent to all of the other aliases, it makes most sense to run it last -- otherwise the `lib` alias will clobber the `utils` alias and transform things to `$LIB$/utils.js` during registry build instead of transforming them to `$UTILS$`

<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->
