### PR TITLE
feat(ui): update calendar, chart, pagination, progress, resizable, and other UI components

### DIFF
--- a/docs/src/lib/registry/registry-categories.ts
+++ b/docs/src/lib/registry/registry-categories.ts
@@ -24,7 +24,7 @@ export const registryCategories = [
 		slug: "sign-up",
 		hidden: false,
 	},
-	{
+	/*{
 		name: "OTP",
 		slug: "otp",
 		hidden: false,
@@ -33,5 +33,5 @@ export const registryCategories = [
 		name: "Calendar",
 		slug: "calendar",
 		hidden: false,
-	},
+	},*/
 ];

--- a/docs/src/lib/registry/ui/button/button.svelte
+++ b/docs/src/lib/registry/ui/button/button.svelte
@@ -59,6 +59,7 @@
 	<a
 		bind:this={ref}
 		data-slot="button"
+		data-size={size}
 		class={cn(buttonVariants({ variant, size }), className)}
 		href={disabled ? undefined : href}
 		aria-disabled={disabled}
@@ -72,6 +73,7 @@
 	<button
 		bind:this={ref}
 		data-slot="button"
+		data-size={size}
 		class={cn(buttonVariants({ variant, size }), className)}
 		{type}
 		{disabled}

--- a/docs/src/lib/registry/ui/calendar/calendar-day.svelte
+++ b/docs/src/lib/registry/ui/calendar/calendar-day.svelte
@@ -16,7 +16,7 @@
 		"[&:last-child[data-selected=true]_button]:rounded-r-(--cell-radius)",
 		"not-data-selected:hover:bg-accent/50 not-data-selected:hover:text-accent-foreground",
 		"[&[data-today]:not([data-selected])]:bg-accent [&[data-today]:not([data-selected])]:text-accent-foreground [&[data-today][data-disabled]]:text-muted-foreground",
-		"data-[selected]:bg-primary data-[selected]:text-primary-foreground data-[selected]:hover:text-foreground",
+		"data-[selected]:bg-primary data-[selected]:text-primary-foreground",
 		// Outside months
 		"[&[data-outside-month]:not([data-selected])]:text-muted-foreground [&[data-outside-month]:not([data-selected])]:hover:text-accent-foreground",
 		// Disabled
@@ -24,7 +24,7 @@
 		// Unavailable
 		"data-[unavailable]:text-muted-foreground data-[unavailable]:line-through",
 		// focus
-		"focus:border-ring focus:ring-ring/50 focus:relative",
+		"focus:border-ring focus:ring-ring/50 focus:relative focus:z-10 focus:ring-[3px] focus:outline-none",
 		// inner spans
 		"[&>span]:text-xs [&>span]:opacity-70",
 		className

--- a/docs/src/lib/registry/ui/calendar/calendar-month-select.svelte
+++ b/docs/src/lib/registry/ui/calendar/calendar-month-select.svelte
@@ -12,12 +12,7 @@
 	}: WithoutChildrenOrChild<CalendarPrimitive.MonthSelectProps> = $props();
 </script>
 
-<span
-	class={cn(
-		"has-focus:border-ring border-input has-focus:ring-ring/50 relative flex rounded-md border shadow-xs has-focus:ring-[3px]",
-		className
-	)}
->
+<span class={cn("relative flex rounded-md", className)}>
 	<CalendarPrimitive.MonthSelect
 		bind:ref
 		class="bg-background dark:bg-popover dark:text-popover-foreground absolute inset-0 opacity-0"

--- a/docs/src/lib/registry/ui/calendar/calendar-next-button.svelte
+++ b/docs/src/lib/registry/ui/calendar/calendar-next-button.svelte
@@ -30,7 +30,7 @@
 	bind:ref
 	class={cn(
 		buttonVariants({ variant }),
-		"size-(--cell-size) bg-transparent p-0 select-none disabled:opacity-50 rtl:rotate-180",
+		"size-(--cell-size) p-0 select-none disabled:opacity-50 rtl:rotate-180",
 		className
 	)}
 	{...restProps}

--- a/docs/src/lib/registry/ui/calendar/calendar-prev-button.svelte
+++ b/docs/src/lib/registry/ui/calendar/calendar-prev-button.svelte
@@ -30,7 +30,7 @@
 	bind:ref
 	class={cn(
 		buttonVariants({ variant }),
-		"size-(--cell-size) bg-transparent p-0 select-none disabled:opacity-50 rtl:rotate-180",
+		"size-(--cell-size) p-0 select-none disabled:opacity-50 rtl:rotate-180",
 		className
 	)}
 	{...restProps}

