### PR TITLE
fix(docs): match css vars

### DIFF
--- a/docs/src/app.css
+++ b/docs/src/app.css
@@ -436,7 +436,7 @@
 	}
 
 	.mdsx code:not(pre code) {
-		@apply bg-muted relative rounded-md px-[0.3rem] py-[0.2rem] font-mono text-[0.8rem] outline-none;
+		@apply bg-muted relative rounded-md px-[0.3rem] py-[0.2rem] font-mono text-[0.8rem] break-words outline-none;
 	}
 
 	.super-debug {

--- a/docs/src/app.css
+++ b/docs/src/app.css
@@ -111,12 +111,12 @@
 	--font-sans: "Geist Variable", sans-serif;
 	--font-mono: "Geist Mono Variable", monospace;
 	--background: oklch(1 0 0);
-	--foreground: oklch(0.145 0 0);
+	--foreground: oklch(0% 0 0);
 	--card: oklch(1 0 0);
-	--card-foreground: oklch(0.145 0 0);
+	--card-foreground: oklch(0% 0 0);
 	--popover: oklch(1 0 0);
-	--popover-foreground: oklch(0.145 0 0);
-	--primary: oklch(0.205 0 0);
+	--popover-foreground: oklch(0% 0 0);
+	--primary: oklch(0% 0 0);
 	--primary-foreground: oklch(0.985 0 0);
 	--secondary: oklch(0.97 0 0);
 	--secondary-foreground: oklch(0.205 0 0);
@@ -124,7 +124,8 @@
 	--muted-foreground: oklch(0.556 0 0);
 	--accent: oklch(0.97 0 0);
 	--accent-foreground: oklch(0.205 0 0);
-	--destructive: oklch(0.58 0.22 27);
+	--destructive: oklch(0.577 0.245 27.325);
+	--destructive-foreground: oklch(0.97 0.01 17);
 	--border: oklch(0.922 0 0);
 	--input: oklch(0.922 0 0);
 	--ring: oklch(0.708 0 0);
@@ -134,7 +135,7 @@
 	--chart-4: var(--color-blue-700);
 	--chart-5: var(--color-blue-800);
 	--sidebar: oklch(0.985 0 0);
-	--sidebar-foreground: oklch(0.145 0 0);
+	--sidebar-foreground: oklch(0% 0 0);
 	--sidebar-primary: oklch(0.205 0 0);
 	--sidebar-primary-foreground: oklch(0.985 0 0);
 	--sidebar-accent: oklch(0.97 0 0);
@@ -147,7 +148,7 @@
 	--code-foreground: var(--surface-foreground);
 	--code-highlight: oklch(0.96 0 0);
 	--code-number: oklch(0.56 0 0);
-	--selection: oklch(0.145 0 0);
+	--selection: oklch(0% 0 0);
 	--selection-foreground: oklch(1 0 0);
 }
 
@@ -158,7 +159,7 @@
 	--card-foreground: oklch(0.985 0 0);
 	--popover: oklch(0.205 0 0);
 	--popover-foreground: oklch(0.985 0 0);
-	--primary: oklch(0.87 0 0);
+	--primary: oklch(0.922 0 0);
 	--primary-foreground: oklch(0.205 0 0);
 	--secondary: oklch(0.269 0 0);
 	--secondary-foreground: oklch(0.985 0 0);
@@ -167,6 +168,7 @@
 	--accent: oklch(0.371 0 0);
 	--accent-foreground: oklch(0.985 0 0);
 	--destructive: oklch(0.704 0.191 22.216);
+	--destructive-foreground: oklch(0.58 0.22 27);
 	--border: oklch(1 0 0 / 10%);
 	--input: oklch(1 0 0 / 15%);
 	--ring: oklch(0.556 0 0);
@@ -182,7 +184,7 @@
 	--sidebar-accent: oklch(0.269 0 0);
 	--sidebar-accent-foreground: oklch(0.985 0 0);
 	--sidebar-border: oklch(1 0 0 / 10%);
-	--sidebar-ring: oklch(0.556 0 0);
+	--sidebar-ring: oklch(0.439 0 0);
 	--surface: oklch(0.2 0 0);
 	--surface-foreground: oklch(0.708 0 0);
 	--code: var(--surface);
@@ -363,6 +365,32 @@
 		min-height: calc(var(--spacing) * 1);
 		width: 100%;
 		display: inline-block;
