### PR TITLE
docs: fix grammar in empty component

### DIFF
--- a/docs/content/components/empty.md
+++ b/docs/content/components/empty.md
@@ -1,6 +1,6 @@
 ---
 title: Empty
-description: Use the Empty component to display a empty state.
+description: Use the Empty component to display an empty state.
 component: true
 links:
   source: https://github.com/huntabyte/shadcn-svelte/tree/next/sites/docs/src/lib/registry/ui/empty
@@ -74,7 +74,7 @@ Copy and paste the following code into your project.
 
 ### Outline
 
-Use the `border` utility class to create a outline empty state.
+Use the `border` utility class to create an outline empty state.
 
 <ComponentPreview name="empty-outline-demo">
 


### PR DESCRIPTION
This is my first PR, I hope it's descriptive enough for such a simple grammatical error. While looking at the empty component docs, I noticed 2 small grammar errors: "a empty state" should be "an empty state", "a outline" -> "an outline".