### PR TITLE
Support class binding in sidebar.svelte on mobile

### DIFF
--- a/docs/src/lib/registry/ui/sidebar/sidebar.svelte
+++ b/docs/src/lib/registry/ui/sidebar/sidebar.svelte
@@ -43,7 +43,10 @@
 			data-sidebar="sidebar"
 			data-slot="sidebar"
 			data-mobile="true"
-			class={cn("bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden", className)}
+			class={cn(
+				"bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden",
+				className
+			)}
 			style="--sidebar-width: {SIDEBAR_WIDTH_MOBILE};"
 			{side}
 		>


### PR DESCRIPTION
eg: safe area inset top for mobile sidebar

```svelte
<Sidebar {collapsible} variant={sidebar} class='pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]'>
  <SidebarHeader>
    <TeamSwitcher {teams} />
  </SidebarHeader>
  <SidebarContent>
    <NavGroup />
  </SidebarContent>
  <SidebarFooter>
    <NavUser />
  </SidebarFooter>
  <SidebarRail />
</Sidebar>
```

<!--
### Before submitting the PR, please make sure you do the following

- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->
