### PR TITLE
chore: Avoid redundant object merging

### DIFF
--- a/docs/src/lib/registry/ui/data-table/data-table.svelte.ts
+++ b/docs/src/lib/registry/ui/data-table/data-table.svelte.ts
@@ -54,8 +54,8 @@ export function createSvelteTable<TData extends RowData>(options: TableOptions<T
 
 	function updateOptions() {
 		table.setOptions(() => {
-			return mergeObjects(resolvedOptions, options, {
-				state: mergeObjects(state, options.state || {}),
+			return mergeObjects(resolvedOptions, {
+				state: mergeObjects(state, resolvedOptions.state),
 
 				onStateChange: (updater: Updater<TableState>) => {
 					if (updater instanceof Function) state = updater(state);


### PR DESCRIPTION
`resolvedOptions` is already `mergeObjects({ ...defaults }, options)` (and is a Proxy that reads from `options` lazily). In `updateOptions`, merging `options` again (`mergeObjects(resolvedOptions, options, …)`) is redundant and adds extra proxy/lookup overhead on every update.

This is a follow-up to #2511.

<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->
