### PR TITLE
docs: fix misaligned dates in calendar block #20

### DIFF
--- a/docs/src/lib/registry/blocks/calendar-20.svelte
+++ b/docs/src/lib/registry/blocks/calendar-20.svelte
@@ -23,7 +23,7 @@
 				type="single"
 				bind:value
 				isDateUnavailable={(date) => bookedDates.some((d) => d.compare(date) === 0)}
-				class="data-unavailable:line-through data-unavailable:opacity-100 bg-transparent p-0 [--cell-size:--spacing(10)] md:[--cell-size:--spacing(12)] [&_[data-outside-month]]:hidden"
+				class="data-unavailable:line-through data-unavailable:opacity-100 bg-transparent p-0 [--cell-size:--spacing(10)] md:[--cell-size:--spacing(12)] **:data-outside-month:invisible"
 				weekdayFormat="short"
 			/>
 		</div>


### PR DESCRIPTION
<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->
The currently live ['With time presets'](https://shadcn-svelte.com/blocks/calendar#calendar-20) calendar block has misaligned date numbers in the first row if the first date of the month is not the first day of the week. (see image)

<img width="928" height="654" alt="Screenshot 2025-12-10 at 21 58 59" src="https://github.com/user-attachments/assets/068d7a52-f3b9-41dd-9bc2-637065dfa596" />

This is because dates that are outside of the current month are taken out of the layout by the `display: none` styling. To fix it, outside-the-month dates are now only visually hidden (`visibility: hidden`), but still take up space in the layout. Setting the `visibility` instead of `opacity` should also make the dates ignore pointer and keyboard events.