### PR TITLE
docs: Update formsnap example to work with the `zod4` adapter

### DIFF
--- a/docs/content/components/form.md
+++ b/docs/content/components/form.md
@@ -120,13 +120,13 @@ For this example, we'll be passing the `form` returned from the load function as
     type Infer,
     superForm,
   } from "sveltekit-superforms";
-  import { zodClient } from "sveltekit-superforms/adapters";
+  import { zod4Client } from "sveltekit-superforms/adapters";
 
   let { data }: { data: { form: SuperValidated<Infer<FormSchema>> } } =
     $props();
 
   const form = superForm(data.form, {
-    validators: zodClient(formSchema),
+    validators: zod4Client(formSchema),
   });
 
   const { form: formData, enhance } = form;


### PR DESCRIPTION
Copy and pasting the example form into a new project does not work anymore because zod defaults to `zod/v4`, but the `zod` export from the superforms adapter is for `zod/v3`. Importing `zod4` from the superforms adapters fixes this.