### PR TITLE
chore: replaced any with unknown in chart tooltip formatters

### DIFF
--- a/docs/src/lib/registry/ui/chart/chart-tooltip.svelte
+++ b/docs/src/lib/registry/ui/chart/chart-tooltip.svelte
@@ -5,9 +5,8 @@
 	import { getTooltipContext, Tooltip as TooltipPrimitive } from "layerchart";
 	import type { Snippet } from "svelte";
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	function defaultFormatter(value: any, _payload: TooltipPayload[]) {
-		return `${value}`;
+	function defaultFormatter(value: unknown, _payload: TooltipPayload[]) {
+		return String(value);
 	}
 
 	let {
@@ -32,8 +31,9 @@
 		labelKey?: string;
 		hideIndicator?: boolean;
 		labelClassName?: string;
-		labelFormatter?: // eslint-disable-next-line @typescript-eslint/no-explicit-any
-			((value: any, payload: TooltipPayload[]) => string | number | Snippet) | null;
+		labelFormatter?: (
+			(value: unknown, payload: TooltipPayload[]) => string | number | Snippet
+		) | null;
 		formatter?: Snippet<
 			[
 				{


### PR DESCRIPTION
Improved type safety by replacing 'any' with 'unknown' in chart tooltip
formatters and removed unnecessary ESLint disable comments.

No runtime or behavioral changes were made.