### PR TITLE
Remove TooltipProvider wrapping from tooltip component

### DIFF
--- a/docs/src/lib/registry/ui/tooltip/tooltip.svelte
+++ b/docs/src/lib/registry/ui/tooltip/tooltip.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
 	import { Tooltip as TooltipPrimitive } from "bits-ui";
-	import TooltipProvider from "./tooltip-provider.svelte";
 
 	let { open = $bindable(false), ...restProps }: TooltipPrimitive.RootProps = $props();
 </script>
 
-<TooltipProvider>
-	<TooltipPrimitive.Root bind:open {...restProps} />
-</TooltipProvider>
+<TooltipPrimitive.Root bind:open {...restProps} />


### PR DESCRIPTION
I'm pretty sure shadcn had it this way at one point but has since reverted it.

Fixes #2644 
