### PR TITLE
fix: do not handle Ctrl+C if command dialog is closed

### DIFF
--- a/docs/src/lib/components/command-menu/command-menu.svelte
+++ b/docs/src/lib/components/command-menu/command-menu.svelte
@@ -89,7 +89,7 @@
 			open = !open;
 		}
 
-		if (e.key === "c" && (e.metaKey || e.ctrlKey)) {
+		if (open && e.key === "c" && (e.metaKey || e.ctrlKey)) {
 			runCommand(() => {
 				if (selectedType === "color") {
 					clipboard.copy(copyPayload);


### PR DESCRIPTION
Fixes #2388 – an issue where Ctrl+C breaks after using the command menu

[command-menu.svelte](https://github.com/huntabyte/shadcn-svelte/blob/36c787d4ff3f67af39513027805bb111f95f0ee9/docs/src/lib/components/command-menu/command-menu.svelte) registers a `keydown` [handler](https://github.com/huntabyte/shadcn-svelte/blob/36c787d4ff3f67af39513027805bb111f95f0ee9/docs/src/lib/components/command-menu/command-menu.svelte#L77) that captures Ctrl+C even after command dialog is closed.
 This PR ensures Ctrl+C is only handled when command dialog is open.

<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->
