### PR TITLE
fix(tabs): use `data-[orientation=horizontal/vertical]` instead of `data-horizontal/vertical` in style CSS

### DIFF
--- a/docs/src/lib/registry/styles/style-luma.css
+++ b/docs/src/lib/registry/styles/style-luma.css
@@ -387,11 +387,11 @@
 	}
 
 	.cn-tabs-list {
-		@apply rounded-full p-1 group-data-horizontal/tabs:h-9 group-data-vertical/tabs:rounded-2xl data-[variant=line]:rounded-none;
+		@apply rounded-full p-1 group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:rounded-2xl data-[variant=line]:rounded-none;
 	}
 
 	.cn-tabs-trigger {
-		@apply gap-2 rounded-full border border-transparent! px-3 py-1 text-sm font-medium group-data-vertical/tabs:rounded-2xl group-data-vertical/tabs:px-3 group-data-vertical/tabs:py-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 [&_svg:not([class*='size-'])]:size-4;
+		@apply gap-2 rounded-full border border-transparent! px-3 py-1 text-sm font-medium group-data-[orientation=vertical]/tabs:rounded-2xl group-data-[orientation=vertical]/tabs:px-3 group-data-[orientation=vertical]/tabs:py-1.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 [&_svg:not([class*='size-'])]:size-4;
 	}
 
 	.cn-tabs-content {

--- a/docs/src/lib/registry/styles/style-lyra.css
+++ b/docs/src/lib/registry/styles/style-lyra.css
@@ -1213,11 +1213,11 @@
 	}
 
 	.cn-tabs-list {
-		@apply rounded-none p-[3px] group-data-horizontal/tabs:h-8 data-[variant=line]:rounded-none;
+		@apply rounded-none p-[3px] group-data-[orientation=horizontal]/tabs:h-8 data-[variant=line]:rounded-none;
 	}
 
 	.cn-tabs-trigger {
-		@apply gap-1.5 rounded-none border border-transparent px-1.5 py-0.5 text-xs font-medium group-data-vertical/tabs:py-[calc(--spacing(1.25))] has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 [&_svg:not([class*='size-'])]:size-4;
+		@apply gap-1.5 rounded-none border border-transparent px-1.5 py-0.5 text-xs font-medium group-data-[orientation=vertical]/tabs:py-[calc(--spacing(1.25))] has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 [&_svg:not([class*='size-'])]:size-4;
 	}
 
 	.cn-tabs-content {

--- a/docs/src/lib/registry/styles/style-maia.css
+++ b/docs/src/lib/registry/styles/style-maia.css
@@ -1238,11 +1238,11 @@
 	}
 
 	.cn-tabs-list {
-		@apply rounded-4xl p-[3px] group-data-horizontal/tabs:h-9 group-data-vertical/tabs:rounded-2xl data-[variant=line]:rounded-none;
+		@apply rounded-4xl p-[3px] group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:rounded-2xl data-[variant=line]:rounded-none;
 	}
 
 	.cn-tabs-trigger {
-		@apply gap-1.5 rounded-xl border border-transparent px-2 py-1 text-sm font-medium group-data-vertical/tabs:px-2.5 group-data-vertical/tabs:py-1.5 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-4;
+		@apply gap-1.5 rounded-xl border border-transparent px-2 py-1 text-sm font-medium group-data-[orientation=vertical]/tabs:px-2.5 group-data-[orientation=vertical]/tabs:py-1.5 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-4;
 	}
 
 	.cn-tabs-content {

--- a/docs/src/lib/registry/styles/style-mira.css
+++ b/docs/src/lib/registry/styles/style-mira.css
@@ -1240,11 +1240,11 @@
 	}
 
 	.cn-tabs-list {
-		@apply rounded-lg p-[3px] group-data-horizontal/tabs:h-8 data-[variant=line]:rounded-none;
+		@apply rounded-lg p-[3px] group-data-[orientation=horizontal]/tabs:h-8 data-[variant=line]:rounded-none;
 	}
 
 	.cn-tabs-trigger {
-		@apply gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-xs font-medium group-data-vertical/tabs:py-[calc(--spacing(1.25))] has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 [&_svg:not([class*='size-'])]:size-3.5;
+		@apply gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-xs font-medium group-data-[orientation=vertical]/tabs:py-[calc(--spacing(1.25))] has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 [&_svg:not([class*='size-'])]:size-3.5;
 	}
 
 	.cn-tabs-content {

--- a/docs/src/lib/registry/styles/style-nova.css
+++ b/docs/src/lib/registry/styles/style-nova.css
@@ -1238,7 +1238,7 @@
 	}
 
 	.cn-tabs-list {
-		@apply rounded-lg p-[3px] group-data-horizontal/tabs:h-8 data-[variant=line]:rounded-none;
+		@apply rounded-lg p-[3px] group-data-[orientation=horizontal]/tabs:h-8 data-[variant=line]:rounded-none;
 	}
 
 	.cn-tabs-trigger {

--- a/docs/src/lib/registry/styles/style-sera.css
+++ b/docs/src/lib/registry/styles/style-sera.css
@@ -1229,11 +1229,11 @@
 	}
 
 	.cn-tabs-list {
-		@apply p-1 group-data-horizontal/tabs:h-10;
+		@apply p-1 group-data-[orientation=horizontal]/tabs:h-10;
 	}
 
 	.cn-tabs-trigger {
-		@apply gap-2 border border-transparent px-4 py-1.5 text-xs font-semibold tracking-wider uppercase group-data-vertical/tabs:px-4 group-data-vertical/tabs:py-2 has-data-[icon=inline-end]:pr-2.5 has-data-[icon=inline-start]:pl-2.5 [&_svg:not([class*='size-'])]:size-3.5;
+		@apply gap-2 border border-transparent px-4 py-1.5 text-xs font-semibold tracking-wider uppercase group-data-[orientation=vertical]/tabs:px-4 group-data-[orientation=vertical]/tabs:py-2 has-data-[icon=inline-end]:pr-2.5 has-data-[icon=inline-start]:pl-2.5 [&_svg:not([class*='size-'])]:size-3.5;
 	}
 
 	.cn-tabs-content {

--- a/docs/src/lib/registry/styles/style-vega.css
+++ b/docs/src/lib/registry/styles/style-vega.css
@@ -1234,7 +1234,7 @@
 	}
 
 	.cn-tabs-list {
-		@apply rounded-lg p-[3px] group-data-horizontal/tabs:h-9 data-[variant=line]:rounded-none;
+		@apply rounded-lg p-[3px] group-data-[orientation=horizontal]/tabs:h-9 data-[variant=line]:rounded-none;
 	}
 
 	.cn-tabs-trigger {


### PR DESCRIPTION
The style CSS files use `group-data-horizontal/tabs` and `group-data-vertical/tabs` shorthands in `.cn-tabs-list` and `.cn-tabs-trigger` classes. These match boolean `data-horizontal` / `data-vertical` attributes, but bits-ui sets `data-orientation="horizontal"` / `data-orientation="vertical"` on the Tabs root.

This PR replaces them with `group-data-[orientation=horizontal]/tabs` and `group-data-[orientation=vertical]/tabs` to match the actual attribute.

The `.svelte` component files (`tabs.svelte`, `tabs-list.svelte`, `tabs-trigger.svelte`) already use the correct `group-data-[orientation=horizontal]/tabs` and `group-data-[orientation=vertical]/tabs` form, so this is an inconsistency in the CSS styles only.

### Affected files

All 7 style files — `.cn-tabs-list` and `.cn-tabs-trigger` rules:

- `style-luma.css`
- `style-lyra.css`
- `style-maia.css`
- `style-mira.css`
- `style-nova.css`
- `style-sera.css`
- `style-vega.css`