### PR TITLE
fix: Remove left margin on sidebar-inset when variant=inset, state=collapsed and collapsible=icon

### DIFF
--- a/docs/src/lib/registry/ui/sidebar/sidebar-inset.svelte
+++ b/docs/src/lib/registry/ui/sidebar/sidebar-inset.svelte
@@ -15,7 +15,7 @@
 	data-slot="sidebar-inset"
 	class={cn(
 		"bg-background relative flex w-full flex-1 flex-col",
-		"md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm",
+		"md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 md:peer-data-[variant=inset]:peer-data-[state=collapsed]:peer-data-[collapsible=icon]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm",
 		className
 	)}
 	{...restProps}


### PR DESCRIPTION
**Problem**  
When `variant="inset"`, `state="collapsed"`, and `collapsible="icon"`, the sidebar becomes misaligned due to the inset's left margin.

**Solution**  
Added the following Tailwind utility to remove the margin in this specific state:
md:peer-data-[variant=inset]:peer-data-[state=collapsed]:peer-data-[collapsible=icon]:ml-0

**Result**  
This ensures the sidebar aligns correctly in this specific situation.

**Testing**  
1. Set `variant="inset"` and `collapsible="icon"` on the sidebar.  
2. Collapse it.  
3. Sidebar now remains properly aligned.