--- a/docs/src/lib/registry/ui/calendar/calendar-year-select.svelte
+++ b/docs/src/lib/registry/ui/calendar/calendar-year-select.svelte
@@ -11,12 +11,7 @@
 	}: WithoutChildrenOrChild<CalendarPrimitive.YearSelectProps> = $props();
 </script>
 
-<span
-	class={cn(
-		"has-focus:border-ring border-input has-focus:ring-ring/50 relative flex rounded-md border shadow-xs has-focus:ring-[3px]",
-		className
-	)}
->
+<span class={cn("relative flex rounded-md", className)}>
 	<CalendarPrimitive.YearSelect
 		bind:ref
 		class="dark:bg-popover dark:text-popover-foreground absolute inset-0 opacity-0"

--- a/docs/src/lib/registry/ui/chart/easing.ts
+++ b/docs/src/lib/registry/ui/chart/easing.ts
@@ -1,0 +1,63 @@
+/**
+ * Creates a cubic-bezier easing function matching the CSS cubic-bezier() specification.
+ * Uses Newton-Raphson iteration to solve for the parametric t value.
+ */
+function createCubicBezier(x1: number, y1: number, x2: number, y2: number): (t: number) => number {
+	function A(a1: number, a2: number) {
+		return 1.0 - 3.0 * a2 + 3.0 * a1;
+	}
+	function B(a1: number, a2: number) {
+		return 3.0 * a2 - 6.0 * a1;
+	}
+	function C(a1: number) {
+		return 3.0 * a1;
+	}
+
+	function calcBezier(t: number, a1: number, a2: number) {
+		return ((A(a1, a2) * t + B(a1, a2)) * t + C(a1)) * t;
+	}
+
+	function getSlope(t: number, a1: number, a2: number) {
+		return 3.0 * A(a1, a2) * t * t + 2.0 * B(a1, a2) * t + C(a1);
+	}
+
+	return function (x: number): number {
+		if (x === 0 || x === 1) return x;
+
+		// Newton-Raphson iteration to find t for given x
+		let t = x;
+		for (let i = 0; i < 8; i++) {
+			const slope = getSlope(t, x1, x2);
+			if (slope === 0.0) break;
+			const currentX = calcBezier(t, x1, x2) - x;
+			t -= currentX / slope;
+		}
+
+		return calcBezier(t, y1, y2);
+	};
+}
+
+/**
+ * CSS `ease` easing function: cubic-bezier(0.25, 0.1, 0.25, 1.0)
+ * Gentle acceleration then strong deceleration — matches Recharts' default.
+ */
+export const ease = createCubicBezier(0.25, 0.1, 0.25, 1.0);
+
+/** Default motion config for splines, pies, arcs (1500ms) */
+export const defaultMotion = { type: "tween", duration: 1500, easing: ease } as const;
+
+/** Default motion config for bar charts (500ms per property) */
+export const defaultBarMotion = {
+	x: { type: "tween", duration: 500, easing: ease },
+	width: { type: "tween", duration: 500, easing: ease },
+	y: { type: "tween", duration: 500, easing: ease },
+	height: { type: "tween", duration: 500, easing: ease },
+} as const;
+
+/** Default motion config for ChartClipPath width animation */
+export const defaultClipMotion = {
+	width: { type: "tween", duration: 1500, easing: ease },
+} as const;
+
+/** Default tweened options for radar chart scale animation */
+export const defaultRadarScale = { duration: 1500, easing: ease } as const;

--- a/docs/src/lib/registry/ui/chart/index.ts
+++ b/docs/src/lib/registry/ui/chart/index.ts
@@ -2,5 +2,12 @@ import ChartContainer from "./chart-container.svelte";
 import ChartTooltip from "./chart-tooltip.svelte";
 
 export { getPayloadConfigFromPayload, type ChartConfig } from "./chart-utils.js";
+export {
+	ease,
+	defaultMotion,
+	defaultBarMotion,
+	defaultClipMotion,
+	defaultRadarScale,
+} from "./easing.js";
 
 export { ChartContainer, ChartTooltip, ChartContainer as Container, ChartTooltip as Tooltip };

--- a/docs/src/lib/registry/ui/menubar/menubar-content.svelte
+++ b/docs/src/lib/registry/ui/menubar/menubar-content.svelte
@@ -26,6 +26,7 @@
 		{alignOffset}
 		{side}
 		{sideOffset}
