### PR TITLE
chore: format tailwind classes correctly

### DIFF
--- a/registry-template/.prettierrc
+++ b/registry-template/.prettierrc
@@ -1,5 +1,6 @@
 {
 	"useTabs": true,
+	"tabWidth": 4,
 	"singleQuote": false,
 	"trailingComma": "es5",
 	"printWidth": 100,
@@ -11,5 +12,7 @@
 				"parser": "svelte"
 			}
 		}
-	]
+	],
+	"tailwindFunctions": ["clsx", "cn", "tv"],
+	"tailwindStylesheet": "src/app.css"
 }

--- a/registry-template/src/lib/registry/blocks/example-form/example-form.svelte
+++ b/registry-template/src/lib/registry/blocks/example-form/example-form.svelte
@@ -77,7 +77,7 @@
 					defaultValue={formState.defaultValues.name}
 				/>
 				{#if formState.errors.name}
-					<p id="error-name" class="text-destructive text-sm">
+					<p id="error-name" class="text-sm text-destructive">
 						{formState.errors.name}
 					</p>
 				{/if}
@@ -97,7 +97,7 @@
 					defaultValue={formState.defaultValues.email}
 				/>
 				{#if formState.errors.email}
-					<p id="error-email" class="text-destructive text-sm">
+					<p id="error-email" class="text-sm text-destructive">
 						{formState.errors.email}
 					</p>
 				{/if}
@@ -117,7 +117,7 @@
 					defaultValue={formState.defaultValues.message}
 				/>
 				{#if formState.errors.message}
-					<p id="error-message" class="text-destructive text-sm">
+					<p id="error-message" class="text-sm text-destructive">
 						{formState.errors.message}
 					</p>
 				{/if}

--- a/registry-template/src/lib/registry/blocks/example-with-css/example-card.svelte
+++ b/registry-template/src/lib/registry/blocks/example-with-css/example-card.svelte
@@ -13,7 +13,12 @@
 			</div>
 			<div class="form-group">
 				<label for="field-password">Password</label>
-				<input id="field-password" type="password" placeholder="Enter your password" required />
+				<input
+					id="field-password"
+					type="password"
+					placeholder="Enter your password"
+					required
+				/>
 			</div>
 			<div class="form-actions">
 				<button type="submit" class="login-button"> Sign In </button>

--- a/registry-template/src/lib/registry/ui/button/button.svelte
+++ b/registry-template/src/lib/registry/ui/button/button.svelte
@@ -2,21 +2,21 @@
 	import { tv, type VariantProps } from "tailwind-variants";
 
 	export const buttonVariants = tv({
-		base: "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+		base: "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 		variants: {
 			variant: {
 				default: "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
 				destructive:
-					"bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+					"bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
 				outline:
-					"border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+					"border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
 				secondary: "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
 				ghost: "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
 				link: "text-primary underline-offset-4 hover:underline",
 			},
 			size: {
 				default: "h-9 px-4 py-2 has-[>svg]:px-3",
-				sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+				sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
 				lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
 				icon: "size-9",
 			},

--- a/registry-template/src/lib/registry/ui/card/card-description.svelte
+++ b/registry-template/src/lib/registry/ui/card/card-description.svelte
@@ -2,12 +2,16 @@
 	import { cn } from "$lib/utils.js";
 	import type { HTMLAttributes } from "svelte/elements";
 
-	let { class: className, children, ...restProps }: HTMLAttributes<HTMLParagraphElement> = $props();
+	let {
+		class: className,
+		children,
+		...restProps
+	}: HTMLAttributes<HTMLParagraphElement> = $props();
 </script>
 
 <div
 	data-slot="card-description"
-	class={cn("text-muted-foreground text-sm", className)}
+	class={cn("text-sm text-muted-foreground", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/registry-template/src/lib/registry/ui/card/card.svelte
+++ b/registry-template/src/lib/registry/ui/card/card.svelte
@@ -8,7 +8,7 @@
 <div
 	data-slot="card"
 	class={cn(
-		"bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+		"flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm",
 		className
 	)}
 	{...restProps}

--- a/registry-template/src/lib/registry/ui/input/input.svelte
+++ b/registry-template/src/lib/registry/ui/input/input.svelte
@@ -9,9 +9,9 @@
 	bind:value
 	data-slot="input"
 	class={cn(
-		"file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-		"focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-		"aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+		"flex h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
+		"focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+		"aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
 		className
 	)}
 	{...restProps}

--- a/registry-template/src/lib/registry/ui/textarea/input.svelte
+++ b/registry-template/src/lib/registry/ui/textarea/input.svelte
@@ -13,7 +13,7 @@
 	bind:value
 	data-slot="input"
 	class={cn(
-		"border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+		"flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
 		className
 	)}
 	{...restProps}

--- a/registry-template/src/routes/+page.svelte
+++ b/registry-template/src/routes/+page.svelte
@@ -18,7 +18,9 @@
 	<main class="flex flex-1 flex-col gap-8">
 		<div class="relative flex min-h-[450px] flex-col gap-4 rounded-lg border p-4">
 			<div class="flex items-center justify-between">
-				<h2 class="text-muted-foreground text-sm sm:pl-3">A simple hello world component</h2>
+				<h2 class="text-sm text-muted-foreground sm:pl-3">
+					A simple hello world component
+				</h2>
 			</div>
 			<div class="relative flex min-h-[400px] items-center justify-center">
 				<HelloWorld />
@@ -27,7 +29,9 @@
 
 		<div class="relative flex min-h-[450px] flex-col gap-4 rounded-lg border p-4">
 			<div class="flex items-center justify-between">
-				<h2 class="text-muted-foreground text-sm sm:pl-3">A contact form with Zod validation.</h2>
+				<h2 class="text-sm text-muted-foreground sm:pl-3">
+					A contact form with Zod validation.
+				</h2>
 			</div>
 			<div class="relative flex min-h-[500px] items-center justify-center">
 				<ExampleForm />
@@ -36,7 +40,7 @@
 
 		<div class="relative flex min-h-[450px] flex-col gap-4 rounded-lg border p-4">
 			<div class="flex items-center justify-between">
-				<h2 class="text-muted-foreground text-sm sm:pl-3">
+				<h2 class="text-sm text-muted-foreground sm:pl-3">
 					A complex component showing hooks, libs and components.
 				</h2>
 			</div>
@@ -47,7 +51,7 @@
 
 		<div class="relative flex min-h-[450px] flex-col gap-4 rounded-lg border p-4">
 			<div class="flex items-center justify-between">
-				<h2 class="text-muted-foreground text-sm sm:pl-3">A login form with a CSS file.</h2>
+				<h2 class="text-sm text-muted-foreground sm:pl-3">A login form with a CSS file.</h2>
 			</div>
 			<div class="relative flex min-h-[400px] items-center justify-center">
 				<ExampleCard />


### PR DESCRIPTION
The tailwind classes in the `registry-template/` directory were not formatted correctly.