### PR TITLE
fix(tabs): use `data-[state=active]` instead of `data-active` in tabs-trigger

### DIFF
--- a/docs/src/lib/registry/styles/style-nova.css
+++ b/docs/src/lib/registry/styles/style-nova.css
@@ -1242,7 +1242,7 @@
 	}
 
 	.cn-tabs-trigger {
-		@apply gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg:not([class*='size-'])]:size-4;
+		@apply gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none [&_svg:not([class*='size-'])]:size-4;
 	}
 
 	.cn-tabs-content {

--- a/docs/src/lib/registry/styles/style-vega.css
+++ b/docs/src/lib/registry/styles/style-vega.css
@@ -1238,7 +1238,7 @@
 	}
 
 	.cn-tabs-trigger {
-		@apply gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg:not([class*='size-'])]:size-4;
+		@apply gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none [&_svg:not([class*='size-'])]:size-4;
 	}
 
 	.cn-tabs-content {

--- a/docs/src/lib/registry/ui/tabs/tabs-trigger.svelte
+++ b/docs/src/lib/registry/ui/tabs/tabs-trigger.svelte
@@ -14,9 +14,9 @@
 	data-slot="tabs-trigger"
 	class={cn(
 		"cn-tabs-trigger focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center whitespace-nowrap transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-		"group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
-		"data-active:bg-background dark:data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 data-active:text-foreground",
-		"after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+		"group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
+		"data-[state=active]:bg-background dark:data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 data-[state=active]:text-foreground",
+		"after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
 		className
 	)}
 	{...restProps}


### PR DESCRIPTION
bits-ui sets `data-state="active"` on the active tab trigger, not a boolean `data-active` attribute. The Tailwind `data-active:` shorthand therefore never matches, silently breaking all active-state styles (background, text color, shadow, line indicator).

This PR replaces all `data-active:` with `data-[state=active]:` in:

- `docs/src/lib/registry/ui/tabs/tabs-trigger.svelte`
- `docs/src/lib/registry/styles/style-nova.css` (`.cn-tabs-trigger` shadow rules)
- `docs/src/lib/registry/styles/style-vega.css` (`.cn-tabs-trigger` shadow rules)

Note: [`doc-tabs-trigger.svelte`](https://github.com/huntabyte/shadcn-svelte/blob/main/docs/src/lib/components/doc-tabs/doc-tabs-trigger.svelte) already uses `data-[state=active]` correctly, so this appears to be an oversight in the registry component and two style files only.

Closes #2706