### PR TITLE
docs: Remove formsnap deprecation notice

### DIFF
--- a/docs/content/components/form.md
+++ b/docs/content/components/form.md
@@ -7,19 +7,11 @@ links:
 ---
 
 <script>
-  import Callout from '$lib/components/callout.svelte'
 	import ComponentPreview from "$lib/components/component-preview.svelte";
 	import PMAddComp from "$lib/components/pm-add-comp.svelte";
 	import PMInstall from "$lib/components/pm-install.svelte";
 	import Steps from "$lib/components/steps.svelte";
-	import InfoIcon from "@lucide/svelte/icons/info"
 </script>
-
-<Callout title="We are not actively developing this component anymore." icon={InfoIcon}>
-
-The Form component is an abstraction over the `formsnap` & `sveltekit-superforms` libraries. Going forward, we recommend using the [`<Field />`](/docs/components/field) component to build forms.
-
-</Callout>
 
 Forms are tricky. They are one of the most common things you'll build in a web application, but also one of the most complex.
 


### PR DESCRIPTION
Understandably this has caused a good bit of confusion I didn't realize this was actually here until fairly recently. Obviously something that was missed in #2391.

We are not deprecating formsnap and have no plans to at this time. It's still the preferred way to use forms in shadcn-svelte.