### PR TITLE
fix(docs): fix create picker submenu contrast

### DIFF
--- a/docs/src/routes/(app)/(layout)/(create)/components/picker/picker-item.svelte
+++ b/docs/src/routes/(app)/(layout)/(create)/components/picker/picker-item.svelte
@@ -18,7 +18,7 @@
 	data-inset={inset}
 	data-variant={variant}
 	class={cn(
-		"group/dropdown-menu-item relative flex cursor-default items-center gap-2 rounded-lg px-2 py-1.5 text-sm font-medium outline-hidden select-none **:text-neutral-100 focus:bg-neutral-600 focus:text-neutral-100 focus:**:text-neutral-100 data-disabled:pointer-events-none data-disabled:opacity-50 data-inset:pl-8 dark:focus:bg-neutral-700/80 pointer-coarse:gap-3 pointer-coarse:py-2.5 pointer-coarse:pl-3 pointer-coarse:text-base [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+		"group/dropdown-menu-item [[data-slot=dropdown-menu-sub-content]_&]:focus:bg-accent [[data-slot=dropdown-menu-sub-content]_&]:focus:text-accent-foreground [[data-slot=dropdown-menu-sub-content]_&]:focus:**:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-lg px-2 py-1.5 text-sm font-medium outline-hidden select-none focus:bg-neutral-600 focus:text-neutral-100 focus:**:text-neutral-100 data-disabled:pointer-events-none data-disabled:opacity-50 data-inset:pl-8 dark:focus:bg-neutral-700/80 pointer-coarse:gap-3 pointer-coarse:py-2.5 pointer-coarse:pl-3 pointer-coarse:text-base [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 		className
 	)}
 	{...restProps}

--- a/docs/src/routes/(app)/(layout)/(create)/components/picker/picker-radio-item.svelte
+++ b/docs/src/routes/(app)/(layout)/(create)/components/picker/picker-radio-item.svelte
@@ -15,7 +15,7 @@
 	bind:ref
 	data-slot="dropdown-menu-radio-item"
 	class={cn(
-		"relative flex cursor-default items-center gap-2 rounded-lg py-1.5 pr-8 pl-2 text-sm font-medium outline-hidden select-none **:text-neutral-100 focus:bg-neutral-600 focus:text-neutral-100 focus:**:text-neutral-100 data-disabled:pointer-events-none data-disabled:opacity-50 data-inset:pl-8 dark:focus:bg-neutral-700/80 pointer-coarse:gap-3 pointer-coarse:py-2.5 pointer-coarse:pl-3 pointer-coarse:text-base [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+		"[[data-slot=dropdown-menu-sub-content]_&]:focus:bg-accent [[data-slot=dropdown-menu-sub-content]_&]:focus:text-accent-foreground [[data-slot=dropdown-menu-sub-content]_&]:focus:**:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-lg py-1.5 pr-8 pl-2 text-sm font-medium outline-hidden select-none focus:bg-neutral-600 focus:text-neutral-100 focus:**:text-neutral-100 data-disabled:pointer-events-none data-disabled:opacity-50 data-inset:pl-8 dark:focus:bg-neutral-700/80 pointer-coarse:gap-3 pointer-coarse:py-2.5 pointer-coarse:pl-3 pointer-coarse:text-base [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 		className
 	)}
 	{...restProps}

--- a/docs/src/routes/(app)/(layout)/(create)/components/picker/picker-separator.svelte
+++ b/docs/src/routes/(app)/(layout)/(create)/components/picker/picker-separator.svelte
@@ -12,6 +12,9 @@
 <DropdownMenuPrimitive.Separator
 	bind:ref
 	data-slot="dropdown-menu-separator"
-	class={cn("-mx-1.5 my-1.5 h-px bg-neutral-600 dark:bg-neutral-700", className)}
+	class={cn(
+		"[[data-slot=dropdown-menu-sub-content]_&]:bg-border -mx-1.5 my-1.5 h-px bg-neutral-600 dark:bg-neutral-700",
+		className
+	)}
 	{...restProps}
 />


### PR DESCRIPTION
Fixes unreadable text contrast in the create/customizer picker submenus.

Picker submenu content uses theme-aware popover colors, but picker items forced all descendant text to `text-neutral-100` and used dark hover styles. This made light-mode submenu text and hover states hard to read.

This updates picker item, radio item, and separator styles so submenu content uses theme-aware foreground, accent, and border tokens.

before: 
<img width="576" height="757" alt="image" src="https://github.com/user-attachments/assets/c50723a8-4289-4703-b375-beec3c193146" />


after:
<img width="568" height="638" alt="image" src="https://github.com/user-attachments/assets/8893f42f-06fb-45f4-9630-7550e55d5f79" />


it has been really bugging me everytime i visit the docs page.. hope this it not an intended behaviour and this addresses it. ty.



