### PR TITLE
Bind ref to Sheet.Content in sidebar.svelte

### DIFF
--- a/docs/src/lib/registry/ui/sidebar/sidebar.svelte
+++ b/docs/src/lib/registry/ui/sidebar/sidebar.svelte
@@ -39,6 +39,7 @@
 		{...restProps}
 	>
 		<Sheet.Content
+			bind:ref
 			data-sidebar="sidebar"
 			data-slot="sidebar"
 			data-mobile="true"


### PR DESCRIPTION
`ref` was not bound in the mobile case.

<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->
