### PR TITLE
Fix WithElementRef type incompatibility with Svelte 5 bind:this

### DIFF
--- a/docs/src/lib/registry/ui/native-select/native-select.svelte
+++ b/docs/src/lib/registry/ui/native-select/native-select.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
-	import { cn, type WithElementRef } from "$lib/utils.js";
+	import { cn } from "@ts-packages/shadcn/generated/lib/utils.js";
 	import type { HTMLSelectAttributes } from "svelte/elements";
 	import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
+
+	type Props = HTMLSelectAttributes & {
+		ref?: HTMLSelectElement | null;
+		value?: string;
+		children?: any;
+	};
 
 	let {
 		ref = $bindable(null),
@@ -9,7 +15,7 @@
 		class: className,
 		children,
 		...restProps
-	}: WithElementRef<HTMLSelectAttributes> = $props();
+	}: Props = $props();
 </script>
 
 <div
@@ -24,7 +30,7 @@
 			"border-input placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 dark:hover:bg-input/50 h-9 w-full min-w-0 appearance-none rounded-md border bg-transparent px-3 py-2 pe-9 text-sm shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed",
 			"focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
 			"aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-			className
+			className,
 		)}
 		{...restProps}
 	>


### PR DESCRIPTION
This PR fixes a TypeScript incompatibility between WithElementRef and Svelte 5’s bind:this typing when used with certain DOM elements such as <select>.

The current implementation types ref as HTMLElement, which causes svelte-check to report an error when binding to more specific element types like HTMLSelectElement.

Example error:

Type 'HTMLSelectElement' is not assignable to type 'HTMLElement'. The types returned by 'remove()' are incompatible between these types. Type 'void' is not assignable to type 'Element'.

Cause

Svelte’s svelte/elements DOM typings differ slightly from the standard lib.dom.d.ts. In particular, remove() is typed differently, which makes HTMLSelectElement incompatible with HTMLElement in strict TypeScript contexts.

Because WithElementRef defines:

type WithElementRef<T> = T & {
  ref?: HTMLElement | null;
};

this forces bind:this={ref} to expect HTMLElement, which conflicts with elements like HTMLSelectElement.

Fix

Instead of forcing HTMLElement, make the element type generic so the ref matches the actual DOM element being bound.

type WithElementRef<Props, El extends Element> = Props & {
  ref?: El | null;
};

<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->
