### PR TITLE
feat: allow files=null in Input, to match SvelteKit remote forms

### DIFF
--- a/docs/src/lib/registry/ui/input/input.svelte
+++ b/docs/src/lib/registry/ui/input/input.svelte
@@ -6,7 +6,7 @@
 
 	type Props = WithElementRef<
 		Omit<HTMLInputAttributes, "type"> &
-			({ type: "file"; files?: FileList } | { type?: InputType; files?: undefined })
+			({ type: "file"; files?: FileList | null } | { type?: InputType; files?: undefined })
 	>;
 
 	let {


### PR DESCRIPTION
`<input type="file" files={null} />` is valid for the HTML input tag, so the Input component should also allow it.

This is especially useful when using SvelteKit remote forms `.as('file')`, which includes files=null in its return type. Without this change, this causes a type error: `<Input {...form.fields.as('file')} />`