### PR TITLE
fix(sheet rtl): swap sidebar slide directions

### DIFF
--- a/docs/src/lib/registry/ui/sheet/sheet-content.svelte
+++ b/docs/src/lib/registry/ui/sheet/sheet-content.svelte
@@ -6,8 +6,8 @@
 			side: {
 				top: "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
 				bottom: "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
-				left: "data-[state=closed]:slide-out-to-start data-[state=open]:slide-in-from-start inset-y-0 start-0 h-full w-3/4 border-e sm:max-w-sm",
-				right: "data-[state=closed]:slide-out-to-end data-[state=open]:slide-in-from-end inset-y-0 end-0 h-full w-3/4 border-s sm:max-w-sm",
+				left: "data-[state=closed]:slide-out-to-start data-[state=open]:slide-in-from-start rtl:data-[state=closed]:slide-out-to-end rtl:data-[state=open]:slide-in-from-end inset-y-0 start-0 h-full w-3/4 border-e sm:max-w-sm",
+				right: "data-[state=closed]:slide-out-to-end data-[state=open]:slide-in-from-end rtl:data-[state=closed]:slide-out-to-start rtl:data-[state=open]:slide-in-from-start inset-y-0 end-0 h-full w-3/4 border-s sm:max-w-sm",
 			},
 		},
 		defaultVariants: {


### PR DESCRIPTION
## Summary
- add RTL-only overrides for side directions on `left` and `right`

## Why
In RTL layouts, sidebar enter/exit directions should be mirrored.
