### PR TITLE
docs: fix useSidebar example snippet

### DIFF
--- a/docs/content/components/sidebar.md
+++ b/docs/content/components/sidebar.md
@@ -436,7 +436,7 @@ The `useSidebar` function is used to hook into the sidebar context. It returns a
 
 ```svelte showLineNumbers
 <script lang="ts">
-  import { useSidebar } from '$lib/components/ui/sidebar/index.js';
+  import { useSidebar } from "$lib/components/ui/sidebar/index.js";
   const sidebar = useSidebar();
 
   // ...


### PR DESCRIPTION
Small improvement of the useSidebar example in the sidebar documentation page.