### PR TITLE
chore: Improve type-safety for rendering components

### DIFF
--- a/docs/src/lib/components/cards/payments.svelte
+++ b/docs/src/lib/components/cards/payments.svelte
@@ -80,13 +80,13 @@
 				renderComponent(Checkbox, {
 					checked: table.getIsAllPageRowsSelected(),
 					indeterminate: table.getIsSomeRowsSelected() && !table.getIsAllRowsSelected(),
-					onCheckedChange: (v) => table.toggleAllPageRowsSelected(!!v),
+					onCheckedChange: (v: boolean) => table.toggleAllPageRowsSelected(v),
 					"aria-label": "Select all",
 				}),
 			cell: ({ row }) =>
 				renderComponent(Checkbox, {
 					checked: row.getIsSelected(),
-					onCheckedChange: (v) => row.toggleSelected(!!v),
+					onCheckedChange: (v: boolean) => row.toggleSelected(v),
 				}),
 			enableSorting: false,
 			enableHiding: false,

--- a/docs/src/lib/registry/blocks/dashboard-01/components/data-table.svelte
+++ b/docs/src/lib/registry/blocks/dashboard-01/components/data-table.svelte
@@ -3,7 +3,7 @@
 		{
 			id: "drag",
 			header: () => null,
-			cell: () => renderSnippet(DragHandle),
+			cell: () => renderSnippet(DragHandle, { attach: () => {} }),
 		},
 		{
 			id: "select",
@@ -12,13 +12,13 @@
 					checked: table.getIsAllPageRowsSelected(),
 					indeterminate:
 						table.getIsSomePageRowsSelected() && !table.getIsAllPageRowsSelected(),
-					onCheckedChange: (value) => table.toggleAllPageRowsSelected(!!value),
+					onCheckedChange: (value: boolean) => table.toggleAllPageRowsSelected(value),
 					"aria-label": "Select all",
 				}),
 			cell: ({ row }) =>
 				renderComponent(DataTableCheckbox, {
 					checked: row.getIsSelected(),
-					onCheckedChange: (value) => row.toggleSelected(!!value),
+					onCheckedChange: (value: boolean) => row.toggleSelected(value),
 					"aria-label": "Select row",
 				}),
 			enableSorting: false,

--- a/docs/src/lib/registry/examples/data-table-demo.svelte
+++ b/docs/src/lib/registry/examples/data-table-demo.svelte
@@ -75,13 +75,13 @@
 					checked: table.getIsAllPageRowsSelected(),
 					indeterminate:
 						table.getIsSomePageRowsSelected() && !table.getIsAllPageRowsSelected(),
-					onCheckedChange: (value) => table.toggleAllPageRowsSelected(!!value),
+					onCheckedChange: (value: boolean) => table.toggleAllPageRowsSelected(value),
 					"aria-label": "Select all",
 				}),
 			cell: ({ row }) =>
 				renderComponent(DataTableCheckbox, {
 					checked: row.getIsSelected(),
-					onCheckedChange: (value) => row.toggleSelected(!!value),
+					onCheckedChange: (value: boolean) => row.toggleSelected(value),
 					"aria-label": "Select row",
 				}),
 			enableSorting: false,

--- a/docs/src/lib/registry/ui/data-table/render-helpers.ts
+++ b/docs/src/lib/registry/ui/data-table/render-helpers.ts
@@ -1,4 +1,4 @@
-import type { Component, ComponentProps, Snippet } from "svelte";
+import type { Component, Snippet } from "svelte";
 
 /**
  * A helper class to make it easy to identify Svelte components in
@@ -16,13 +16,13 @@ import type { Component, ComponentProps, Snippet } from "svelte";
  * {/if}
  * ```
  */
