### PR TITLE
docs: put back app.css import in sidebar docs

### DIFF
--- a/docs/content/components/sidebar.md
+++ b/docs/content/components/sidebar.md
@@ -137,6 +137,7 @@ A `Sidebar` component is composed of the following parts:
 
 ```svelte showLineNumbers title="src/routes/+layout.svelte"
 <script lang="ts">
+  import '../app.css';
   import * as Sidebar from "$lib/components/ui/sidebar/index.js";
   import AppSidebar from "$lib/components/app-sidebar.svelte";
 


### PR DESCRIPTION
it took me like 30 min to figure out why my page isn't styled after coping side from the docs.

finally I noticed the app.css import was missing.

I think it should be there
