### PR TITLE
fix: preserve preview deployment branch

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -34,4 +34,5 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           projectName: shadcn-svelte
           deploymentName: Preview
+          branch: ${{ github.event.workflow_run.head_branch }}
           directory: ${{ steps.preview-build-artifact.outputs.download-path }}/cloudflare


### PR DESCRIPTION
This closed PR adds an explicit `github.event.workflow_run.head_branch` input to the preview deployment action.

Correction: `refined-cf-pages-action@v1` already infers that branch from the `workflow_run` payload, so this change does not fix #2812. The action instead has a race in its deployment reporting: it selects the first deployment from the project's deployment list without matching it to the current run, and can report another overlapping deployment's URL.

The replacement work is tracked in #2736, which migrates to Cloudflare's Wrangler action and removes that lookup.

Original validation: parsed `.github/workflows/deploy-preview.yml` as YAML and ran `git diff --check`. These checks did not verify a fix for the deployment race.
