### PR TITLE
chore: migrate CF Pages deploys to cloudflare/wrangler-action

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -27,11 +27,9 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Deploy to Cloudflare Pages
-        uses: AdrianGonz97/refined-cf-pages-action@v1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-          projectName: shadcn-svelte
-          deploymentName: Preview
-          directory: ${{ steps.preview-build-artifact.outputs.download-path }}/cloudflare
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          command: pages deploy ${{ steps.preview-build-artifact.outputs.download-path }}/cloudflare --project-name=shadcn-svelte

--- a/.github/workflows/deploy-svelte-4.yml
+++ b/.github/workflows/deploy-svelte-4.yml
@@ -32,12 +32,10 @@ jobs:
         run: pnpm build
 
       - name: Deploy to Cloudflare Pages
-        uses: AdrianGonz97/refined-cf-pages-action@v1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-          projectName: shadcn-svelte
-          directory: ./.svelte-kit/cloudflare
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
           workingDirectory: sites/docs
-          branch: ${{ github.ref_name }}
+          command: pages deploy ./.svelte-kit/cloudflare --project-name=shadcn-svelte --branch=${{ github.ref_name }}

--- a/.github/workflows/deploy-tailwind-3.yml
+++ b/.github/workflows/deploy-tailwind-3.yml
@@ -33,12 +33,10 @@ jobs:
         run: pnpm build
 
       - name: Deploy to Cloudflare Pages
-        uses: AdrianGonz97/refined-cf-pages-action@v1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-          projectName: shadcn-svelte-tw-3
-          directory: ./.svelte-kit/cloudflare
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
           workingDirectory: sites/docs
-          deploymentName: Production Tailwind 3
+          command: pages deploy ./.svelte-kit/cloudflare --project-name=shadcn-svelte-tw-3


### PR DESCRIPTION
`AdrianGonz97/refined-cf-pages-action` is [deprecated](https://github.com/marketplace/actions/cloudflare-pages-github-action). Replaces it with the official `cloudflare/wrangler-action@v3` using `wrangler pages deploy` across the preview, svelte-4, and tailwind-3 deploy workflows.