### PR TITLE
fix: add missing fields in schema of components.json

### DIFF
--- a/.changeset/lovely-tigers-glow.md
+++ b/.changeset/lovely-tigers-glow.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": patch
+---
+
+fix: add missing fields to components.json schema

--- a/docs/static/schema.json
+++ b/docs/static/schema.json
@@ -86,6 +86,35 @@
 					"additionalProperties": false
 				}
 			]
+		},
+		"iconLibrary": {
+			"description": "The icon library to use for your components.",
+			"type": "string",
+			"enum": [
+				"lucide",
+				"tabler",
+				"hugeicons",
+				"phosphor",
+				"remixicon"
+			]
+		},
+		"menuColor": {
+			"description": "The color scheme for menus.",
+			"type": "string",
+			"enum": [
+				"default",
+				"inverted",
+				"default-translucent",
+				"inverted-translucent"
+			]
+		},
+		"menuAccent": {
+			"description": "The accent style for menus.",
+			"type": "string",
+			"enum": [
+				"subtle",
+				"bold"
+			]
 		}
 	},
 	"required": [

--- a/packages/cli/src/utils/config/schema.ts
+++ b/packages/cli/src/utils/config/schema.ts
@@ -11,6 +11,8 @@ import {
 } from "../../preset/index.js";
 import { PRESET_ICON_LIBRARIES } from "../../preset/preset.js";
 
+export const ICON_LIBRARIES = PRESET_ICON_LIBRARIES;
+
 export const STYLES = PRESET_STYLES;
 export type StyleName = (typeof STYLES)[number];
 export const BASE_COLORS = PRESET_BASE_COLOR_KEYS;
@@ -91,7 +93,7 @@ export const newConfigSchema = baseConfigSchema.extend({
 	registry: z.string().default(DEFAULT_CONFIG.registry),
 	// design system
 	style: z.string().optional(),
-	iconLibrary: z.enum(PRESET_ICON_LIBRARIES).optional(),
+	iconLibrary: z.enum(ICON_LIBRARIES).optional(),
 	menuColor: z.enum(MENU_COLORS).optional(),
 	menuAccent: z.enum(MENU_ACCENTS).optional(),
 });
@@ -120,7 +122,7 @@ export const resolvedConfigSchema = rawConfigSchema.extend({
 		lib: z.string(),
 	}),
 	style: z.string().default(DEFAULT_CONFIG.style),
-	iconLibrary: z.enum(PRESET_ICON_LIBRARIES).default(DEFAULT_CONFIG.iconLibrary),
+	iconLibrary: z.enum(ICON_LIBRARIES).default(DEFAULT_CONFIG.iconLibrary),
 	menuColor: z.enum(MENU_COLORS).default(DEFAULT_CONFIG.menuColor),
 	menuAccent: z.enum(MENU_ACCENTS).default(DEFAULT_CONFIG.menuAccent),
 });

--- a/packages/cli/src/utils/registry/schema.ts
+++ b/packages/cli/src/utils/registry/schema.ts
@@ -1,7 +1,7 @@
 // !! BROWSER SAFE !!
 
 import { z } from "zod";
-import { rawConfigSchema } from "../config/schema.js";
+import { ICON_LIBRARIES, MENU_ACCENTS, MENU_COLORS, rawConfigSchema } from "../config/schema.js";
 
 const registryItemFileType = [
 	"registry:lib",
@@ -310,6 +310,12 @@ export const componentsJsonSchema = z.object({
 		.describe(
 			"Used to determine if Typescript is used for this project. When set to `false`, `.js` files will be installed instead. Defaults to `true`."
 		),
+	iconLibrary: z
+		.enum(ICON_LIBRARIES)
+		.optional()
+		.describe("The icon library to use for your components."),
+	menuColor: z.enum(MENU_COLORS).optional().describe("The color scheme for menus."),
+	menuAccent: z.enum(MENU_ACCENTS).optional().describe("The accent style for menus."),
 });
 
 /**


### PR DESCRIPTION
This PR fixes a mismatch between the `components.json` generated by `bunx shadcn-svelte@latest init` and the published schema definition of shadcn-svelte.

## Problem

`bunx shadcn-svelte@latest init` generates `components.json` which includes the following fields:

<details>
<summary>Example</summary>

```json
{
  "$schema": "https://shadcn-svelte.com/schema.json",
  "tailwind": {
    "css": "src/style/global.css",
    "baseColor": "neutral"
  },
  "aliases": {
    "components": "$lib/components",
    "utils": "$lib/utils",
    "ui": "$lib/components/ui",
    "hooks": "$lib/hooks",
    "lib": "$lib"
  },
  "typescript": true,
  "registry": "https://shadcn-svelte.com/registry",
  "style": "vega",
  "iconLibrary": "lucide",
  "menuColor": "default",
  "menuAccent": "subtle"
}
```
</details>

- `iconLibrary`
- `menuColor`
- `menuAccent`
 
However, these fields are not defined in the current schema.json, resulting in validation errors such as:

```
Property iconLibrary is not allowed.
Property menuColor is not allowed.
Property menuAccent is not allowed.
```

## Changes

Added the following missing fields to schema.json:

* `iconLibrary`
* `menuColor`
* `menuAccent`

This ensures consistency between the CLI output and the schema, eliminating unnecessary validation errors.