+		onOpenAutoFocus={(e) => e.preventDefault()}
 		class={cn(
 			"cn-menu-target cn-menu-translucent bg-popover text-popover-foreground ring-foreground/10 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 z-50 min-w-36 origin-(--bits-menubar-content-transform-origin) overflow-hidden rounded-lg p-1 shadow-md ring-1 duration-100",
 			className

--- a/docs/src/lib/registry/ui/pagination/pagination-next.svelte
+++ b/docs/src/lib/registry/ui/pagination/pagination-next.svelte
@@ -1,20 +1,18 @@
 <script lang="ts">
-	import type { ComponentProps } from "svelte";
+	import { Pagination as PaginationPrimitive } from "bits-ui";
 	import { cn } from "$lib/utils.js";
-	import { PaginationLink } from "./index.js";
+	import { buttonVariants } from "$lib/registry/ui/button/index.js";
 	import IconPlaceholder from "$lib/components/icon-placeholder/icon-placeholder.svelte";
 
-	type PaginationNextProps = ComponentProps<typeof PaginationLink>;
-
-	let { class: className, ...restProps }: PaginationNextProps = $props();
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: PaginationPrimitive.NextButtonProps = $props();
 </script>
 
-<PaginationLink
-	aria-label="Go to next page"
-	size="default"
-	class={cn("cn-pagination-next", className)}
-	{...restProps}
->
+{#snippet Fallback()}
 	<span class="cn-pagination-next-text hidden sm:block">Next</span>
 	<IconPlaceholder
 		lucide="ChevronRightIcon"
@@ -24,4 +22,18 @@
 		remixicon="RiArrowRightSLine"
 		data-icon="inline-end"
 	/>
-</PaginationLink>
+{/snippet}
+
+<PaginationPrimitive.NextButton
+	bind:ref
+	aria-label="Go to next page"
+	data-slot="pagination-next"
+	class={cn(buttonVariants({ variant: "ghost" }), "cn-pagination-next", className)}
+	{...restProps}
+>
+	{#if children}
+		{@render children?.()}
+	{:else}
+		{@render Fallback()}
+	{/if}
+</PaginationPrimitive.NextButton>

--- a/docs/src/lib/registry/ui/pagination/pagination-previous.svelte
+++ b/docs/src/lib/registry/ui/pagination/pagination-previous.svelte
@@ -1,20 +1,18 @@
 <script lang="ts">
-	import type { ComponentProps } from "svelte";
+	import { Pagination as PaginationPrimitive } from "bits-ui";
 	import { cn } from "$lib/utils.js";
-	import { PaginationLink } from "./index.js";
+	import { buttonVariants } from "$lib/registry/ui/button/index.js";
 	import IconPlaceholder from "$lib/components/icon-placeholder/icon-placeholder.svelte";
 
-	type PaginationPreviousProps = ComponentProps<typeof PaginationLink>;
-
-	let { class: className, ...restProps }: PaginationPreviousProps = $props();
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: PaginationPrimitive.PrevButtonProps = $props();
 </script>
 
-<PaginationLink
-	aria-label="Go to previous page"
-	size="default"
-	class={cn("cn-pagination-previous", className)}
-	{...restProps}
->
+{#snippet Fallback()}
 	<IconPlaceholder
 		lucide="ChevronLeftIcon"
 		tabler="IconChevronLeft"
@@ -24,4 +22,18 @@
 		data-icon="inline-start"
 	/>
 	<span class="cn-pagination-previous-text hidden sm:block">Previous</span>
-</PaginationLink>
+{/snippet}
+
+<PaginationPrimitive.PrevButton
+	bind:ref
+	aria-label="Go to previous page"
+	data-slot="pagination-previous"
+	class={cn(buttonVariants({ variant: "ghost" }), "cn-pagination-previous", className)}
+	{...restProps}
+>
+	{#if children}
+		{@render children?.()}
+	{:else}
+		{@render Fallback()}
+	{/if}
+</PaginationPrimitive.PrevButton>

--- a/docs/src/lib/registry/ui/range-calendar/range-calendar-day.svelte
+++ b/docs/src/lib/registry/ui/range-calendar/range-calendar-day.svelte
@@ -16,18 +16,18 @@
 		"not-data-selected:hover:bg-accent/50 not-data-selected:hover:text-accent-foreground",
 		"[&[data-today]:not([data-selected])]:bg-accent [&[data-today]:not([data-selected])]:text-accent-foreground [&[data-today][data-disabled]]:text-muted-foreground data-[range-middle]:rounded-none",
 		// range Start
-		"data-[range-start]:bg-primary data-[range-start]:text-primary-foreground data-[range-start]:hover:text-foreground",
+		"data-[range-start]:bg-primary data-[range-start]:text-primary-foreground",
 		// range End
-		"data-[range-end]:bg-primary data-[range-end]:text-primary-foreground data-[range-end]:hover:text-foreground",
+		"data-[range-end]:bg-primary data-[range-end]:text-primary-foreground",
 		// Outside months
 		"[&[data-outside-month]:not([data-selected])]:text-muted-foreground [&[data-outside-month]:not([data-selected])]:hover:text-accent-foreground",
 		// Disabled
 		"data-[disabled]:text-muted-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
 		// Unavailable
-		"data-[unavailable]:line-through",
+		"data-[unavailable]:text-muted-foreground data-[unavailable]:line-through",
 		"dark:data-[range-middle]:hover:bg-accent/0",
 		// focus
-		"focus:border-ring focus:ring-ring/50 focus:relative",
+		"focus:border-ring focus:ring-ring/50 focus:relative focus:z-10 focus:ring-[3px] focus:outline-none",
 		// inner spans
 		"[&>span]:text-xs [&>span]:opacity-70",
 		className

--- a/docs/src/lib/registry/ui/range-calendar/range-calendar-month-select.svelte
+++ b/docs/src/lib/registry/ui/range-calendar/range-calendar-month-select.svelte
@@ -14,11 +14,15 @@
 
 <span
 	class={cn(
-		"has-focus:border-ring border-input has-focus:ring-ring/50 relative flex rounded-md border shadow-xs has-focus:ring-[3px]",
+		"has-focus:border-ring has-focus:ring-ring/50 relative flex rounded-(--cell-radius) has-focus:ring-[3px]",
 		className
 	)}
 >
-	<RangeCalendarPrimitive.MonthSelect bind:ref class="absolute inset-0 opacity-0" {...restProps}>
+	<RangeCalendarPrimitive.MonthSelect
+		bind:ref
+		class="bg-popover absolute inset-0 opacity-0"
+		{...restProps}
+	>
 		{#snippet child({ props, monthItems, selectedMonthItem })}
 			<select {...props} {value} {onchange}>
 				{#each monthItems as monthItem (monthItem.value)}
@@ -33,7 +37,7 @@
 				{/each}
 			</select>
 			<span
-				class="[&>svg]:text-muted-foreground flex h-(--cell-size) items-center gap-1 rounded-md ps-2 pe-1 text-sm font-medium select-none [&>svg]:size-3.5"
+				class="[&>svg]:text-muted-foreground flex h-(--cell-size) items-center gap-1 rounded-(--cell-radius) ps-2 pe-1 text-sm font-medium select-none [&>svg]:size-3.5"
 				aria-hidden="true"
 			>
 				{monthItems.find((item) => item.value === value)?.label || selectedMonthItem.label}

--- a/docs/src/lib/registry/ui/range-calendar/range-calendar-next-button.svelte
+++ b/docs/src/lib/registry/ui/range-calendar/range-calendar-next-button.svelte
@@ -30,7 +30,7 @@
 	bind:ref
 	class={cn(
 		buttonVariants({ variant }),
-		"size-(--cell-size) bg-transparent p-0 select-none disabled:opacity-50 rtl:rotate-180",
+		"size-(--cell-size) p-0 select-none disabled:opacity-50 rtl:rotate-180",
 		className
 	)}
 	{...restProps}

--- a/docs/src/lib/registry/ui/range-calendar/range-calendar-prev-button.svelte
+++ b/docs/src/lib/registry/ui/range-calendar/range-calendar-prev-button.svelte
@@ -30,7 +30,7 @@
 	bind:ref
 	class={cn(
 		buttonVariants({ variant }),
-		"size-(--cell-size) bg-transparent p-0 select-none disabled:opacity-50 rtl:rotate-180",
+		"size-(--cell-size) p-0 select-none disabled:opacity-50 rtl:rotate-180",
 		className
 	)}
 	{...restProps}

--- a/docs/src/lib/registry/ui/range-calendar/range-calendar-year-select.svelte
+++ b/docs/src/lib/registry/ui/range-calendar/range-calendar-year-select.svelte
@@ -13,11 +13,15 @@
 
 <span
 	class={cn(
-		"has-focus:border-ring border-input has-focus:ring-ring/50 relative flex rounded-md border shadow-xs has-focus:ring-[3px]",
+		"has-focus:border-ring has-focus:ring-ring/50 relative flex rounded-(--cell-radius) has-focus:ring-[3px]",
 		className
 	)}
 >
-	<RangeCalendarPrimitive.YearSelect bind:ref class="absolute inset-0 opacity-0" {...restProps}>
+	<RangeCalendarPrimitive.YearSelect
+		bind:ref
+		class="bg-popover absolute inset-0 opacity-0"
+		{...restProps}
+	>
 		{#snippet child({ props, yearItems, selectedYearItem })}
 			<select {...props} {value}>
 				{#each yearItems as yearItem (yearItem.value)}
@@ -32,7 +36,7 @@
 				{/each}
 			</select>
 			<span
-				class="[&>svg]:text-muted-foreground flex h-(--cell-size) items-center gap-1 rounded-md ps-2 pe-1 text-sm font-medium select-none [&>svg]:size-3.5"
+				class="[&>svg]:text-muted-foreground flex h-(--cell-size) items-center gap-1 rounded-(--cell-radius) ps-2 pe-1 text-sm font-medium select-none [&>svg]:size-3.5"
 				aria-hidden="true"
 			>
 				{yearItems.find((item) => item.value === value)?.label || selectedYearItem.label}

--- a/docs/src/lib/registry/ui/resizable/index.ts
+++ b/docs/src/lib/registry/ui/resizable/index.ts
@@ -10,4 +10,9 @@ export {
 	PaneGroup as ResizablePaneGroup,
 	Pane as ResizablePane,
 	Handle as ResizableHandle,
+	//
+	PaneGroup as PanelGroup,
+	Pane as Panel,
+	Pane as ResizablePanel,
+	PaneGroup as ResizablePanelGroup,
 };

--- a/docs/src/lib/registry/ui/resizable/resizable-pane-group.svelte
+++ b/docs/src/lib/registry/ui/resizable/resizable-pane-group.svelte
@@ -6,10 +6,16 @@
 		ref = $bindable(null),
 		this: paneGroup = $bindable(),
 		class: className,
+		orientation,
+		direction,
 		...restProps
-	}: ResizablePrimitive.PaneGroupProps & {
+	}: Omit<ResizablePrimitive.PaneGroupProps, "direction"> & {
 		this?: ResizablePrimitive.PaneGroup;
+		direction?: ResizablePrimitive.PaneGroupProps["direction"];
+		orientation?: "horizontal" | "vertical";
 	} = $props();
+
+	const resolvedDirection = $derived(orientation ?? direction ?? "horizontal");
 </script>
 
 <ResizablePrimitive.PaneGroup
@@ -20,5 +26,6 @@
 		"cn-resizable-panel-group flex h-full w-full data-[direction=vertical]:flex-col",
 		className
 	)}
+	direction={resolvedDirection}
 	{...restProps}
 />

--- a/docs/src/lib/registry/ui/separator/separator.svelte
+++ b/docs/src/lib/registry/ui/separator/separator.svelte
@@ -14,9 +14,7 @@
 	bind:ref
 	data-slot={dataSlot}
 	class={cn(
-		"bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px",
-		// this is different in shadcn/ui but self-stretch breaks things for us
-		"data-[orientation=vertical]:h-full",
+		"bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px data-[orientation=vertical]:self-stretch",
 		className
 	)}
 	{...restProps}

--- a/docs/src/lib/registry/ui/toggle-group/toggle-group.svelte
+++ b/docs/src/lib/registry/ui/toggle-group/toggle-group.svelte
@@ -66,6 +66,7 @@ get along, so we shut typescript up by casting `value` to `never`.
 	data-variant={variant}
 	data-size={size}
 	data-spacing={spacing}
+	data-orientation={orientation}
 	style={`--gap: ${spacing}`}
 	class={cn(
 		"cn-toggle-group group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] data-vertical:flex-col data-vertical:items-stretch",


### PR DESCRIPTION
⚠️ **AI-generated description — will be updated before merge.**

## Summary

#2641 
- Updates to `calendar` and `range-calendar` sub-components (day, month-select, year-select, nav buttons)
- Adds `easing.ts` to chart UI and updates chart `index.ts`
- Updates `menubar-content`, `pagination-next/previous`, `progress-label/track` (new files), `resizable-pane-group`, `separator`, `toggle-group`
- Updates `registry-categories.ts` with new category definitions

## Test plan

- [ ] `pnpm --filter docs check` passes with 0 errors
- [ ] Calendar, chart, pagination, progress, and resizable components render correctly