+	}
+
+	[data-rehype-pretty-code-figure] pre[data-language="text"] code,
+	[data-rehype-pretty-code-figure] pre[data-language="plaintext"] code,
+	[data-slot="docs"] pre[data-language="text"] code,
+	[data-slot="docs"] pre[data-language="plaintext"] code {
+		display: block !important;
+		white-space: pre;
+		line-height: 0.95;
+		font-family:
+			ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+			monospace;
+		font-variant-ligatures: none;
+	}
+
+	[data-rehype-pretty-code-figure] pre[data-language="text"] [data-line],
+	[data-rehype-pretty-code-figure] pre[data-language="plaintext"] [data-line],
+	[data-rehype-pretty-code-figure] code[data-language="text"] [data-line],
+	[data-rehype-pretty-code-figure] code[data-language="plaintext"] [data-line],
+	[data-slot="docs"] pre[data-language="text"] [data-line],
+	[data-slot="docs"] pre[data-language="plaintext"] [data-line] {
+		padding-top: 0;
+		padding-bottom: 0;
+		min-height: unset;
+		line-height: 0.95;
+		display: block;
 	}
 
 	[data-line] span {

--- a/docs/src/app.css
+++ b/docs/src/app.css
@@ -304,7 +304,7 @@
 	[data-rehype-pretty-code-figure] {
 		background-color: var(--color-code);
 		color: var(--color-code-foreground);
-		border-radius: var(--radius-lg);
+		border-radius: var(--radius-xl);
 		border-width: 0px;
 		border-color: var(--border);
 		margin-top: calc(var(--spacing) * 6);
@@ -317,6 +317,14 @@
 		&:has([data-rehype-pretty-code-title]) [data-slot="copy-button"] {
 			top: calc(var(--spacing) * 1.5) !important;
 		}
+	}
+
+	[data-rehype-pretty-code-figure] code,
+	[data-rehype-pretty-code-figure] code span {
+		font-variant-ligatures: none;
+		font-feature-settings:
+			"liga" 0,
+			"calt" 0;
 	}
 
 	[data-rehype-pretty-code-title] {

--- a/docs/src/app.css
+++ b/docs/src/app.css
@@ -304,7 +304,7 @@
 	[data-rehype-pretty-code-figure] {
 		background-color: var(--color-code);
 		color: var(--color-code-foreground);
-		border-radius: var(--radius-xl);
+		border-radius: var(--radius-lg);
 		border-width: 0px;
 		border-color: var(--border);
 		margin-top: calc(var(--spacing) * 6);

--- a/docs/src/app.css
+++ b/docs/src/app.css
@@ -304,7 +304,7 @@
 	[data-rehype-pretty-code-figure] {
 		background-color: var(--color-code);
 		color: var(--color-code-foreground);
-		border-radius: var(--radius-lg);
+		border-radius: var(--radius-xl);
 		border-width: 0px;
 		border-color: var(--border);
 		margin-top: calc(var(--spacing) * 6);

--- a/docs/src/routes/(app)/(layout)/docs/[...slug]/+page.svelte
+++ b/docs/src/routes/(app)/(layout)/docs/[...slug]/+page.svelte
@@ -64,7 +64,7 @@ the docs container. The issue this resolves is prominent on slow connections (3G
 	<div class="flex min-w-0 flex-1 flex-col">
 		<div class="h-(--top-spacing) shrink-0"></div>
 		<div
-			class="mx-auto flex w-full max-w-[40rem] min-w-0 flex-1 flex-col gap-6 px-4 py-6 text-neutral-800 md:px-0 lg:py-8 dark:text-neutral-300"
+			class="text-foreground dark:text-foreground mx-auto flex w-full max-w-[40rem] min-w-0 flex-1 flex-col gap-6 px-4 py-6 md:px-0 lg:py-8"
 		>
 			<div class="flex flex-col gap-2">
 				<div class="flex flex-col gap-2">

--- a/docs/src/routes/(app)/(layout)/docs/changelog/+page.svelte
+++ b/docs/src/routes/(app)/(layout)/docs/changelog/+page.svelte
@@ -85,7 +85,7 @@ the docs container. The issue this resolves is prominent on slow connections (3G
 	<div class="flex min-w-0 flex-1 flex-col">
 		<div class="h-(--top-spacing) shrink-0"></div>
 		<div
-			class="mx-auto flex w-full max-w-[40rem] min-w-0 flex-1 flex-col gap-6 px-4 py-6 text-neutral-800 md:px-0 lg:py-8 dark:text-neutral-300"
+			class="text-foreground dark:text-foreground mx-auto flex w-full max-w-[40rem] min-w-0 flex-1 flex-col gap-6 px-4 py-6 md:px-0 lg:py-8"
 		>
 			<div class="flex flex-col gap-2">
 				<div class="flex items-center justify-between md:items-start">


### PR DESCRIPTION
## Summary

Align the docs typography/code styling with the current `shadcn/ui` v4 docs implementation.

This ports the relevant global docs styling from `shadcn/ui/apps/v4/app/globals.css` and matches the docs content color scoping used in `shadcn/ui/apps/v4/app/(app)/docs/[[...slug]]/page.tsx`.

## What changed

- Match the upstream docs color tokens in `docs/src/app.css` for both `:root` and `.dark`:
  - light foreground values now use upstream `oklch(0% 0 0)` tokens
  - dark mode keeps upstream `foreground`, `muted-foreground`, `surface-foreground`, and code foreground values
  - related token fixes include `primary`, `destructive`, `destructive-foreground`, `sidebar-foreground`, `sidebar-ring`, and `selection`
- Scope docs page content to `text-foreground dark:text-foreground` instead of `text-neutral-800 dark:text-neutral-300`, matching upstream docs and fixing dimmer dark-mode body/inline-code text.
- Match upstream pretty-code styling:
  - code block radius uses `var(--radius-xl)`
  - code/code span ligatures are disabled like upstream
  - `text` / `plaintext` code blocks reset line padding/display for composition trees, preserving box-drawing connectors
- Match upstream inline-code wrapping by adding `break-words` to the docs inline code rule.
- Preserve Shiki token-based colors for code spans, including light and dark mode.

## Verification

- Compared against current `shadcn/ui` main (`b59f68e`) for the relevant docs globals, MDX code classes, and docs page color scoping.
- Verified `:root` and `.dark` foreground/code color tokens match upstream for the docs surface.
- Ran `pnpm lint`.
