### PR TITLE
docs(select): add example for constraining dropdown width

### DIFF
--- a/docs/content/components/select.md
+++ b/docs/content/components/select.md
@@ -77,20 +77,12 @@ Copy and paste the component source files linked at the top of this page into yo
 
 </ComponentPreview>
 
----
-
-### Constraining Dropdown Width
+### Constrained Width
 
 By default, the Select dropdown can expand wider than the trigger when options contain long text. To constrain the dropdown to match the trigger width (with content wrapping to multiple lines), add `max-w-min` to `Select.Content`:
 
-```svelte
-<Select.Root type="single">
-  <Select.Trigger class="w-[180px]">Select a model</Select.Trigger>
-  <Select.Content class="max-w-min">
-    <Select.Item value="v3">whisper-large-v3</Select.Item>
-    <Select.Item value="v3-turbo">
-      whisper-large-v3-turbo - Fast multilingual model with good accuracy
-    </Select.Item>
-  </Select.Content>
-</Select.Root>
-```
+<ComponentPreview name="select-constrain-width">
+
+<div></div>
+
+</ComponentPreview>

--- a/docs/src/lib/registry/examples/select-constrain-width.svelte
+++ b/docs/src/lib/registry/examples/select-constrain-width.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import * as Select from "$lib/registry/ui/select/index.js";
+
+	const models = [
+		{
+			value: "gpt-4o",
+			name: "GPT-4o",
+			description:
+				"Most capable model for complex tasks. Best for nuanced understanding and creative content.",
+		},
+		{
+			value: "gpt-4o-mini",
+			name: "GPT-4o Mini",
+			description:
+				"Fast and cost-effective for straightforward tasks. Good balance of speed and quality.",
+		},
+	];
+
+	let value = $state("");
+
+	const triggerContent = $derived(
+		models.find((m) => m.value === value)?.name ?? "Select a model"
+	);
+</script>
+
+<Select.Root type="single" bind:value>
+	<Select.Trigger class="w-[300px]">
+		{triggerContent}
+	</Select.Trigger>
+	<Select.Content class="max-w-min">
+		{#each models as model (model.value)}
+			<Select.Item value={model.value} label={model.name}>
+				<div class="flex flex-col gap-1">
+					<span class="font-medium">{model.name}</span>
+					<span class="text-muted-foreground text-sm">
+						{model.description}
+					</span>
+				</div>
+			</Select.Item>
+		{/each}
+	</Select.Content>
+</Select.Root>


### PR DESCRIPTION
This adds documentation for constraining Select dropdown width using `max-w-min`.

When Select options contain long descriptive text, the dropdown expands beyond the trigger width, creating a visual disconnect. Adding `class="max-w-min"` to `Select.Content` constrains the dropdown to match the trigger width, with content wrapping naturally to multiple lines.

This documents the opt-in solution discussed in #2208, where we agreed this should be a class-based approach rather than a default behavior change.

**Without `max-w-min`:**

<img width="2170" height="586" alt="CleanShot 2025-11-29 at 11 04 46@2x" src="https://github.com/user-attachments/assets/3e7bb189-026e-4e48-80d5-2f6fafdbf9c6" />

**With `max-w-min`:**

<img width="791" height="321" alt="image" src="https://github.com/user-attachments/assets/fba26f0f-885e-466f-b705-3eba4cef10e2" />