### PR TITLE
improve(cli): error messages for registry item not found

### DIFF
--- a/.changeset/good-guests-itch.md
+++ b/.changeset/good-guests-itch.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": patch
+---
+
+Improve error message when registry item not found to include the configured registry URL and suggest using the official registry

--- a/packages/cli/src/commands/update/index.ts
+++ b/packages/cli/src/commands/update/index.ts
@@ -154,7 +154,8 @@ async function runUpdate(cwd: string, config: cliConfig.ResolvedConfig, options:
 	const tasks: p.Task[] = [];
 
 	const resolvedItems = await registry.resolveRegistryItems({
-		registryIndex: registryIndex,
+		registryUrl,
+		registryIndex,
 		items: selectedComponents.map((comp) => comp.name),
 	});
 

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -1,5 +1,6 @@
 export const SITE_BASE_URL = "https://shadcn-svelte.com";
 export const TW3_SITE_BASE_URL = "https://tw3.shadcn-svelte.com";
+export const OFFICIAL_REGISTRY_URL = `${SITE_BASE_URL}/registry`;
 
 export const ALIASES = ["components", "ui", "hooks", "utils", "lib"] as const;
 

--- a/packages/cli/src/utils/add-registry-items.ts
+++ b/packages/cli/src/utils/add-registry-items.ts
@@ -32,8 +32,9 @@ export async function addRegistryItems(opts: AddRegistryItemsProps) {
 
 	const registryIndex = await registry.getRegistryIndex(registryUrl);
 	const resolvedItems = await registry.resolveRegistryItems({
-		items: Array.from(selectedItems),
+		registryUrl,
 		registryIndex,
+		items: Array.from(selectedItems),
 	});
 
 	const itemsWithContent = await registry.fetchRegistryItems({

--- a/packages/cli/test/utils/registry.test.ts
+++ b/packages/cli/test/utils/registry.test.ts
@@ -136,8 +136,11 @@ describe("Registry Utilities", () => {
 	});
 
 	describe("resolveRegistryItems", () => {
+		const registryUrl = "https://shadcn-svelte.com/registry";
+
 		it("should resolve items from registry index", async () => {
 			const result = await resolveRegistryItems({
+				registryUrl,
 				registryIndex: mockRegistryIndex,
 				items: ["button"],
 			});
@@ -163,6 +166,7 @@ describe("Registry Utilities", () => {
 			vi.mocked(fetch).mockResolvedValueOnce(mockResponse as Response);
 
 			const result = await resolveRegistryItems({
+				registryUrl,
 				registryIndex: mockRegistryIndex,
 				items: ["https://remote.com/button.json"],
 			});
@@ -175,10 +179,33 @@ describe("Registry Utilities", () => {
 			vi.mocked(fetch).mockRejectedValueOnce(new Error("Network error"));
 			await expect(
 				resolveRegistryItems({
+					registryUrl,
 					registryIndex: mockRegistryIndex,
 					items: ["https://remote.com/button.json"],
 				})
 			).rejects.toThrow("Failed to fetch registry.");
+		});
+
+		it("should show registry URL in error message when item not found", async () => {
+			await expect(
+				resolveRegistryItems({
+					registryUrl: "https://custom-registry.com/registry",
+					registryIndex: mockRegistryIndex,
+					items: ["nonexistent-item"],
+				})
+			).rejects.toThrow(
+				/Registry item 'nonexistent-item' does not exist in the registry at 'https:\/\/custom-registry\.com\/registry'/
+			);
+		});
+
+		it("should suggest official registry URL when using custom registry", async () => {
+			await expect(
+				resolveRegistryItems({
+					registryUrl: "https://custom-registry.com/registry",
+					registryIndex: mockRegistryIndex,
+					items: ["nonexistent-item"],
+				})
+			).rejects.toThrow(/https:\/\/shadcn-svelte\.com\/registry/);
 		});
 	});
 


### PR DESCRIPTION
<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->
This pull request improves the error handling and user guidance when a registry item is not found, especially for users configuring custom registries. It ensures that error messages include the relevant registry URL and, when appropriate, suggest switching to the official registry.