### PR TITLE
docs: Include instructions for adding to an existing project

### DIFF
--- a/docs/content/installation/sveltekit.md
+++ b/docs/content/installation/sveltekit.md
@@ -14,7 +14,7 @@ description: How to setup shadcn-svelte in a SvelteKit project.
 
 <Steps>
 
-### Add tailwind to your project
+### Add TailwindCSS to your project
 
 Use the SvelteKit CLI to create a new project with TailwindCSS
 


### PR DESCRIPTION
The instructions currently have a command for adding tailwindcss to a new Svelte project, but not for an existing project.

This adds the command to add tailwindcss to an existing project: `sv add tailwindcss`