### PR TITLE
Ensure we don't add a font dependency for `fontHeading:  "inherit"`

### DIFF
--- a/docs/src/lib/registry/config.ts
+++ b/docs/src/lib/registry/config.ts
@@ -285,7 +285,7 @@ export function buildRegistryBase(config: PresetConfig) {
 		registryDependencies.push(`font-${config.font}`);
 	}
 
-	if (config.fontHeading) {
+	if (config.fontHeading && config.fontHeading !== "inherit") {
 		registryDependencies.push(`font-heading-${config.fontHeading}`);
 	}
 


### PR DESCRIPTION
Fixes #2617 