### PR TITLE
fix: fix checkbox padding in tables in rtl

### DIFF
--- a/docs/src/lib/registry/ui/table/table-cell.svelte
+++ b/docs/src/lib/registry/ui/table/table-cell.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="table-cell"
 	class={cn(
-		"whitespace-nowrap bg-clip-padding p-2 align-middle [&:has([role=checkbox])]:pr-0",
+		"whitespace-nowrap bg-clip-padding p-2 align-middle [&:has([role=checkbox])]:pe-0",
 		className
 	)}
 	{...restProps}

--- a/docs/src/lib/registry/ui/table/table-head.svelte
+++ b/docs/src/lib/registry/ui/table/table-head.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="table-head"
 	class={cn(
-		"text-foreground h-10 whitespace-nowrap bg-clip-padding px-2 text-left align-middle font-medium [&:has([role=checkbox])]:pr-0",
+		"text-foreground h-10 whitespace-nowrap bg-clip-padding px-2 text-left align-middle font-medium [&:has([role=checkbox])]:pe-0",
 		className
 	)}
 	{...restProps}


### PR DESCRIPTION
replaces `pr-0` with `pe-0` for checkboxes in tables, fixing odd padding when in rtl layout direction