### PR TITLE
Fix tabIndex attribute casing in sidebar-rail.svelte

### DIFF
--- a/docs/src/lib/registry/ui/sidebar/sidebar-rail.svelte
+++ b/docs/src/lib/registry/ui/sidebar/sidebar-rail.svelte
@@ -18,7 +18,7 @@
 	data-sidebar="rail"
 	data-slot="sidebar-rail"
 	aria-label="Toggle Sidebar"
-	tabIndex={-1}
+	tabindex={-1}
 	onclick={sidebar.toggle}
 	title="Toggle Sidebar"
 	class={cn(


### PR DESCRIPTION
<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->
