### PR TITLE
docs: fix broken link to MIT license in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This project is supported by the following beautiful people/organizations:
 
 <!-- automd:contributors license=MIT author="huntabyte" -->
 
-Published under the [MIT](https://github.com/huntabyte/shadcn-svelte/blob/main/LICENSE) license.
+Published under the [MIT](https://github.com/huntabyte/shadcn-svelte/blob/main/LICENSE.md) license.
 Built by [@huntabyte](https://github.com/huntabyte), [CokaKoala](https://github.com/adriangonz97),and [community](https://github.com/huntabyte/shadcn-svelte/graphs/contributors) 💛
 <br><br>
 <a href="https://github.com/huntabyte/shadcn-svelte/graphs/contributors">


### PR DESCRIPTION
The link to the MIT license in README.md was pointing to the non-existing [LICENSE](https://github.com/huntabyte/shadcn-svelte/blob/main/LICENSE) instead of [LICENSE.md](https://github.com/huntabyte/shadcn-svelte/blob/main/LICENSE.md).
