### PR TITLE
fix: epicenter sponsor logo visibility on light backgrounds

### DIFF
--- a/docs/src/lib/components/cta-mobile.svelte
+++ b/docs/src/lib/components/cta-mobile.svelte
@@ -10,17 +10,18 @@
 	></div>
 
 	<div
-		class="relative z-10 size-8 shrink-0 opacity-80 transition-opacity group-hover:opacity-100"
+		class="relative z-10 size-8 shrink-0 overflow-hidden rounded-md opacity-80 transition-opacity group-hover:opacity-100"
 	>
 		<svg viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg">
-			<circle cx="170" cy="170" r="100" fill="#cccccc" opacity="1" />
-			<circle cx="230" cy="230" r="100" fill="#ffffff" opacity="1" />
+			<rect width="400" height="400" fill="#000" />
+			<circle cx="170" cy="170" r="100" fill="#ccc" />
+			<circle cx="230" cy="230" r="100" fill="#fff" />
 		</svg>
 	</div>
 
 	<div class="relative z-10 min-w-0 flex-1">
 		<h3 class="text-foreground text-sm font-semibold tracking-tight">Epicenter</h3>
-		<p class="text-foreground/70 truncate text-xs">Open source, local first apps</p>
+		<p class="text-foreground/70 truncate text-xs">Local-first, open source apps</p>
 	</div>
 
 	<span

--- a/docs/src/lib/components/cta.svelte
+++ b/docs/src/lib/components/cta.svelte
@@ -14,7 +14,9 @@
 			<span class="text-muted-foreground text-[10px] font-medium tracking-wide uppercase"
 				>Special Sponsor</span
 			>
-			<div class="size-10 overflow-hidden rounded-lg opacity-80 transition-opacity group-hover:opacity-100">
+			<div
+				class="size-10 overflow-hidden rounded-lg opacity-80 transition-opacity group-hover:opacity-100"
+			>
 				<svg viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg">
 					<rect width="400" height="400" fill="#000" />
 					<circle cx="170" cy="170" r="100" fill="#ccc" />

--- a/docs/src/lib/components/cta.svelte
+++ b/docs/src/lib/components/cta.svelte
@@ -14,16 +14,17 @@
 			<span class="text-muted-foreground text-[10px] font-medium tracking-wide uppercase"
 				>Special Sponsor</span
 			>
-			<div class="size-10 opacity-80 transition-opacity group-hover:opacity-100">
+			<div class="size-10 overflow-hidden rounded-lg opacity-80 transition-opacity group-hover:opacity-100">
 				<svg viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg">
-					<circle cx="170" cy="170" r="100" fill="#cccccc" opacity="1" />
-					<circle cx="230" cy="230" r="100" fill="#ffffff" opacity="1" />
+					<rect width="400" height="400" fill="#000" />
+					<circle cx="170" cy="170" r="100" fill="#ccc" />
+					<circle cx="230" cy="230" r="100" fill="#fff" />
 				</svg>
 			</div>
 		</div>
 		<div>
 			<h3 class="text-foreground text-lg font-semibold tracking-tight">Epicenter</h3>
-			<p class="text-foreground/85 text-xs leading-relaxed">Open source, local first apps</p>
+			<p class="text-foreground/85 text-xs leading-relaxed">Local-first, open source apps</p>
 		</div>
 	</div>
 </a>


### PR DESCRIPTION
The Epicenter sponsor card renders its logo as two overlapping circles—gray and white—with no background. On dark mode this looks fine, but on light mode the white circle is invisible against the light card surface. The logo appears as a single gray crescent instead of the actual mark.

The fix adds a black `<rect>` background to the inline SVG, matching the canonical Epicenter logo (which is always two circles on a black background—the black is part of the identity). The wrapper div gets `overflow-hidden` + `rounded-lg`/`rounded-md` to clip the square rect into a rounded mark shape:

```svelte
<!-- before: circles float with no background -->
<svg viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg">
  <circle cx="170" cy="170" r="100" fill="#cccccc" opacity="1" />
  <circle cx="230" cy="230" r="100" fill="#ffffff" opacity="1" />
</svg>

<!-- after: proper mark with black background -->
<div class="size-10 overflow-hidden rounded-lg ...">
  <svg viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg">
    <rect width="400" height="400" fill="#000" />
    <circle cx="170" cy="170" r="100" fill="#ccc" />
    <circle cx="230" cy="230" r="100" fill="#fff" />
  </svg>
</div>
```

Also fixes the tagline from "Open source, local first apps" to "Local-first, open source apps"—hyphenated compound adjective, and leads with the differentiator instead of table-stakes "open source."