### PR TITLE
fix(sheet): use data-[state] variants for open/close animations

### DIFF
--- a/docs/src/lib/registry/ui/sheet/sheet-content.svelte
+++ b/docs/src/lib/registry/ui/sheet/sheet-content.svelte
@@ -35,7 +35,7 @@
 		data-slot="sheet-content"
 		data-side={side}
 		class={cn(
-			"cn-sheet-content data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10",
+			"cn-sheet-content data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[side=bottom]:data-[state=closed]:slide-out-to-bottom-10 data-[side=left]:data-[state=closed]:slide-out-to-left-10 data-[side=right]:data-[state=closed]:slide-out-to-right-10 data-[side=top]:data-[state=closed]:slide-out-to-top-10 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[side=bottom]:data-[state=open]:slide-in-from-bottom-10 data-[side=left]:data-[state=open]:slide-in-from-left-10 data-[side=right]:data-[state=open]:slide-in-from-right-10 data-[side=top]:data-[state=open]:slide-in-from-top-10",
 			className
 		)}
 		{...restProps}


### PR DESCRIPTION
Fixes #2815

## Problem

`Sheet.Content` wraps bits-ui's `Dialog.Content`, which exposes its state via `data-state="open" | "closed"`. The class string used `data-open:` / `data-closed:` Tailwind variants, which never match — so the sheet had no enter/exit animation.

## Change

Replace the `data-open:` / `data-closed:` variants with `data-[state=open]:` / `data-[state=closed]:` in `sheet-content.svelte`.

## Verification

- `svelte-check` (docs): 0 errors, 0 warnings
- `oxfmt --check` on the file: pass
- Confirmed against `bits-ui/dist/bits/dialog` that content sets `data-state` via `getDataOpenClosed(...)`

Scope is the single component from the issue; other components with `data-closed:` usages (dropdown-menu, menubar, sidebar) are left untouched.