### PR TITLE
fix(cli): resolve wildcard path alias roots

### DIFF
--- a/.changeset/calm-tools-resolve.md
+++ b/.changeset/calm-tools-resolve.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": patch
+---
+
+fix: resolve wildcard path alias roots for components.json directory aliases

--- a/packages/cli/src/utils/resolve-imports.ts
+++ b/packages/cli/src/utils/resolve-imports.ts
@@ -24,6 +24,7 @@ export function resolveImportAlias(opts: ResolveImportOpts): string | undefined 
 	const resolvedPath = matcher?.(opts.importPath)?.[0];
 	if (resolvedPath) return resolvedPath;
 
+	// resolves the path if it's a wildcard (e.g. `$lib` resolves to `$lib/*`)
 	if (opts.tsconfig.config.compilerOptions?.paths?.[`${opts.importPath}/*`]) {
 		const resolvedPath = matcher?.(`${opts.importPath}${NOOP}`)?.[0];
 		if (resolvedPath) return path.dirname(resolvedPath);

--- a/packages/cli/src/utils/resolve-imports.ts
+++ b/packages/cli/src/utils/resolve-imports.ts
@@ -24,6 +24,11 @@ export function resolveImportAlias(opts: ResolveImportOpts): string | undefined 
 	const resolvedPath = matcher?.(opts.importPath)?.[0];
 	if (resolvedPath) return resolvedPath;
 
+	if (opts.tsconfig.config.compilerOptions?.paths?.[`${opts.importPath}/*`]) {
+		const resolvedPath = matcher?.(`${opts.importPath}${NOOP}`)?.[0];
+		if (resolvedPath) return path.dirname(resolvedPath);
+	}
+
 	// resolves the path if it's in the project's import map
 	const pkg = project.getPackageInfo(opts.cwd);
 	if (opts.importPath.startsWith("#")) {

--- a/packages/cli/test/utils/resolve-imports.test.ts
+++ b/packages/cli/test/utils/resolve-imports.test.ts
@@ -52,6 +52,27 @@ describe("resolveImportAlias", () => {
 		expect(toPosixPath(result!)).toBe("/project/src/components/Button");
 	});
 
+	it("returns the root of a wildcard tsconfig path", () => {
+		const mockTsconfig: TsConfigResult = {
+			config: {
+				compilerOptions: {
+					paths: {
+						"$lib/*": ["./src/lib/*"],
+					},
+				},
+			},
+			path: path.posix.normalize("/project/tsconfig.json"),
+		};
+
+		const result = resolveImportAlias({
+			importPath: "$lib",
+			tsconfig: mockTsconfig,
+			cwd: "/project",
+		});
+		expect(result).toBeDefined();
+		expect(toPosixPath(result!)).toBe("/project/src/lib");
+	});
+
 	it("returns first path match from import map", () => {
 		const mockTsconfig: TsConfigResult = {
 			config: { compilerOptions: {} },


### PR DESCRIPTION
Fixes #2821.

Resolve directory aliases such as `$lib` from an existing `$lib/*` tsconfig path. Includes a focused regression test and patch changeset.