### PR TITLE
fix(docs): honor ?preset= over the stored preset

### DIFF
--- a/docs/src/lib/features/design-system/components/design-system-provider-state.svelte.ts
+++ b/docs/src/lib/features/design-system/components/design-system-provider-state.svelte.ts
@@ -4,6 +4,7 @@ import { StateHistory, Context, PersistedState } from "runed";
 import {
 	decodePreset,
 	encodePreset,
+	isValidPreset,
 	DEFAULT_PRESET_CONFIG,
 	type PresetConfig,
 	PRESET_BASE_COLOR_KEYS,
@@ -64,10 +65,16 @@ class DesignSystemState implements IDesignSystemState {
 	#preset: PersistedState<string>;
 	#locks: PersistedState<Lockable>;
 	constructor() {
+		const presetFromUrl = this.#getSearchParam("preset");
 		this.#preset = new PersistedState<string>(
 			"design-system-preset",
-			this.#getSearchParam("preset") ?? encodePreset(DEFAULT_PRESET_CONFIG)
+			presetFromUrl ?? encodePreset(DEFAULT_PRESET_CONFIG)
 		);
+		// PersistedState only falls back to the initial value when nothing is stored yet, so a
+		// shared ?preset= link is ignored for anyone who has already used the editor.
+		if (presetFromUrl && isValidPreset(presetFromUrl)) {
+			this.#preset.current = presetFromUrl;
+		}
 		this.#locks = new PersistedState<Lockable>("locks", {
 			style: false,
 			baseColor: false,


### PR DESCRIPTION
Fixes #2831

`/create` hands out `?preset=<code>` links through the Share dialog, but the code was only used as the initial value of the `PersistedState` holding the preset. runed prefers an existing localStorage entry over that initial value, so for anyone who had opened the editor before, a shared link did nothing and they kept their own theme. On a cold profile it was a race with the embedded preview iframe, which loads without a query and writes the default under the same key.

This captures the param once and, when it decodes, assigns it after construction so the URL wins. Without a param nothing changes: a returning visitor keeps their stored preset, a first-time visitor gets the default, and an invalid code is ignored rather than persisted.

Verified in a browser against `pnpm dev` and a production build: a shared link overrides a stored preset, applies on a cold profile across repeated runs, no query keeps the stored preset, no query on a cold profile falls back to `b0`, `?preset=not-a-preset` is ignored without page errors, and editing after opening a shared link still round-trips to the URL.

#2755 touches the same constructor. It gives the preview iframe its own storage key but still passes the URL as the initial value only, so the two changes are orthogonal.
