### PR TITLE
fix(cli): fall back to running package manager when detected one isn't installed

### DIFF
--- a/.changeset/pm-fallback-when-not-installed.md
+++ b/.changeset/pm-fallback-when-not-installed.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": patch
+---
+
+fix(cli): fall back to the running package manager when the detected one (e.g. from a stale `packageManager` field) isn't installed

--- a/packages/cli/src/utils/auto-detect.ts
+++ b/packages/cli/src/utils/auto-detect.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import * as p from "@clack/prompts";
 import * as find from "empathic/find";
 import ignore, { type Ignore } from "ignore";
+import { exec } from "tinyexec";
 import { AGENTS, detect, getUserAgent, type Agent, type AgentName } from "package-manager-detector";
 import { cancel } from "./prompt-helpers.js";
 
@@ -110,4 +111,18 @@ export async function detectPM(cwd: string, prompt: boolean): Promise<Agent | un
 	}
 
 	return agent;
+}
+
+/** Checks whether the given package manager's binary is installed. */
+export async function isPackageManagerInstalled(agent: Agent): Promise<boolean> {
+	const bin = agent.split("@")[0] ?? agent; // strip version suffix (e.g. yarn@berry)
+	try {
+		await exec(bin, ["--version"], {
+			throwOnError: true,
+			nodeOptions: { stdio: "ignore" },
+		});
+		return true;
+	} catch {
+		return false;
+	}
 }

--- a/packages/cli/src/utils/install-deps.ts
+++ b/packages/cli/src/utils/install-deps.ts
@@ -1,9 +1,9 @@
 import semver from "semver";
 import * as p from "@clack/prompts";
-import { detectPM } from "./auto-detect.js";
+import { detectPM, isPackageManagerInstalled } from "./auto-detect.js";
 import * as project from "./project.js";
 import { exec } from "tinyexec";
-import { resolveCommand } from "package-manager-detector";
+import { getUserAgent, resolveCommand } from "package-manager-detector";
 import { error } from "./errors.js";
 import { silentOutput } from "./node-utils.js";
 
