### PR TITLE
docs(button): use Spinner component in loading example

### DIFF
--- a/docs/content/components/button.md
+++ b/docs/content/components/button.md
@@ -160,6 +160,8 @@ Alternatively, you can use the `buttonVariants` helper to create a link that loo
 
 ### Loading
 
+Use the [Spinner](/docs/components/spinner) component to indicate a loading state.
+
 <ComponentPreview name="button-loading">
 
 <div></div>

--- a/docs/src/lib/registry/examples/button-loading.svelte
+++ b/docs/src/lib/registry/examples/button-loading.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import Loader2Icon from "@lucide/svelte/icons/loader-2";
 	import { Button } from "$lib/registry/ui/button/index.js";
+	import { Spinner } from "$lib/registry/ui/spinner/index.js";
 </script>
 
 <Button disabled>
-	<Loader2Icon class="animate-spin" />
+	<Spinner />
 	Please wait
 </Button>


### PR DESCRIPTION
The loading example in the Button documentation was using `Loader2Icon` with `class="animate-spin"` directly. This updates it to use the `Spinner` component instead, which provides better accessibility (`role="status"`, `aria-label="Loading"`) and aligns with the recommended pattern already shown in the Spinner documentation.

Also adds a brief description with a link to the Spinner docs for discoverability, following the pattern used in other example sections.