### PR TITLE
fix: make InputGroup direction-agnostic

### DIFF
--- a/docs/src/lib/registry/ui/input-group/input-group-addon.svelte
+++ b/docs/src/lib/registry/ui/input-group/input-group-addon.svelte
@@ -5,9 +5,9 @@
 		variants: {
 			align: {
 				"inline-start":
-					"order-first pl-3 has-[>button]:ml-[-0.45rem] has-[>kbd]:ml-[-0.35rem]",
+					"order-first ps-3 has-[>button]:ms-[-0.45rem] has-[>kbd]:ms-[-0.35rem]",
 				"inline-end":
-					"order-last pr-3 has-[>button]:mr-[-0.45rem] has-[>kbd]:mr-[-0.35rem]",
+					"order-last pe-3 has-[>button]:me-[-0.45rem] has-[>kbd]:me-[-0.35rem]",
 				"block-start":
 					"[.border-b]:pb-3 order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-2.5",
 				"block-end":

--- a/docs/src/lib/registry/ui/input-group/input-group.svelte
+++ b/docs/src/lib/registry/ui/input-group/input-group.svelte
@@ -19,8 +19,8 @@
 		"h-9 has-[>textarea]:h-auto",
 
 		// Variants based on alignment.
-		"has-[>[data-align=inline-start]]:[&>input]:pl-2",
-		"has-[>[data-align=inline-end]]:[&>input]:pr-2",
+		"has-[>[data-align=inline-start]]:[&>input]:ps-2",
+		"has-[>[data-align=inline-end]]:[&>input]:pe-2",
 		"has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3",
 		"has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3",
 


### PR DESCRIPTION
another rtl bug i just found, this time for `InputGroup`.

> sidenote: would an RTL toggle on the official samples help catch these types of issues?