@@ -21,8 +21,20 @@ export async function installDependencies({
 	devDependencies,
 	silent,
 }: InstallOptions): Promise<void> {
-	const pm = await detectPM(cwd, prompt);
+	let pm = await detectPM(cwd, prompt);
 	if (!pm) return;
+
+	// Detected PM may not be installed (e.g. a stale `packageManager` field); fall
+	// back to the PM running the CLI, then npm.
+	if (!(await isPackageManagerInstalled(pm))) {
+		const fallback = getUserAgent() ?? "npm";
+		if (fallback !== pm) {
+			p.log.warn(
+				`The detected package manager (${pm}) is not installed. Falling back to ${fallback}.`
+			);
+			pm = fallback;
+		}
+	}
 
 	// Deno requires the `npm:` specifier
 	const pkgSpecifier = pm === "deno" ? "npm:" : "";

--- a/packages/cli/src/utils/project.ts
+++ b/packages/cli/src/utils/project.ts
@@ -2,8 +2,9 @@ import { existsSync, promises as fs } from "node:fs";
 import path from "node:path";
 import { exec } from "tinyexec";
 import type { PackageJson } from "type-fest";
-import { detect, resolveCommand } from "package-manager-detector";
+import { detect, getUserAgent, resolveCommand } from "package-manager-detector";
 import { readJSONSync } from "./get-package-info.js";
+import { isPackageManagerInstalled } from "./auto-detect.js";
 import { CLIError } from "./errors.js";
 import type * as cliConfig from "./config/schema.js";
 import type * as registry from "./registry/index.js";
@@ -51,7 +52,11 @@ export async function syncSvelteKit(cwd: string) {
 		// we'll exit early since syncing is rather slow
 		if (existsSync(path.join(cwd, ".svelte-kit"))) return;
 
-		const agent = (await detect({ cwd }))?.agent ?? "npm";
+		let agent = (await detect({ cwd }))?.agent ?? "npm";
+		// fall back to the running PM if the detected one isn't installed
+		if (!(await isPackageManagerInstalled(agent))) {
+			agent = getUserAgent() ?? "npm";
+		}
 		const cmd = resolveCommand(agent, "execute-local", ["svelte-kit", "sync"])!;
 
 		try {

--- a/packages/cli/test/utils/auto-detect.test.ts
+++ b/packages/cli/test/utils/auto-detect.test.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, it, expect, afterAll, beforeEach } from "vitest";
-import { detectConfigs } from "../../src/utils/auto-detect";
+import { detectConfigs, isPackageManagerInstalled } from "../../src/utils/auto-detect";
+import type { Agent } from "package-manager-detector";
 
 describe("detectConfigs", () => {
 	const tmpDir = path.join(process.cwd(), "test-fixtures");
@@ -92,5 +93,23 @@ describe("detectConfigs", () => {
 
 		const result = detectConfigs(tmpDir);
 		expect(result.tsconfigPath).toBe(path.join(tmpDir, "tsconfig.json"));
+	});
+});
+
+describe("isPackageManagerInstalled", () => {
+	it("returns true for a binary that exists (node)", async () => {
+		// `node` is guaranteed to be present since the tests run on it
+		await expect(isPackageManagerInstalled("node" as Agent)).resolves.toBe(true);
+	});
+
+	it("returns false for a binary that does not exist", async () => {
+		await expect(isPackageManagerInstalled("definitely-not-a-real-pm" as Agent)).resolves.toBe(
+			false
+		);
+	});
+
+	it("strips the version suffix before probing the binary", async () => {
+		// `node@99` should still resolve to the real `node` binary
+		await expect(isPackageManagerInstalled("node@99" as Agent)).resolves.toBe(true);
 	});
 });

--- a/packages/cli/test/utils/install-deps.test.ts
+++ b/packages/cli/test/utils/install-deps.test.ts
@@ -6,9 +6,21 @@ import * as project from "../../src/utils/project.js";
 
 vi.mock("tinyexec", () => ({ exec: vi.fn(() => ({})) }));
 
-vi.mock("../../src/utils/auto-detect.js", () => ({ detectPM: vi.fn() }));
+vi.mock("../../src/utils/auto-detect.js", () => ({
+	detectPM: vi.fn(),
+	isPackageManagerInstalled: vi.fn(),
+}));
 
 vi.mock("../../src/utils/project.js", () => ({ getPackageInfo: vi.fn() }));
+
+vi.mock("package-manager-detector", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("package-manager-detector")>();
+	return {
+		...actual,
+		// running under `npx`/npm; keeps the fallback deterministic in tests
+		getUserAgent: vi.fn(() => "npm"),
+	};
+});
 
 vi.mock("@clack/prompts", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("@clack/prompts")>();
@@ -20,10 +32,13 @@ vi.mock("@clack/prompts", async (importOriginal) => {
 });
 
 const args = () => vi.mocked(exec).mock.calls.map((c) => c[1] as string[]);
+const commands = () => vi.mocked(exec).mock.calls.map((c) => c[0] as string);
 
 beforeEach(() => {
 	vi.clearAllMocks();
 	vi.mocked(autoDetect.detectPM).mockResolvedValue("pnpm");
+	// by default the detected package manager is installed
+	vi.mocked(autoDetect.isPackageManagerInstalled).mockResolvedValue(true);
 	vi.mocked(project.getPackageInfo).mockReturnValue({
 		dependencies: {},
 		devDependencies: { "tailwind-variants": "^0.3.0", "tw-animate-css": "^1.0.0" },
@@ -56,5 +71,25 @@ describe("installDependencies", () => {
 		});
 
 		expect(exec).not.toHaveBeenCalled();
+	});
+
+	it("falls back to the running package manager when the detected one isn't installed", async () => {
+		// detected pnpm (e.g. from a stale `packageManager` field) but pnpm isn't installed
+		vi.mocked(autoDetect.detectPM).mockResolvedValue("pnpm");
+		vi.mocked(autoDetect.isPackageManagerInstalled).mockResolvedValue(false);
+
+		await installDependencies({
+			cwd: "/test",
+			prompt: false,
+			silent: true,
+			dependencies: [],
+			devDependencies: ["tailwind-variants@^1.0.0"],
+		});
+
+		// the install must run with the fallback (npm), not the uninstalled pnpm
+		expect(exec).toHaveBeenCalledTimes(1);
+		expect(commands()[0]).toBe("npm");
+		expect(commands()[0]).not.toBe("pnpm");
+		expect(args()[0]).toContain("tailwind-variants@^1.0.0");
 	});
 });


### PR DESCRIPTION
### Problem
Running `add` with **npm** and installing dependencies can crash with a "pnpm is not installed" error in a project that never used pnpm.

`detect()` from `package-manager-detector` prioritizes the `packageManager` field in `package.json` (and parent-dir lockfiles) over the project's own `package-lock.json`. Templates commonly ship `"packageManager": "pnpm@x"`, so the CLI resolves pnpm and runs `pnpm add …` — which fails when pnpm isn't installed. Selecting all components makes the dependency list non-empty, so the install command actually runs and the crash surfaces.

### Fix
Probe whether the detected package manager is actually installed; if not, fall back to the package manager running the CLI (`getUserAgent()`, i.e. npm under `npx`), then npm. Projects with a correctly-installed pnpm/yarn/bun are unaffected — the fallback only fires when the detected PM is genuinely absent. The same guard is applied to `syncSvelteKit`.

### Tests
- Unit tests for the new `isPackageManagerInstalled` helper.
- `installDependencies` test asserting the install command falls back to npm when the detected pnpm isn't installed.