### PR TITLE
fix: make sidebar file tree under group scrollable

### DIFF
--- a/docs/src/lib/components/component-code-viewer/component-code-viewer-file-tree.svelte
+++ b/docs/src/lib/components/component-code-viewer/component-code-viewer-file-tree.svelte
@@ -6,12 +6,12 @@
 	const ctx = ComponentCodeViewerContext.get();
 </script>
 
-<Sidebar.Provider class="flex !min-h-full select-none flex-col">
-	<Sidebar.Root collapsible="none" class="w-full flex-1">
+<Sidebar.Provider class="flex h-full !min-h-0 select-none flex-col">
+	<Sidebar.Root collapsible="none" class="h-full w-full flex-1">
 		<Sidebar.GroupLabel class="h-12 rounded-none border-b px-4 text-sm">
 			Files
 		</Sidebar.GroupLabel>
-		<Sidebar.Group class="p-0">
+		<Sidebar.Group class="overflow-y-auto p-0">
 			<Sidebar.GroupContent>
 				<Sidebar.Menu class="translate-x-0 gap-1.5">
 					{#if ctx.tree}


### PR DESCRIPTION
<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->

Closes #2293 

Fix scrollable sidebar group where files in code viewer tree are located under.
