### PR TITLE
docs: enable year and month dropdowns on date-picker example

### DIFF
--- a/docs/content/components/date-picker.md
+++ b/docs/content/components/date-picker.md
@@ -61,7 +61,7 @@ See installations instructions for the [Popover](/docs/components/popover#instal
     {/snippet}
   </Popover.Trigger>
   <Popover.Content class="w-auto p-0">
-    <Calendar bind:value type="single" initialFocus />
+    <Calendar bind:value type="single" initialFocus captionLayout="dropdown" />
   </Popover.Content>
 </Popover.Root>
 ```

--- a/docs/registry.json
+++ b/docs/registry.json
@@ -705,6 +705,10 @@
 			"files": [
 				{
 					"type": "registry:file",
+					"path": "src/lib/registry/ui/dropdown-menu/dropdown-menu-checkbox-group.svelte"
+				},
+				{
+					"type": "registry:file",
 					"path": "src/lib/registry/ui/dropdown-menu/dropdown-menu-checkbox-item.svelte"
 				},
 				{

--- a/docs/src/lib/registry/examples/date-picker-demo.svelte
+++ b/docs/src/lib/registry/examples/date-picker-demo.svelte
@@ -28,6 +28,6 @@
 		{value ? df.format(value.toDate(getLocalTimeZone())) : "Pick a date"}
 	</Popover.Trigger>
 	<Popover.Content bind:ref={contentRef} class="w-auto p-0">
-		<Calendar type="single" bind:value />
+		<Calendar type="single" bind:value captionLayout="dropdown" />
 	</Popover.Content>
 </Popover.Root>

--- a/docs/src/lib/registry/examples/date-picker-form.svelte
+++ b/docs/src/lib/registry/examples/date-picker-form.svelte
@@ -70,6 +70,7 @@
 							type="single"
 							value={value as DateValue}
 							bind:placeholder
+							captionLayout="dropdown"
 							minValue={new CalendarDate(1900, 1, 1)}
 							maxValue={today(getLocalTimeZone())}
 							calendarLabel="Date of birth"


### PR DESCRIPTION
I was reading the date-picker examples and found none of the calendars included year/month dropdowns. The current examples create UX problems when picking a date years away as the user has to click next many many times. I've changed the <Calendar /> props to add them in.

Old example:
<img width="359" height="403" alt="image" src="https://github.com/user-attachments/assets/316a3729-5e50-410b-8bff-117f42d42acf" />

New example:
<img width="300" height="408" alt="image" src="https://github.com/user-attachments/assets/c84a0edc-6b1b-4d76-b5c8-e0aeb2675b3d" />

This now looks similar to the example at https://ui.shadcn.com/docs/components/date-picker:
<img width="489" height="438" alt="image" src="https://github.com/user-attachments/assets/147f88cc-213e-4c34-bc77-462ed7af2d6c" />

