### PR TITLE
Fix : bad render of NativeSelect.Option in dark mode

### DIFF
--- a/docs/src/lib/registry/ui/native-select/native-select-option.svelte
+++ b/docs/src/lib/registry/ui/native-select/native-select-option.svelte
@@ -13,10 +13,7 @@
 <option
 	bind:this={ref}
 	data-slot="native-select-option"
-	class={cn(
-		"bg-[Canvas] text-[CanvasText]",
-		className
-	)}
+	class={cn("bg-[Canvas] text-[CanvasText]", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/docs/src/lib/registry/ui/native-select/native-select-option.svelte
+++ b/docs/src/lib/registry/ui/native-select/native-select-option.svelte
@@ -1,14 +1,23 @@
 <script lang="ts">
 	import type { HTMLOptionAttributes } from "svelte/elements";
-	import type { WithElementRef } from "$lib/utils.js";
+	import { cn, type WithElementRef } from "$lib/utils.js";
 
 	let {
 		ref = $bindable(null),
+		class: className,
 		children,
 		...restProps
 	}: WithElementRef<HTMLOptionAttributes> = $props();
 </script>
 
-<option bind:this={ref} data-slot="native-select-option" {...restProps}>
+<option
+	bind:this={ref}
+	data-slot="native-select-option"
+	class={cn(
+		"bg-[Canvas] text-[CanvasText]",
+		className
+	)}
+	{...restProps}
+>
 	{@render children?.()}
 </option>


### PR DESCRIPTION
Fixing NativeSelect.Option that was rendering badly in dark mode by adding : "bg-[Canvas] text-[CanvasText]" (getting this from shadcn)

<!--
### Before submitting the PR, please make sure you do the following

- Read the [contributing guidelines](https://github.com/huntabyte/shadcn-svelte/blob/main/CONTRIBUTING.md)
- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
-->
