### PR TITLE
Use hydratable for random width in sidebar menu

### DIFF
--- a/docs/src/lib/registry/ui/sidebar/sidebar-menu-skeleton.svelte
+++ b/docs/src/lib/registry/ui/sidebar/sidebar-menu-skeleton.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { cn, type WithElementRef } from "$lib/utils.js";
 	import { Skeleton } from "$lib/registry/ui/skeleton/index.js";
+	import { hydratable } from "svelte";
 	import type { HTMLAttributes } from "svelte/elements";
 
 	let {
@@ -12,9 +13,11 @@
 	}: WithElementRef<HTMLAttributes<HTMLElement>> & {
 		showIcon?: boolean;
 	} = $props();
+	const uid = $props.id();
 
 	// Random width between 50% and 90%
-	const width = `${Math.floor(Math.random() * 40) + 50}%`;
+	const rand = hydratable(`${uid}-skeleton-width`, () => Math.random());
+	const width = `${Math.floor(rand * 40) + 50}%`;
 </script>
 
 <div


### PR DESCRIPTION
This prevents the skeleton width from changing during hydration.

<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->
