### PR TITLE
fix: Bind ref to Select.Group component

### DIFF
--- a/docs/src/lib/registry/ui/select/select-group.svelte
+++ b/docs/src/lib/registry/ui/select/select-group.svelte
@@ -4,4 +4,4 @@
 	let { ref = $bindable(null), ...restProps }: SelectPrimitive.GroupProps = $props();
 </script>
 
-<SelectPrimitive.Group data-slot="select-group" {...restProps} />
+<SelectPrimitive.Group bind:ref data-slot="select-group" {...restProps} />


### PR DESCRIPTION
Adds missing `ref` for `Select.Group`.