### PR TITLE
fix: add bindable ref to input-group

### DIFF
--- a/docs/src/lib/registry/ui/input-group/input-group.svelte
+++ b/docs/src/lib/registry/ui/input-group/input-group.svelte
@@ -11,6 +11,7 @@
 </script>
 
 <div
+	bind:this={ref}
 	data-slot="input-group"
 	role="group"
 	class={cn(


### PR DESCRIPTION
Hey, I've added a "ref" binding to the newly added InputGroup, in a similar way like we bind a ref in Input