### PR TITLE
fix(docs): resolve Svelte 5 state_referenced_locally warning in form example

### DIFF
--- a/docs/content/components/form.md
+++ b/docs/content/components/form.md
@@ -122,10 +122,10 @@ For this example, we'll be passing the `form` returned from the load function as
   } from "sveltekit-superforms";
   import { zod4Client } from "sveltekit-superforms/adapters";
 
-  let { data }: { data: { form: SuperValidated<Infer<FormSchema>> } } =
+  let { form: initialForm }: { form: SuperValidated<Infer<FormSchema>> } =
     $props();
 
-  const form = superForm(data.form, {
+  const form = superForm(initialForm, {
     validators: zod4Client(formSchema),
   });
 
@@ -160,7 +160,7 @@ We'll pass the `form` from the data returned from the load function to the form 
   let { data }: { data: PageData } = $props();
 </script>
 
-<SettingsForm {data} />
+<SettingsForm form={data.form} />
 ```
 
 ### Create an Action


### PR DESCRIPTION
## What

The `settings-form.svelte` code snippet in the Form docs was accepting `data` as a prop and passing `data.form` directly to `superForm()`, triggering this Svelte 5 compiler warning:

> This reference only captures the initial value of `data`. Did you mean to reference it inside a closure instead?
> https://svelte.dev/e/state_referenced_locally

## Fix

Change the prop to accept `form` directly (renamed to `initialForm` to avoid shadowing the `superForm()` return value), and update the `+page.svelte` snippet to pass `form={data.form}` accordingly.

This also aligns the code with the prose description on the same page, which already said *"we'll be passing the `form` returned from the load function as a prop"* — the old code was passing the entire `data` object instead.

## Changes

- `docs/content/components/form.md` — 3 line changes, docs only

Closes #2651