### PR TITLE
fix: Sidebar cookie name breaks strict cookie parsers (#2696)

### DIFF
--- a/docs/src/lib/registry/ui/sidebar/constants.ts
+++ b/docs/src/lib/registry/ui/sidebar/constants.ts
@@ -1,4 +1,4 @@
-export const SIDEBAR_COOKIE_NAME = "sidebar:state";
+export const SIDEBAR_COOKIE_NAME = "sidebar_state";
 export const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 export const SIDEBAR_WIDTH = "16rem";
 export const SIDEBAR_WIDTH_MOBILE = "18rem";

--- a/docs/static/registry/styles/luma/sidebar.json
+++ b/docs/static/registry/styles/luma/sidebar.json
@@ -18,7 +18,7 @@
 	],
 	"files": [
 		{
-			"content": "export const SIDEBAR_COOKIE_NAME = \"sidebar:state\";\nexport const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;\nexport const SIDEBAR_WIDTH = \"16rem\";\nexport const SIDEBAR_WIDTH_MOBILE = \"18rem\";\nexport const SIDEBAR_WIDTH_ICON = \"3rem\";\nexport const SIDEBAR_KEYBOARD_SHORTCUT = \"b\";\n",
+			"content": "export const SIDEBAR_COOKIE_NAME = \"sidebar_state\";\nexport const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;\nexport const SIDEBAR_WIDTH = \"16rem\";\nexport const SIDEBAR_WIDTH_MOBILE = \"18rem\";\nexport const SIDEBAR_WIDTH_ICON = \"3rem\";\nexport const SIDEBAR_KEYBOARD_SHORTCUT = \"b\";\n",
 			"type": "registry:file",
 			"target": "sidebar/constants.ts"
 		},

--- a/docs/static/registry/styles/lyra/sidebar.json
+++ b/docs/static/registry/styles/lyra/sidebar.json
@@ -18,7 +18,7 @@
 	],
 	"files": [
 		{
-			"content": "export const SIDEBAR_COOKIE_NAME = \"sidebar:state\";\nexport const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;\nexport const SIDEBAR_WIDTH = \"16rem\";\nexport const SIDEBAR_WIDTH_MOBILE = \"18rem\";\nexport const SIDEBAR_WIDTH_ICON = \"3rem\";\nexport const SIDEBAR_KEYBOARD_SHORTCUT = \"b\";\n",
+			"content": "export const SIDEBAR_COOKIE_NAME = \"sidebar_state\";\nexport const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;\nexport const SIDEBAR_WIDTH = \"16rem\";\nexport const SIDEBAR_WIDTH_MOBILE = \"18rem\";\nexport const SIDEBAR_WIDTH_ICON = \"3rem\";\nexport const SIDEBAR_KEYBOARD_SHORTCUT = \"b\";\n",
 			"type": "registry:file",
 			"target": "sidebar/constants.ts"
 		},

--- a/docs/static/registry/styles/maia/sidebar.json
+++ b/docs/static/registry/styles/maia/sidebar.json
@@ -18,7 +18,7 @@
 	],
 	"files": [
 		{
-			"content": "export const SIDEBAR_COOKIE_NAME = \"sidebar:state\";\nexport const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;\nexport const SIDEBAR_WIDTH = \"16rem\";\nexport const SIDEBAR_WIDTH_MOBILE = \"18rem\";\nexport const SIDEBAR_WIDTH_ICON = \"3rem\";\nexport const SIDEBAR_KEYBOARD_SHORTCUT = \"b\";\n",
+			"content": "export const SIDEBAR_COOKIE_NAME = \"sidebar_state\";\nexport const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;\nexport const SIDEBAR_WIDTH = \"16rem\";\nexport const SIDEBAR_WIDTH_MOBILE = \"18rem\";\nexport const SIDEBAR_WIDTH_ICON = \"3rem\";\nexport const SIDEBAR_KEYBOARD_SHORTCUT = \"b\";\n",
 			"type": "registry:file",
 			"target": "sidebar/constants.ts"
 		},

--- a/docs/static/registry/styles/mira/sidebar.json
+++ b/docs/static/registry/styles/mira/sidebar.json
@@ -18,7 +18,7 @@
 	],
 	"files": [
 		{
-			"content": "export const SIDEBAR_COOKIE_NAME = \"sidebar:state\";\nexport const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;\nexport const SIDEBAR_WIDTH = \"16rem\";\nexport const SIDEBAR_WIDTH_MOBILE = \"18rem\";\nexport const SIDEBAR_WIDTH_ICON = \"3rem\";\nexport const SIDEBAR_KEYBOARD_SHORTCUT = \"b\";\n",
+			"content": "export const SIDEBAR_COOKIE_NAME = \"sidebar_state\";\nexport const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;\nexport const SIDEBAR_WIDTH = \"16rem\";\nexport const SIDEBAR_WIDTH_MOBILE = \"18rem\";\nexport const SIDEBAR_WIDTH_ICON = \"3rem\";\nexport const SIDEBAR_KEYBOARD_SHORTCUT = \"b\";\n",
 			"type": "registry:file",
 			"target": "sidebar/constants.ts"
 		},

--- a/docs/static/registry/styles/nova/sidebar.json
+++ b/docs/static/registry/styles/nova/sidebar.json
@@ -18,7 +18,7 @@
 	],
 	"files": [
 		{
-			"content": "export const SIDEBAR_COOKIE_NAME = \"sidebar:state\";\nexport const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;\nexport const SIDEBAR_WIDTH = \"16rem\";\nexport const SIDEBAR_WIDTH_MOBILE = \"18rem\";\nexport const SIDEBAR_WIDTH_ICON = \"3rem\";\nexport const SIDEBAR_KEYBOARD_SHORTCUT = \"b\";\n",
+			"content": "export const SIDEBAR_COOKIE_NAME = \"sidebar_state\";\nexport const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;\nexport const SIDEBAR_WIDTH = \"16rem\";\nexport const SIDEBAR_WIDTH_MOBILE = \"18rem\";\nexport const SIDEBAR_WIDTH_ICON = \"3rem\";\nexport const SIDEBAR_KEYBOARD_SHORTCUT = \"b\";\n",
 			"type": "registry:file",
 			"target": "sidebar/constants.ts"
 		},

--- a/docs/static/registry/styles/sera/sidebar.json
+++ b/docs/static/registry/styles/sera/sidebar.json
@@ -18,7 +18,7 @@
 	],
 	"files": [
 		{
-			"content": "export const SIDEBAR_COOKIE_NAME = \"sidebar:state\";\nexport const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;\nexport const SIDEBAR_WIDTH = \"16rem\";\nexport const SIDEBAR_WIDTH_MOBILE = \"18rem\";\nexport const SIDEBAR_WIDTH_ICON = \"3rem\";\nexport const SIDEBAR_KEYBOARD_SHORTCUT = \"b\";\n",
+			"content": "export const SIDEBAR_COOKIE_NAME = \"sidebar_state\";\nexport const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;\nexport const SIDEBAR_WIDTH = \"16rem\";\nexport const SIDEBAR_WIDTH_MOBILE = \"18rem\";\nexport const SIDEBAR_WIDTH_ICON = \"3rem\";\nexport const SIDEBAR_KEYBOARD_SHORTCUT = \"b\";\n",
 			"type": "registry:file",
 			"target": "sidebar/constants.ts"
 		},

--- a/docs/static/registry/styles/vega/sidebar.json
+++ b/docs/static/registry/styles/vega/sidebar.json
@@ -18,7 +18,7 @@
 	],
 	"files": [
 		{
-			"content": "export const SIDEBAR_COOKIE_NAME = \"sidebar:state\";\nexport const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;\nexport const SIDEBAR_WIDTH = \"16rem\";\nexport const SIDEBAR_WIDTH_MOBILE = \"18rem\";\nexport const SIDEBAR_WIDTH_ICON = \"3rem\";\nexport const SIDEBAR_KEYBOARD_SHORTCUT = \"b\";\n",
+			"content": "export const SIDEBAR_COOKIE_NAME = \"sidebar_state\";\nexport const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;\nexport const SIDEBAR_WIDTH = \"16rem\";\nexport const SIDEBAR_WIDTH_MOBILE = \"18rem\";\nexport const SIDEBAR_WIDTH_ICON = \"3rem\";\nexport const SIDEBAR_KEYBOARD_SHORTCUT = \"b\";\n",
 			"type": "registry:file",
 			"target": "sidebar/constants.ts"
 		},


### PR DESCRIPTION
<!--
### Before submitting the PR, please make sure you do the following - Read the [contributing guidelines](https://github.com/huntabyte/shadcn-svelte/blob/main/CONTRIBUTING.md)
- If your PR isn't addressing a small fix (like a typo), it references an issue where it is discussed ahead of time and assigned to you. In many cases, features are absent for a reason.
- Prefix your PR title with `feat:`, `fix:`, `chore:`, or `docs:`.
- This message body should clearly illustrate what problems it solves.
- Format & lint the code with `pnpm format` and `pnpm lint`
--> Closes #2696 ## Problem `SIDEBAR_COOKIE_NAME` was set to `"sidebar:state"`, but a colon is a separator under RFC 6265/2616, so strict server-side cookie parsers (e.g. Go's `http.ParseCookie`) reject the header. The docs site itself was already working around this in `+layout.server.ts` by reading `sidebar_state`. ## Fix Renamed `SIDEBAR_COOKIE_NAME` to `"sidebar_state"` in `docs/src/lib/registry/ui/sidebar/constants.ts`. Running `pnpm build:registry` propagated the change into the generated `docs/static/registry/styles/*/sidebar.json` files.