### PR TITLE
fix: use getters in toggle-group context to avoid Svelte 5 reactivity warning

### DIFF
--- a/docs/src/lib/registry/ui/toggle-group/toggle-group.svelte
+++ b/docs/src/lib/registry/ui/toggle-group/toggle-group.svelte
@@ -33,9 +33,15 @@
 	}: ToggleGroupPrimitive.RootProps & ToggleVariants & { spacing?: number } = $props();
 
 	setToggleGroupCtx({
-		variant,
-		size,
-		spacing,
+		get variant() {
+			return variant;
+		},
+		get size() {
+			return size;
+		},
+		get spacing() {
+			return spacing;
+		},
 	});
 </script>
 


### PR DESCRIPTION
Fixes a Svelte 5 warning in the **ToggleGroup** component:

When props are destructured and passed directly to setContext, Svelte 5 warns because the values are captured at initialization time rather than being read reactively.

**The fix**: 
Convert direct prop values to getter functions, ensuring values are read lazily when accessed. This matches the pattern already used in `chart-container.svelte`.

**Before:**
```js
setToggleGroupCtx({
    variant,
    size,
    spacing,
});
```

**After:**
```js
setToggleGroupCtx({
    get variant() { return variant; },
    get size() { return size; },
    get spacing() { return spacing; },
});
```

Related: https://svelte.dev/e/state_referenced_locally