### PR TITLE
docs: Data-table return to render content for sorted list

### DIFF
--- a/docs/content/components/data-table.md
+++ b/docs/content/components/data-table.md
@@ -594,7 +594,7 @@ export const columns: ColumnDef<Payment>[] = [
   {
     accessorKey: "email",
     header: ({ column }) =>
-      renderComponent(DataTableEmailButton, {
+      return renderComponent(DataTableEmailButton, {
         onclick: column.getToggleSortingHandler(),
       }),
   },


### PR DESCRIPTION
Added required return statement to render a sorted list header. Otherwise the header will not display.
