### PR TITLE
fix: hide field errors div on empty array

### DIFF
--- a/docs/src/lib/registry/ui/field/field-error.svelte
+++ b/docs/src/lib/registry/ui/field/field-error.svelte
@@ -19,7 +19,7 @@
 		if (children) return true;
 
 		// no errors
-		if (!errors) return false;
+		if (!errors || errors.length === 0) return false;
 
 		// has an error but no message
 		if (errors.length === 1 && !errors[0]?.message) {


### PR DESCRIPTION
Handle case of empty error array, which is truthy, and thus shows the emtpy alert div.

```diff
                if (children) return true;
 
                // no errors
-               if (!errors) return false;
+               if (!errors || errors.length === 0) return false;
 
                // has an error but no message
                if (errors.length === 1 && !errors[0]?.message) {
```