### PR TITLE
chore: use `const` to comply with `svelte/prefer-const` lint rule

### DIFF
--- a/docs/src/lib/registry/ui/chart/chart-style.svelte
+++ b/docs/src/lib/registry/ui/chart/chart-style.svelte
@@ -11,7 +11,7 @@
 		if (!colorConfig || !colorConfig.length) return;
 
 		const themeContents = [];
-		for (let [_theme, prefix] of Object.entries(THEMES)) {
+		for (const [_theme, prefix] of Object.entries(THEMES)) {
 			let content = `${prefix} [data-chart=${id}] {\n`;
 			const color = colorConfig.map(([key, itemConfig]) => {
 				const theme = _theme as keyof typeof itemConfig.theme;


### PR DESCRIPTION
I think this is a nice default to avoid linting issues, and I assume many users have `svelte/prefer-const` rule enabled.
Feel free to close if it is deemed irrelevant!

**Side question:** It seems to have been a while since somebody ran `pnpm format`? I get 272 changed files. Any reason for that?