### PR TITLE
Prevent select item text wrapping

### DIFF
--- a/docs/src/lib/registry/ui/select/select-item.svelte
+++ b/docs/src/lib/registry/ui/select/select-item.svelte
@@ -36,10 +36,12 @@
 				/>
 			{/if}
 		</span>
-		{#if childrenProp}
-			{@render childrenProp({ selected, highlighted })}
-		{:else}
-			{label || value}
-		{/if}
+		<span class="cn-select-item-text shrink-0 whitespace-nowrap">
+			{#if childrenProp}
+				{@render childrenProp({ selected, highlighted })}
+			{:else}
+				{label || value}
+			{/if}
+		</span>
 	{/snippet}
 </SelectPrimitive.Item>


### PR DESCRIPTION
## Summary

- wrap select item content in a text span
- add `shrink-0 whitespace-nowrap` to keep long item labels on one line

Fixes #2730

## Testing

- `pnpm -F docs check`
