### PR TITLE
docs: update empty component docs usage example.

### DIFF
--- a/docs/content/components/empty.md
+++ b/docs/content/components/empty.md
@@ -44,19 +44,22 @@ Copy and paste the component source files linked at the top of this page into yo
 
 ```svelte
 <script lang="ts">
-  import * as InputGroup from "$lib/components/ui/input-group/index.js";
-  import SearchIcon from "@lucide/svelte/icons/search";
+  import * as Empty from "$lib/components/ui/empty/index.js";
+  import FolderCodeIcon from "@tabler/icons-svelte/icons/folder-code";
 </script>
 
-<InputGroup.Root>
-  <InputGroup.Input placeholder="Search..." />
-  <InputGroup.Addon>
-    <SearchIcon />
-  </InputGroup.Addon>
-  <InputGroup.Addon align="inline-end">
-    <InputGroup.Button>Search</InputGroup.Button>
-  </InputGroup.Addon>
-</InputGroup.Root>
+<Empty.Root>
+  <Empty.Header>
+    <Empty.Media variant="icon">
+      <FolderCodeIcon />
+    </Empty.Media>
+    <Empty.Title>No data</Empty.Title>
+    <Empty.Description>No data found</Empty.Description>
+  </Empty.Header>
+  <Empty.Content>
+    <Button>Add data</Button>
+  </Empty.Content>
+</Empty.Root>
 ```
 
 ## Examples


### PR DESCRIPTION
Updates the correct usage example in the [new Empty ](https://www.shadcn-svelte.com/docs/components/empty#usage)component docs.

Closes: #2324

Edit: updated commit message.