### PR TITLE
fix(switch): support RTL thumb translation

### DIFF
--- a/docs/src/lib/registry/ui/switch/switch.svelte
+++ b/docs/src/lib/registry/ui/switch/switch.svelte
@@ -23,7 +23,7 @@
 	<SwitchPrimitive.Thumb
 		data-slot="switch-thumb"
 		class={cn(
-			"bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+			"bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 rtl:data-[state=checked]:translate-x-[calc(-100%)]"
 		)}
 	/>
 </SwitchPrimitive.Root>


### PR DESCRIPTION
## Summary
- add RTL checked-state translation for the switch thumb
- keep existing LTR checked/unchecked behavior unchanged

## Why
In RTL layouts, the thumb should shift to the opposite side when checked.