### PR TITLE
feat: add viewportRef for the ScrollArea.Viewport

### DIFF
--- a/docs/src/lib/registry/ui/scroll-area/scroll-area.svelte
+++ b/docs/src/lib/registry/ui/scroll-area/scroll-area.svelte
@@ -16,7 +16,7 @@
 		orientation?: "vertical" | "horizontal" | "both" | undefined;
 		scrollbarXClasses?: string | undefined;
 		scrollbarYClasses?: string | undefined;
-		viewportRef?: HTMLElement | null | undefined;
+		viewportRef?: HTMLElement | null;
 	} = $props();
 </script>
 


### PR DESCRIPTION
Hi, I've added a ref prop for the ScrollArea.Viewport.
It's raised in this issue https://github.com/huntabyte/shadcn-svelte/issues/2289

Closes #2289 