### PR TITLE
fix: dark mode for DatePicker component

### DIFF
--- a/docs/src/lib/registry/ui/calendar/calendar-month-select.svelte
+++ b/docs/src/lib/registry/ui/calendar/calendar-month-select.svelte
@@ -18,7 +18,11 @@
 		className
 	)}
 >
-	<CalendarPrimitive.MonthSelect bind:ref class="absolute inset-0 opacity-0 dark:bg-popover dark:text-popover-foreground" {...restProps}>
+	<CalendarPrimitive.MonthSelect
+		bind:ref
+		class="dark:bg-popover dark:text-popover-foreground absolute inset-0 opacity-0"
+		{...restProps}
+	>
 		{#snippet child({ props, monthItems, selectedMonthItem })}
 			<select {...props} {value} {onchange}>
 				{#each monthItems as monthItem (monthItem.value)}

--- a/docs/src/lib/registry/ui/calendar/calendar-year-select.svelte
+++ b/docs/src/lib/registry/ui/calendar/calendar-year-select.svelte
@@ -17,7 +17,11 @@
 		className
 	)}
 >
-	<CalendarPrimitive.YearSelect bind:ref class="absolute inset-0 opacity-0 dark:bg-popover dark:text-popover-foreground" {...restProps}>
+	<CalendarPrimitive.YearSelect
+		bind:ref
+		class="dark:bg-popover dark:text-popover-foreground absolute inset-0 opacity-0"
+		{...restProps}
+	>
 		{#snippet child({ props, yearItems, selectedYearItem })}
 			<select {...props} {value}>
 				{#each yearItems as yearItem (yearItem.value)}


### PR DESCRIPTION
### Affected component

[Date Picker](https://www.shadcn-svelte.com/docs/components/date-picker)

Date picker dropdown values are not visible when the application is in dark mode, making it impossible for users to select dates using web browsers. They appear to be rendered but with insufficient contrast or incorrect color styling.
<img width="300" height="400" alt="image" src="https://github.com/user-attachments/assets/9809f6e0-984f-4535-ab46-4df0e54e4d4a" />

The solution is to add inside the `Calendar month` and `year` `select` components 2 dark variant classes.

Closes #2505 

<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->
