### PR TITLE
fix: add bindable value prop to InputGroup.Input component

### DIFF
--- a/docs/src/lib/registry/ui/input-group/input-group-input.svelte
+++ b/docs/src/lib/registry/ui/input-group/input-group-input.svelte
@@ -3,7 +3,11 @@
 	import type { ComponentProps } from "svelte";
 	import { Input } from "$lib/registry/ui/input/index.js";
 
-	let { class: className, ...props }: ComponentProps<typeof Input> = $props();
+	let {
+		value = $bindable(),
+		class: className,
+		...props
+	}: ComponentProps<typeof Input> = $props();
 </script>
 
 <Input
@@ -12,5 +16,6 @@
 		"flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0 dark:bg-transparent",
 		className
 	)}
+	bind:value
 	{...props}
 />


### PR DESCRIPTION
## Description

Fixes the `InputGroup.Input` component to support two-way binding with `bind:value`. #2331 

## Problem

The component wasn't usable in real-world scenarios because it didn't support `bind:value`. Attempting to bind the value resulted in this error: 

>  Cannot use 'bind:' with this property. It is declared as non-bindable inside the component. To mark a property as bindable: 'let { value = $bindable() } = $props()'

## Solution

- Added `value = $bindable()` to the component's props declaration
- Added `bind:value` to the underlying `Input` component to properly bind the value
