### PR TITLE
fix: demo number input docs homepage wrong height

### DIFF
--- a/docs/src/lib/components/cards/appearance-settings.svelte
+++ b/docs/src/lib/components/cards/appearance-settings.svelte
@@ -97,7 +97,7 @@
 					id="number-of-gpus-f6l"
 					bind:value={gpuCount}
 					size={3}
-					class="font-mono"
+					class="style-luma:h-8 style-vega:h-8 style-maia:h-8 style-lyra:h-7 style-nova:h-7 style-mira:h-6 style-sera:h-9 font-mono"
 					maxlength={3}
 					oninput={handleGpuCountChange}
 					type="text"


### PR DESCRIPTION
Demo number input in the docs homepage wasn't the same height as the plus and minus buttons.

The fix:
From this:
<img width="392" height="110" alt="image" src="https://github.com/user-attachments/assets/81c856de-8c8c-448b-b103-f5bcdc4bd58d" />

To this:
<img width="372" height="95" alt="image" src="https://github.com/user-attachments/assets/f3f903f9-7da3-4b3f-8ed2-5db821682016" />