### PR TITLE
Fix typo in Input attribute from 'autoComplete' to 'autocomplete'

### DIFF
--- a/docs/content/components/field.md
+++ b/docs/content/components/field.md
@@ -61,7 +61,7 @@ Copy and paste the following code into your project.
   <Field.Group>
     <Field.Field>
       <Field.Label for="name">Full name</Field.Label>
-      <Input id="name" autoComplete="off" placeholder="Evil Rabbit" />
+      <Input id="name" autocomplete="off" placeholder="Evil Rabbit" />
       <Field.Description
         >This appears on invoices and emails.</Field.Description
       >


### PR DESCRIPTION
Fix error: Object literal may only specify known properties, and '"autoComplete"' does not exist in type 'Props'. (ts 2353)

The interface properties are lowercase

```
export interface HTMLInputAttributes extends HTMLAttributes<HTMLInputElement> {
	accept?: string | undefined | null;
	alt?: string | undefined | null;
	autocomplete?: FullAutoFill | undefined | null;
```