### PR TITLE
docs(tooltip): clarify Tooltip.Provider usage and placement

### DIFF
--- a/docs/content/components/tooltip.md
+++ b/docs/content/components/tooltip.md
@@ -52,17 +52,41 @@ Copy and paste the component source files linked at the top of this page into yo
 
 ## Usage
 
+The `Tooltip.Provider` component should be placed once in your root layout, wrapping all content that will contain tooltips. This ensures that only one tooltip within the provider can be open at a time.
+
+```svelte title="src/routes/+layout.svelte"
+<script lang="ts">
+  import * as Tooltip from "$lib/components/ui/tooltip/index.js";
+
+  let { children } = $props();
+</script>
+
+<Tooltip.Provider>
+  {@render children()}
+</Tooltip.Provider>
+```
+
+Then use tooltips anywhere in your app:
+
 ```svelte
 <script lang="ts">
   import * as Tooltip from "$lib/components/ui/tooltip/index.js";
 </script>
 
-<Tooltip.Provider>
-  <Tooltip.Root>
-    <Tooltip.Trigger>Hover</Tooltip.Trigger>
-    <Tooltip.Content>
-      <p>Add to library</p>
-    </Tooltip.Content>
-  </Tooltip.Root>
+<Tooltip.Root>
+  <Tooltip.Trigger>Hover</Tooltip.Trigger>
+  <Tooltip.Content>
+    <p>Add to library</p>
+  </Tooltip.Content>
+</Tooltip.Root>
+```
+
+### Nested Providers
+
+You can nest providers to create groups with different settings. Tooltips use the closest ancestor provider. This is useful when you want instant tooltips in specific areas:
+
+```svelte
+<Tooltip.Provider delayDuration={0}>
+  <!-- Tooltips here will open instantly -->
 </Tooltip.Provider>
 ```


### PR DESCRIPTION
The current tooltip usage example wraps `Tooltip.Provider` around a single tooltip, which can be misleading since it implies each tooltip needs its own provider.

This updates the documentation to clarify that `Tooltip.Provider` should typically be placed once in your root layout, with all tooltips sharing that provider. It also adds a section on nested providers for cases where you need different settings (like `delayDuration={0}` for instant tooltips in sidebars).

The changes align with how the docs site itself uses the provider (one in `+layout.svelte`, with nested providers in `sidebar-provider.svelte` and other components that need instant tooltips).