### PR TITLE
fix(notion-prompt-form): fix Popover content doesn't show correctly

### DIFF
--- a/docs/src/lib/components/cards/notion-prompt-form.svelte
+++ b/docs/src/lib/components/cards/notion-prompt-form.svelte
@@ -109,7 +109,7 @@
 	let selectedModel = $state(SAMPLE_DATA.models[0]);
 	let scopeMenuOpen = $state(false);
 
-	const grouped = $derived(() => {
+	const grouped = $derived.by(() => {
 		return SAMPLE_DATA.mentionable.reduce(
 			(acc, item) => {
 				const isAvailable = !mentions.includes(item.title);
@@ -152,7 +152,7 @@
 			/>
 			<InputGroup.Addon align="block-start">
 				<Popover.Root bind:open={mentionPopoverOpen}>
-					<Tooltip.Root>
+					<Tooltip.Root ignoreNonKeyboardFocus>
 						<Tooltip.Trigger>
 							{#snippet child({ props })}
 								<Popover.Trigger {...props}>
@@ -164,7 +164,9 @@
 											class="rounded-full transition-transform"
 										>
 											<AtIcon />
-											{!hasMentions && "Add context"}
+											{#if !hasMentions}
+												Add context
+											{/if}
 										</InputGroup.Button>
 									{/snippet}
 								</Popover.Trigger>
@@ -183,7 +185,7 @@
 											<Command.Item
 												value={item.title}
 												onSelect={() => {
-													mentions = [...mentions, item];
+													mentions = [...mentions, item.title];
 													mentionPopoverOpen = false;
 												}}
 											>

--- a/docs/src/lib/registry/blocks/new-components-01/components/notion-prompt-form.svelte
+++ b/docs/src/lib/registry/blocks/new-components-01/components/notion-prompt-form.svelte
@@ -109,7 +109,7 @@
 	let selectedModel = $state(SAMPLE_DATA.models[0]);
 	let scopeMenuOpen = $state(false);
 
-	const grouped = $derived(() => {
+	const grouped = $derived.by(() => {
 		return SAMPLE_DATA.mentionable.reduce(
 			(acc, item) => {
 				const isAvailable = !mentions.includes(item.title);
@@ -152,7 +152,7 @@
 			/>
 			<InputGroup.Addon align="block-start">
 				<Popover.Root bind:open={mentionPopoverOpen}>
-					<Tooltip.Root>
+					<Tooltip.Root ignoreNonKeyboardFocus>
 						<Tooltip.Trigger>
 							{#snippet child({ props })}
 								<Popover.Trigger {...props}>
@@ -164,7 +164,9 @@
 											class="rounded-full transition-transform"
 										>
 											<AtIcon />
-											{!hasMentions && "Add context"}
+											{#if !hasMentions}
+												Add context
+											{/if}
 										</InputGroup.Button>
 									{/snippet}
 								</Popover.Trigger>
@@ -183,7 +185,7 @@
 											<Command.Item
 												value={item.title}
 												onSelect={() => {
-													mentions = [...mentions, item];
+													mentions = [...mentions, item.title];
 													mentionPopoverOpen = false;
 												}}
 											>


### PR DESCRIPTION
## Summary
Fix Popover content not displaying correctly due to reactivity and focus issues.
Follows up #2310 and #2320

## Changes
- Fix `$derived` reactivity issue by using `$derived.by` for grouped computation
- Add `ignoreNonKeyboardFocus` to `Tooltip.Root` to prevent focus interference
- Fix mention selection to store `item.title` instead of full `item` object
- Fix conditional rendering showing `false` as text by using `{#if}` block instead of `&&`
