### PR TITLE
refactor(toggle-group): use Svelte 5 createContext for type-safe context

### DIFF
--- a/docs/src/lib/registry/ui/toggle-group/toggle-group.svelte
+++ b/docs/src/lib/registry/ui/toggle-group/toggle-group.svelte
@@ -1,13 +1,7 @@
 <script lang="ts" module>
-	import { getContext, setContext } from "svelte";
+	import { createContext } from "svelte";
 	import type { ToggleVariants } from "$lib/registry/ui/toggle/index.js";
-	export function setToggleGroupCtx(props: ToggleVariants) {
-		setContext("toggleGroup", props);
-	}
-
-	export function getToggleGroupCtx() {
-		return getContext<ToggleVariants>("toggleGroup");
-	}
+	export const [getToggleGroupCtx, setToggleGroupCtx] = createContext<ToggleVariants>();
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
This replaces the manual `setContext`/`getContext` wrapper functions with Svelte 5's `createContext` factory in the toggle-group component.

The new pattern from the [Svelte 5 docs](https://svelte.dev/docs/svelte/context#Type-safe-context) provides automatic type safety without requiring string keys or explicit type annotations:

```typescript
// Before (10 lines)
import { getContext, setContext } from "svelte";
export function setToggleGroupCtx(props: ToggleVariants) {
    setContext("toggleGroup", props);
}
export function getToggleGroupCtx() {
    return getContext<ToggleVariants>("toggleGroup");
}

// After (2 lines)
import { createContext } from "svelte";
export const [getToggleGroupCtx, setToggleGroupCtx] = createContext<ToggleVariants>();
```

The consumer (`toggle-group-item.svelte`) doesn't require any changes since the `getToggleGroupCtx()` API remains identical.

This is a pure refactor with no behavioral changes.