### PR TITLE
docs: fix NativeSelect import path to components

### DIFF
--- a/docs/content/components/native-select.md
+++ b/docs/content/components/native-select.md
@@ -39,7 +39,7 @@ Copy and paste the component source files linked at the top of this page into yo
 
 ```svelte showLineNumbers
 <script lang="ts">
-  import * as NativeSelect from "$lib/registry/ui/native-select/index.js";
+  import * as NativeSelect from "$lib/components/ui/native-select/index.js";
 </script>
 
 <NativeSelect.Root>


### PR DESCRIPTION
The Native Select docs currently import from $lib/registry/ui/native-select/index.js, but the component source and other examples use $lib/components/ui/native-select/index.js. This PR aligns the docs with the correct path for consistency and to prevent copy‑paste errors.

- Scope: docs/content/components/native-select.md
- Change: 1 addition, 1 deletion matching the Native Select page examples on shadcn‑svelte
- Motivation: Keep “Component Source” and “Usage” sections consistent so users can import the right module

