### PR TITLE
docs: removed stale TODO comment from chart-bar-active example

### DIFF
--- a/docs/src/lib/registry/blocks/chart-bar-active.svelte
+++ b/docs/src/lib/registry/blocks/chart-bar-active.svelte
@@ -86,7 +86,6 @@
 					{/each}
 				{/snippet}
 			</BarChart>
-			<!-- todo -->
 		</Chart.Container>
 	</Card.Content>
 	<Card.Footer>


### PR DESCRIPTION
Removed a leftover TODO comment in the chart-bar-active example.

This is a docs-only cleanup to avoid confusion for contributors reading the example.  
No functional or behavioral changes were made.
