### PR TITLE
fix: new-components-01 by adding Tooltip.Provider

### DIFF
--- a/docs/registry.json
+++ b/docs/registry.json
@@ -3240,6 +3240,7 @@
 			"registryDependencies": [
 				"checkbox",
 				"field",
+				"tooltip",
 				"button",
 				"button-group",
 				"input",
@@ -3248,7 +3249,6 @@
 				"switch",
 				"dropdown-menu",
 				"input-group",
-				"tooltip",
 				"popover",
 				"separator",
 				"textarea",

--- a/docs/src/lib/registry/blocks/new-components-01/+page.svelte
+++ b/docs/src/lib/registry/blocks/new-components-01/+page.svelte
@@ -15,54 +15,57 @@
 	import SpinnerEmpty from "./components/spinner-empty.svelte";
 	import { Checkbox } from "$lib/registry/ui/checkbox/index.js";
 	import * as Field from "$lib/registry/ui/field/index.js";
+	import * as Tooltip from "$lib/registry/ui/tooltip/index.js";
 </script>
 
-<div class="flex flex-col justify-center">
-	<div
-		class="theme-container mx-auto grid max-w-[2200px] gap-8 p-6 md:grid-cols-2 md:p-8 lg:grid-cols-3 xl:grid-cols-4"
-	>
-		<div class="*:[div]:w-full *:[div]:max-w-full flex flex-col gap-6">
-			<FieldDemo />
-		</div>
-		<div class="*:[div]:w-full *:[div]:max-w-full flex flex-col gap-6">
-			<div class="*:[div]:border">
-				<EmptyAvatarGroup />
-			</div>
-			<ButtonGroupInputGroup />
-			<FieldSlider />
-			<InputGroupDemo />
-		</div>
-		<div class="*:[div]:w-full *:[div]:max-w-full flex flex-col gap-6">
-			<ItemDemo />
-			<Field.Separator>Appearance Settings</Field.Separator>
-			<AppearanceSettings />
-		</div>
+<Tooltip.Provider>
+	<div class="flex flex-col justify-center">
 		<div
-			class="*:[div]:w-full *:[div]:max-w-full order-first flex flex-col gap-6 min-[1400px]:order-last"
+			class="theme-container mx-auto grid max-w-[2200px] gap-8 p-6 md:grid-cols-2 md:p-8 lg:grid-cols-3 xl:grid-cols-4"
 		>
-			<div class="flex gap-2">
-				<SpinnerBadge />
+			<div class="*:[div]:w-full *:[div]:max-w-full flex flex-col gap-6">
+				<FieldDemo />
 			</div>
-			<InputGroupButtonExample />
-			<NotionPromptForm />
-			<ButtonGroupDemo />
-			<div class="flex gap-6">
-				<Field.Label for="checkbox-demo">
-					<Field.Field orientation="horizontal">
-						<Checkbox id="checkbox-demo" checked />
-						<Field.Label for="checkbox-demo" class="line-clamp-1">
-							I agree to the terms and conditions
-						</Field.Label>
-					</Field.Field>
-				</Field.Label>
+			<div class="*:[div]:w-full *:[div]:max-w-full flex flex-col gap-6">
+				<div class="*:[div]:border">
+					<EmptyAvatarGroup />
+				</div>
+				<ButtonGroupInputGroup />
+				<FieldSlider />
+				<InputGroupDemo />
 			</div>
-			<div class="flex gap-4">
-				<ButtonGroupNested />
-				<ButtonGroupPopover />
+			<div class="*:[div]:w-full *:[div]:max-w-full flex flex-col gap-6">
+				<ItemDemo />
+				<Field.Separator>Appearance Settings</Field.Separator>
+				<AppearanceSettings />
 			</div>
-			<div class="*:[div]:border">
-				<SpinnerEmpty />
+			<div
+				class="*:[div]:w-full *:[div]:max-w-full order-first flex flex-col gap-6 min-[1400px]:order-last"
+			>
+				<div class="flex gap-2">
+					<SpinnerBadge />
+				</div>
+				<InputGroupButtonExample />
+				<NotionPromptForm />
+				<ButtonGroupDemo />
+				<div class="flex gap-6">
+					<Field.Label for="checkbox-demo">
+						<Field.Field orientation="horizontal">
+							<Checkbox id="checkbox-demo" checked />
+							<Field.Label for="checkbox-demo" class="line-clamp-1">
+								I agree to the terms and conditions
+							</Field.Label>
+						</Field.Field>
+					</Field.Label>
+				</div>
+				<div class="flex gap-4">
+					<ButtonGroupNested />
+					<ButtonGroupPopover />
+				</div>
+				<div class="*:[div]:border">
+					<SpinnerEmpty />
+				</div>
 			</div>
 		</div>
 	</div>
-</div>
+</Tooltip.Provider>


### PR DESCRIPTION
<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->

Fixes the broken new-components-01 block by adding the missing `<Tooltip.Provider>` to `+page.svelte`. 

Checkout the preview build to see the working block. https://icalvin102-fix-new-component.shadcn-svelte.pages.dev/view/new-components-01

Fixes #2322


