### PR TITLE
fix: adjust initial package version of `@shadcn-svelte/sv`

### DIFF
--- a/sv-addons/sv/package.json
+++ b/sv-addons/sv/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@shadcn-svelte/sv",
-	"version": "0.0.1",
+	"version": "0.0.0",
 	"description": "sv add-on that initializes shadcn-svelte and adds components",
 	"keywords": [
 		"sv-add",


### PR DESCRIPTION
this should be starting from `0.0.0`