### PR TITLE
feat: Update command.svelte to expose bits-ui imperative API

### DIFF
--- a/docs/src/lib/registry/ui/command/command.svelte
+++ b/docs/src/lib/registry/ui/command/command.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-	import { cn } from '$lib/utils.js';
-	import { Command as CommandPrimitive } from 'bits-ui';
+	import { cn } from "$lib/utils.js";
+	import { Command as CommandPrimitive } from "bits-ui";
 
 	export type CommandRootApi = CommandPrimitive.Root;
 
 	let {
 		api = $bindable(null),
 		ref = $bindable(null),
-		value = $bindable(''),
+		value = $bindable(""),
 		class: className,
 		...restProps
 	}: CommandPrimitive.RootProps & {
@@ -21,7 +21,7 @@
 	bind:ref
 	data-slot="command"
 	class={cn(
-		'bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md',
+		"bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
 		className
 	)}
 	{...restProps}


### PR DESCRIPTION
Exposed the imperative API of command components so that users can take advantage of it.

I was implementing a text editor and needed to do something like: `commandRef.ref?.updateSelectedByItem(1);` but I quickly discovered that the `ref` here is just a node of the DOM and not the imperative API. I hope this helps others too.

Now I use: `commandRef.api?.updateSelectedByItem(1);`