### PR TITLE
fix: demo number input docs homepage wrong height

### DIFF
--- a/docs/src/lib/components/cards/appearance-settings.svelte
+++ b/docs/src/lib/components/cards/appearance-settings.svelte
@@ -97,7 +97,7 @@
 					id="number-of-gpus-f6l"
 					bind:value={gpuCount}
 					size={3}
-					class="font-mono"
+					class="style-luma:h-8 style-vega:h-8 style-maia:h-8 style-lyra:h-7 style-nova:h-7 style-mira:h-6 style-sera:h-9 font-mono"
 					maxlength={3}
 					oninput={handleGpuCountChange}
 					type="text"


### PR DESCRIPTION
Demo number input in the docs homepage wasn't the same height as the plus and minus buttons.

The fix:
From this:
<img width="369" height="89" alt="image" src="https://github.com/user-attachments/assets/e62a8632-544b-4d97-b967-ce60a3e41a23" />

To this:
<img width="369" height="86" alt="image" src="https://github.com/user-attachments/assets/a5d82933-e1af-42f6-97c8-9a3b15daecaa" />

