### PR TITLE
fix: Improve error message when `svelte-kit` CLI cannot be found

### DIFF
--- a/.changeset/polite-nails-cut.md
+++ b/.changeset/polite-nails-cut.md
@@ -2,4 +2,4 @@
 "shadcn-svelte": patch
 ---
 
-fix: Improve error message when `svelte-kit` CLI cannot be found
+fix: improve error message when `svelte-kit` CLI cannot be found


### PR DESCRIPTION
Noticed this while trying to init a project without installing dependencies. It gives a really confusing error:

```
┌   shadcn-svelte  v1.0.8
│
└  Error: Process exited with non-zero status (254)
    at R4._waitForOutput (file:///Users/ieedan/Documents/github/shadcn-svelte/packages/cli/dist/index.js:27490:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async syncSvelteKit (file:///Users/ieedan/Documents/github/shadcn-svelte/packages/cli/dist/index.js:27841:5)
    at async promptForConfig (file:///Users/ieedan/Documents/github/shadcn-svelte/packages/cli/dist/index.js:69880:3)
    at async Command.<anonymous> (file:///Users/ieedan/Documents/github/shadcn-svelte/packages/cli/dist/index.js:69854:21)
```

Now when we get a `254` when attempting to sync we will detect it and give a much nicer error:

```
┌   shadcn-svelte  v1.0.8
│
└  [CLI Error]: Cannot find svelte-kit CLI
```