-export class RenderComponentConfig<TComponent extends Component> {
-	component: TComponent;
-	props: ComponentProps<TComponent> | Record<string, never>;
-	constructor(
-		component: TComponent,
-		props: ComponentProps<TComponent> | Record<string, never> = {}
-	) {
+export class RenderComponentConfig<
+	TProps extends Record<string, unknown>,
+	TComponent extends Component<TProps>,
+> {
+	component;
+	props;
+	constructor(component: TComponent, props: TProps) {
 		this.component = component;
 		this.props = props;
 	}
@@ -75,10 +75,19 @@ export class RenderSnippetConfig<TProps> {
  * @see {@link https://tanstack.com/table/latest/docs/guide/column-defs}
  */
 export function renderComponent<
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	T extends Component<any>,
-	Props extends ComponentProps<T>,
->(component: T, props: Props = {} as Props) {
+	TProps extends Record<string, never>,
+	TComponent extends Component<TProps>,
+>(component: TComponent): RenderComponentConfig<TProps, TComponent>;
+
+export function renderComponent<
+	TProps extends Record<string, unknown>,
+	TComponent extends Component<TProps>,
+>(component: TComponent, props: TProps): RenderComponentConfig<TProps, TComponent>;
+
+export function renderComponent<
+	TProps extends Record<string, unknown>,
+	TComponent extends Component<TProps>,
+>(component: TComponent, props: TProps = {} as TProps) {
 	return new RenderComponentConfig(component, props);
 }
 
@@ -106,6 +115,15 @@ export function renderComponent<
  * ```
  * @see {@link https://tanstack.com/table/latest/docs/guide/column-defs}
  */
+export function renderSnippet<TProps extends Record<string, never>>(
+	snippet: Snippet<[TProps]>
+): RenderSnippetConfig<TProps>;
+
+export function renderSnippet<TProps extends Record<string, unknown>>(
+	snippet: Snippet<[TProps]>,
+	props: TProps
+): RenderSnippetConfig<TProps>;
+
 export function renderSnippet<TProps>(snippet: Snippet<[TProps]>, params: TProps = {} as TProps) {
 	return new RenderSnippetConfig(snippet, params);
 }

--- a/docs/src/routes/(app)/examples/dashboard/components/data-table.svelte
+++ b/docs/src/routes/(app)/examples/dashboard/components/data-table.svelte
@@ -3,7 +3,7 @@
 		{
 			id: "drag",
 			header: () => null,
-			cell: () => renderSnippet(DragHandle),
+			cell: () => renderSnippet(DragHandle, { attach: () => {} }),
 		},
 		{
 			id: "select",
@@ -12,13 +12,13 @@
 					checked: table.getIsAllPageRowsSelected(),
 					indeterminate:
 						table.getIsSomePageRowsSelected() && !table.getIsAllPageRowsSelected(),
-					onCheckedChange: (value) => table.toggleAllPageRowsSelected(!!value),
+					onCheckedChange: (value: boolean) => table.toggleAllPageRowsSelected(value),
 					"aria-label": "Select all",
 				}),
 			cell: ({ row }) =>
 				renderComponent(DataTableCheckbox, {
 					checked: row.getIsSelected(),
-					onCheckedChange: (value) => row.toggleSelected(!!value),
+					onCheckedChange: (value: boolean) => row.toggleSelected(value),
 					"aria-label": "Select row",
 				}),
 			enableSorting: false,

--- a/docs/src/routes/(app)/examples/tasks/components/data-table.svelte
+++ b/docs/src/routes/(app)/examples/tasks/components/data-table.svelte
@@ -55,7 +55,7 @@
 			header: ({ table }) =>
 				renderComponent(Checkbox, {
 					checked: table.getIsAllPageRowsSelected(),
-					onCheckedChange: (value) => table.toggleAllPageRowsSelected(value),
+					onCheckedChange: (value: boolean) => table.toggleAllPageRowsSelected(value),
 					indeterminate:
 						table.getIsSomePageRowsSelected() && !table.getIsAllPageRowsSelected(),
 					"aria-label": "Select all",
@@ -63,7 +63,7 @@
 			cell: ({ row }) =>
 				renderComponent(Checkbox, {
 					checked: row.getIsSelected(),
-					onCheckedChange: (value) => row.toggleSelected(value),
+					onCheckedChange: (value: boolean) => row.toggleSelected(value),
 					"aria-label": "Select row",
 				}),
 			enableSorting: false,


### PR DESCRIPTION
This PR aims to improve type-safety when providing props to components, at the exense of more verbose error messages in some cases. The most important case is when no props are passed to a component expecting props. **The old version gives no type-safety in that case.** Here are the resulting changes in type-safety error messages.

## No props component

```svelte
<!-- no-prop-component.svelte -->
no props
```

### No props provided
No change.
<img width="352" height="54" alt="image" src="https://github.com/user-attachments/assets/d44045d4-6f8f-41f6-ab21-1d2c15c649fa" />

### Unexpected prop provied
Less verbose error message in old version when props are provided but not expected.
<img width="1192" height="156" alt="image" src="https://github.com/user-attachments/assets/33f576f3-e9a9-4006-90ae-e07734b81f2c" />
<img width="1045" height="340" alt="image" src="https://github.com/user-attachments/assets/9be58457-18c4-4565-9e8b-13a5e9685e6d" />

## Single prop component

```svelte
<!-- single-prop-component.svelte -->
<script lang="ts">
  type Props = { value: number };
  let { value }: Props = $props();
</script>

{value}
```

### No props provided
**Type-safety in new version when props are required but not provided.**

<img width="386" height="32" alt="image" src="https://github.com/user-attachments/assets/484bfac1-7460-441d-9049-37650eacf4ec" />
<img width="1026" height="301" alt="image" src="https://github.com/user-attachments/assets/4fbedb5e-760f-4182-ab52-88bf17b8ab4e" />

### Empty props provided
Less verbose error message in old version when required prop is not provided.

<img width="1152" height="151" alt="image" src="https://github.com/user-attachments/assets/797d30c8-3495-48a7-8228-2b08b7ac5a92" />
<img width="991" height="276" alt="image" src="https://github.com/user-attachments/assets/68f4b89f-4203-4fdf-827c-b2c6df623872" />

### Expected props provided
No change.

<img width="522" height="53" alt="image" src="https://github.com/user-attachments/assets/1a6b886f-2c34-49b6-bd3b-7552cf85df65" />

### Prop has wrong type
Less verbose error message in old version when prop has wrong type.

<img width="956" height="132" alt="image" src="https://github.com/user-attachments/assets/71f12ce3-9e35-4386-b580-3f19bf872764" />
<img width="1074" height="293" alt="image" src="https://github.com/user-attachments/assets/f7e1c91e-d31d-4231-96b9-12865f81bf34" />

### Only unexpected prop provided
Better error message in new version when extra props are provided, but required prop is not provided.

<img width="1191" height="159" alt="image" src="https://github.com/user-attachments/assets/2511c6e8-e30c-4eed-a2d9-da1fd1e66d73" />
<img width="1088" height="306" alt="image" src="https://github.com/user-attachments/assets/d031a327-a4e6-4986-ae8c-7c7e23141a21" />

### Unexpected prop provided
No change.

<img width="642" height="54" alt="image" src="https://github.com/user-attachments/assets/f76bc727-5e79-47ad-9dfd-badfba7074b8" />