### PR TITLE
fix(cli): support SvelteKit 3 projects

### DIFF
--- a/.changeset/calm-lions-sync.md
+++ b/.changeset/calm-lions-sync.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": patch
+---
+
+Support SvelteKit 3 generated config and `#lib` aliases while preserving SvelteKit 2 behavior. Resolves #2849.

--- a/docs/content/components-json.md
+++ b/docs/content/components-json.md
@@ -67,9 +67,11 @@ This is used to generate the default color palette for your components. **This c
 
 ## aliases
 
-The CLI uses these values and the `alias` config from your `svelte.config.js` file to place generated components in the correct location.
+The CLI uses these values and your project's configured import aliases to place generated components in the correct location.
 
-Path aliases have to be set up in your `svelte.config.js` file.
+SvelteKit 2 aliases are configured by SvelteKit or in `svelte.config.js`. SvelteKit 3 aliases use the `imports` field in `package.json`. Other Vite projects typically configure aliases in `tsconfig.json` and `vite.config.ts`.
+
+The examples below use the SvelteKit 2 `$lib` alias. In SvelteKit 3, use the corresponding `#lib` values instead; for example, `"lib": "#lib"` and `"ui": "#lib/components/ui"`.
 
 ### aliases.lib
 

--- a/docs/content/installation/manual.md
+++ b/docs/content/installation/manual.md
@@ -33,7 +33,7 @@ Install `@lucide/svelte`:
 
 ### Configure path aliases
 
-If you are using SvelteKit and are not using the default alias `$lib`, you'll need to update your `svelte.config.js` file to include those aliases.
+SvelteKit 2 provides `$lib` automatically. If you use a custom alias, configure it in `svelte.config.js`:
 
 ```ts title="svelte.config.js" {6} showLineNumbers
 const config = {
@@ -45,6 +45,17 @@ const config = {
     },
   },
 };
+```
+
+SvelteKit 3 uses Node package imports instead of SvelteKit-managed aliases. Declare `#lib` in `package.json`:
+
+```json title="package.json" {3-6} showLineNumbers
+{
+  "imports": {
+    "#lib": "./src/lib/index.js",
+    "#lib/*": "./src/lib/*"
+  }
+}
 ```
 
 If you are _not_ using SvelteKit, then you'll need to update your path aliases in your `tsconfig.json` and `vite.config.ts`.

--- a/docs/content/installation/sveltekit.md
+++ b/docs/content/installation/sveltekit.md
@@ -22,7 +22,7 @@ Use the SvelteKit CLI to create a new project with TailwindCSS
 
 ### Setup path aliases
 
-If you are not using the default alias `$lib`, you'll need to update your `svelte.config.js` file to include those aliases.
+SvelteKit 2 provides the `$lib` alias automatically. If you use a custom alias, configure it in `svelte.config.js`:
 
 ```ts title="svelte.config.js" {6} showLineNumbers
 const config = {
@@ -36,15 +36,26 @@ const config = {
 };
 ```
 
+SvelteKit 3 replaces `$lib` with the `#lib` package import declared by new projects. Your `package.json` should contain both the exact and wildcard mappings:
+
+```json title="package.json" {3-6} showLineNumbers
+{
+  "imports": {
+    "#lib": "./src/lib/index.js",
+    "#lib/*": "./src/lib/*"
+  }
+}
+```
+
 ### Run the CLI
 
 <PMExecute command="shadcn-svelte@latest init" />
 
 ### Configure components.json
 
-You will be asked a few questions to configure `components.json`:
+You will be asked a few questions to configure `components.json`. The CLI defaults to `$lib` for SvelteKit 2 and `#lib` for SvelteKit 3.
 
-```txt showLineNumbers
+```txt title="SvelteKit 2" showLineNumbers
 Which base color would you like to use? › Slate
 Where is your global CSS file? (this file will be overwritten) › src/routes/layout.css
 Configure the import alias for lib: › $lib
@@ -52,6 +63,16 @@ Configure the import alias for components: › $lib/components
 Configure the import alias for utils: › $lib/utils
 Configure the import alias for hooks: › $lib/hooks
 Configure the import alias for ui: › $lib/components/ui
+```
+
+```txt title="SvelteKit 3" showLineNumbers
+Which base color would you like to use? › Slate
+Where is your global CSS file? (this file will be overwritten) › src/app.css
+Configure the import alias for lib: › #lib
+Configure the import alias for components: › #lib/components
+Configure the import alias for utils: › #lib/utils
+Configure the import alias for hooks: › #lib/hooks
+Configure the import alias for ui: › #lib/components/ui
 ```
 
 ### That's it
@@ -64,10 +85,12 @@ The command above will add the `Button` component to your project. You can then 
 
 ```svelte {2,5} showLineNumbers
 <script lang="ts">
-  import { Button } from "$lib/components/ui/button/index.js";
+  import { Button } from "#lib/components/ui/button/index.js";
 </script>
 
 <Button>Click me</Button>
 ```
+
+Use `$lib/components/ui/button/index.js` instead in a SvelteKit 2 project.
 
 </Steps>

--- a/docs/src/lib/registry/examples/combobox-responsive.svelte
+++ b/docs/src/lib/registry/examples/combobox-responsive.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { browser } from "$app/environment";
 	import { onMount } from "svelte";
 	import * as Command from "$lib/registry/ui/command/index.js";
 	import * as Drawer from "$lib/registry/ui/drawer/index.js";
@@ -43,11 +42,9 @@
 	}
 
 	onMount(() => {
-		if (browser) {
-			checkScreenSize();
-			window.addEventListener("resize", checkScreenSize);
-			return () => window.removeEventListener("resize", checkScreenSize);
-		}
+		checkScreenSize();
+		window.addEventListener("resize", checkScreenSize);
+		return () => window.removeEventListener("resize", checkScreenSize);
 	});
 
 	function handleStatusSelect(value: string) {

--- a/docs/static/schema.json
+++ b/docs/static/schema.json
@@ -60,7 +60,7 @@
 				"utils"
 			],
 			"additionalProperties": false,
-			"description": "The CLI uses these values and the `alias` config from your `svelte.config.js` file to place generated components in the correct location."
+			"description": "The CLI uses these values and your project's configured import aliases to place generated components in the correct location."
 		},
 		"registry": {
 			"description": "The registry URL tells the CLI where to fetch the shadcn-svelte components/registry from. You can pin this to a specific preview release or your own fork of the registry.",

--- a/packages/cli/src/utils/config/utils.ts
+++ b/packages/cli/src/utils/config/utils.ts
@@ -125,7 +125,8 @@ type PromptForAliasesOptions = {
 	uiAlias?: string | undefined;
 };
 export async function promptForAliases(options: PromptForAliasesOptions) {
-	const libAlias = await promptAlias("lib", "$lib", options);
+	const defaults = getDefaultAliases(options.cwd);
+	const libAlias = await promptAlias("lib", defaults.lib, options);
 	const componentAlias = await promptAlias("components", `${libAlias}/components`, options);
 	const uiAlias = await promptAlias("ui", `${componentAlias}/ui`, options);
 	const utilsAlias = await promptAlias("utils", `${libAlias}/utils`, options);
@@ -137,6 +138,17 @@ export async function promptForAliases(options: PromptForAliasesOptions) {
 		uiAlias,
 		utilsAlias,
 		hooksAlias,
+	};
+}
+
+export function getDefaultAliases(cwd: string) {
+	const lib = project.isUsingSvelteKitV3(cwd) ? "#lib" : "$lib";
+	return {
+		lib,
+		components: `${lib}/components`,
+		ui: `${lib}/components/ui`,
+		utils: `${lib}/utils`,
+		hooks: `${lib}/hooks`,
 	};
 }
 

--- a/packages/cli/src/utils/install-deps.ts
+++ b/packages/cli/src/utils/install-deps.ts
@@ -7,7 +7,7 @@ import { resolveCommand, type Agent } from "package-manager-detector";
 import { exec } from "tinyexec";
 import * as project from "./project.js";
 import { detectPM } from "./auto-detect.js";
-import { error } from "./errors.js";
+import { CLIError, error } from "./errors.js";
 import { silentOutput } from "./node-utils.js";
 import type { PackageJson } from "type-fest";
 
@@ -129,9 +129,10 @@ export async function installDependencies({
 		}
 
 		task.success("Successfully installed dependencies");
-	} catch {
+	} catch (e) {
 		task.error("Failed to install dependencies");
-		throw error("Operation failed.");
+		if (e instanceof CLIError) throw e;
+		throw error("Operation failed.", e);
 	}
 }
 

--- a/packages/cli/src/utils/install-deps.ts
+++ b/packages/cli/src/utils/install-deps.ts
@@ -122,6 +122,12 @@ export async function installDependencies({
 			await runInstall(addDevDeps.command, addDevDeps.args);
 		}
 
+		// npm can prune SvelteKit 3's generated node_modules/$app package while adding
+		// dependencies. Restore it so subsequent CLI commands can resolve $app/tsconfig.
+		if (project.isUsingSvelteKitV3(cwd)) {
+			await project.syncSvelteKit(cwd);
+		}
+
 		task.success("Successfully installed dependencies");
 	} catch {
 		task.error("Failed to install dependencies");

--- a/packages/cli/src/utils/project.ts
+++ b/packages/cli/src/utils/project.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { existsSync, promises as fs } from "node:fs";
+import semver from "semver";
 import { detect, resolveCommand } from "package-manager-detector";
 import { exec } from "tinyexec";
 import { CLIError } from "./errors.js";
@@ -44,12 +45,15 @@ export async function getComponents({
 	return existingComponents;
 }
 
-// if it's a SvelteKit project, run `svelte-kit sync` if the `.svelte-kit` dir is missing
+// if it's a SvelteKit project, run `svelte-kit sync` if its generated config is missing
 export async function syncSvelteKit(cwd: string) {
 	const isSvelteKit = isUsingSvelteKit(cwd);
 	if (isSvelteKit) {
 		// we'll exit early since syncing is rather slow
-		if (existsSync(path.join(cwd, ".svelte-kit"))) return;
+		const generatedConfig = isUsingSvelteKitV3(cwd)
+			? path.join(cwd, "node_modules", "$app", "tsconfig.json")
+			: path.join(cwd, ".svelte-kit");
+		if (existsSync(generatedConfig)) return;
 
 		const agent = (await detect({ cwd }))?.agent ?? "npm";
 		const cmd = resolveCommand(agent, "execute-local", ["svelte-kit", "sync"])!;
@@ -76,6 +80,19 @@ export function isUsingSvelteKit(cwd: string): boolean {
 	const packageJSON = getPackageInfo(cwd);
 	const deps = { ...packageJSON.devDependencies, ...packageJSON.dependencies };
 	return deps["@sveltejs/kit"] !== undefined;
+}
+
+export function isUsingSvelteKitV3(cwd: string): boolean {
+	const packageJSON = getPackageInfo(cwd);
+	const deps = { ...packageJSON.devDependencies, ...packageJSON.dependencies };
+	const declaredVersion = deps["@sveltejs/kit"];
+	if (typeof declaredVersion !== "string") return false;
+
+	try {
+		return semver.minVersion(declaredVersion)?.major === 3;
+	} catch {
+		return false;
+	}
 }
 
 export function getPackageInfo(cwd: string) {

--- a/packages/cli/src/utils/project.ts
+++ b/packages/cli/src/utils/project.ts
@@ -1,10 +1,10 @@
 import path from "node:path";
-import { existsSync, promises as fs } from "node:fs";
+import { existsSync, promises as fs, readFileSync } from "node:fs";
 import semver from "semver";
 import { detect, resolveCommand } from "package-manager-detector";
 import { exec } from "tinyexec";
 import { CLIError } from "./errors.js";
-import { readJSONSync } from "./get-package-info.js";
+import { getDependencyPackageInfo, readJSONSync } from "./get-package-info.js";
 import type * as cliConfig from "./config/schema.js";
 import type * as registry from "./registry/index.js";
 import type { PackageJson } from "type-fest";
@@ -88,11 +88,31 @@ export function isUsingSvelteKitV3(cwd: string): boolean {
 	const declaredVersion = deps["@sveltejs/kit"];
 	if (typeof declaredVersion !== "string") return false;
 
-	try {
-		return semver.minVersion(declaredVersion)?.major === 3;
-	} catch {
-		return false;
+	const declaredRange = semver.validRange(declaredVersion);
+	if (declaredRange) {
+		const rangeOptions = { includePrerelease: true };
+		const allowsV2 = semver.intersects(declaredRange, ">=2.0.0-0 <3.0.0-0", rangeOptions);
+		const allowsV3 = semver.intersects(declaredRange, ">=3.0.0-0 <4.0.0-0", rangeOptions);
+		if (allowsV2 !== allowsV3) return allowsV3;
 	}
+
+	for (const filename of ["tsconfig.json", "jsconfig.json"]) {
+		const configPath = path.join(cwd, filename);
+		if (!existsSync(configPath)) continue;
+
+		const contents = readFileSync(configPath, "utf8");
+		if (/"extends"\s*:\s*"\$app\/tsconfig(?:\.json)?"/.test(contents)) return true;
+		if (/"extends"\s*:\s*"(?:\.\/)?\.svelte-kit\/tsconfig(?:\.json)?"/.test(contents)) {
+			return false;
+		}
+	}
+
+	const installedVersion = getDependencyPackageInfo(cwd, "@sveltejs/kit")?.pkg.version;
+	return (
+		typeof installedVersion === "string" &&
+		semver.valid(installedVersion) !== null &&
+		semver.major(installedVersion) === 3
+	);
 }
 
 export function getPackageInfo(cwd: string) {

--- a/packages/cli/src/utils/registry/schema.ts
+++ b/packages/cli/src/utils/registry/schema.ts
@@ -279,7 +279,7 @@ export const componentsJsonSchema = z.object({
 				),
 		})
 		.describe(
-			"The CLI uses these values and the `alias` config from your `svelte.config.js` file to place generated components in the correct location."
+			"The CLI uses these values and your project's configured import aliases to place generated components in the correct location."
 		),
 	registry: z
 		.string()

--- a/packages/cli/test/utils/install-deps.test.ts
+++ b/packages/cli/test/utils/install-deps.test.ts
@@ -3,6 +3,7 @@ import { exec } from "tinyexec";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as autoDetect from "../../src/utils/auto-detect.js";
 import * as project from "../../src/utils/project.js";
+import { CLIError } from "../../src/utils/errors.js";
 import { installDependencies } from "../../src/utils/install-deps.js";
 
 vi.mock("tinyexec", () => ({ exec: vi.fn(() => ({})) }));
@@ -146,6 +147,23 @@ describe("installDependencies", () => {
 		});
 
 		expect(project.syncSvelteKit).toHaveBeenCalledWith("/test");
+	});
+
+	it("preserves an actionable SvelteKit sync error after installing dependencies", async () => {
+		vi.mocked(project.isUsingSvelteKitV3).mockReturnValue(true);
+		vi.mocked(project.syncSvelteKit).mockRejectedValue(
+			new CLIError("Install dependencies and try again.")
+		);
+
+		await expect(
+			installDependencies({
+				cwd: "/test",
+				prompt: false,
+				silent: true,
+				dependencies: [],
+				devDependencies: ["tailwind-variants@^1.0.0"],
+			})
+		).rejects.toThrow("Install dependencies and try again.");
 	});
 
 	it("does not add a post-install sync for SvelteKit 2", async () => {

--- a/packages/cli/test/utils/install-deps.test.ts
+++ b/packages/cli/test/utils/install-deps.test.ts
@@ -9,7 +9,11 @@ vi.mock("tinyexec", () => ({ exec: vi.fn(() => ({})) }));
 
 vi.mock("../../src/utils/auto-detect.js", () => ({ detectPM: vi.fn() }));
 
-vi.mock("../../src/utils/project.js", () => ({ getPackageInfo: vi.fn() }));
+vi.mock("../../src/utils/project.js", () => ({
+	getPackageInfo: vi.fn(),
+	isUsingSvelteKitV3: vi.fn(),
+	syncSvelteKit: vi.fn(),
+}));
 
 vi.mock("node:fs", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("node:fs")>();
@@ -56,6 +60,8 @@ beforeEach(() => {
 		dependencies: {},
 		devDependencies: { "tailwind-variants": "^0.3.0", "tw-animate-css": "^1.0.0" },
 	} as ReturnType<typeof project.getPackageInfo>);
+	vi.mocked(project.isUsingSvelteKitV3).mockReturnValue(false);
+	vi.mocked(project.syncSvelteKit).mockResolvedValue();
 	vi.mocked(fs.readFileSync).mockReturnValue(packageJson());
 	vi.mocked(exec).mockResolvedValue({ stdout: "", stderr: "" } as Awaited<ReturnType<typeof exec>>);
 });
@@ -126,6 +132,32 @@ describe("installDependencies", () => {
 		expect(exec).toHaveBeenCalledTimes(1);
 		expect(args()[0]).toContain("-D");
 		expect(args()[0]).toContain("clsx@^2.0.0");
+	});
+
+	it("restores SvelteKit 3 generated config after installing dependencies", async () => {
+		vi.mocked(project.isUsingSvelteKitV3).mockReturnValue(true);
+
+		await installDependencies({
+			cwd: "/test",
+			prompt: false,
+			silent: true,
+			dependencies: [],
+			devDependencies: ["tailwind-variants@^1.0.0"],
+		});
+
+		expect(project.syncSvelteKit).toHaveBeenCalledWith("/test");
+	});
+
+	it("does not add a post-install sync for SvelteKit 2", async () => {
+		await installDependencies({
+			cwd: "/test",
+			prompt: false,
+			silent: true,
+			dependencies: [],
+			devDependencies: ["tailwind-variants@^1.0.0"],
+		});
+
+		expect(project.syncSvelteKit).not.toHaveBeenCalled();
 	});
 
 	it("writes package.json without running pm add when install is false", async () => {

--- a/packages/cli/test/utils/project-sync.test.ts
+++ b/packages/cli/test/utils/project-sync.test.ts
@@ -33,6 +33,15 @@ async function createProject(version: string, generated: "none" | "kit2" | "kit3
 	return cwd;
 }
 
+async function installSvelteKit(cwd: string, version: string) {
+	const packageDir = path.join(cwd, "node_modules", "@sveltejs", "kit");
+	await fs.mkdir(packageDir, { recursive: true });
+	await fs.writeFile(
+		path.join(packageDir, "package.json"),
+		JSON.stringify({ name: "@sveltejs/kit", version })
+	);
+}
+
 beforeEach(() => {
 	vi.resetAllMocks();
 	vi.mocked(detect).mockResolvedValue({ agent: "npm" } as never);
@@ -92,5 +101,39 @@ describe("isUsingSvelteKitV3", () => {
 
 		expect(project.isUsingSvelteKitV3(kit2)).toBe(false);
 		expect(project.isUsingSvelteKitV3(kit3)).toBe(true);
+	});
+
+	it("uses the installed version for package manager protocols", async () => {
+		const cwd = await createProject("catalog:", "none");
+		await installSvelteKit(cwd, "3.0.0-next.25");
+
+		expect(project.isUsingSvelteKitV3(cwd)).toBe(true);
+	});
+
+	it("uses the installed version when a declared range spans Kit majors", async () => {
+		const cwd = await createProject(">=2 <4", "none");
+		await installSvelteKit(cwd, "3.0.0-next.25");
+
+		expect(project.isUsingSvelteKitV3(cwd)).toBe(true);
+	});
+
+	it("falls back to the Kit 3 tsconfig shape when dependencies are missing", async () => {
+		const cwd = await createProject("next", "none");
+		await fs.writeFile(
+			path.join(cwd, "tsconfig.json"),
+			'{\n\t"extends": "$app/tsconfig",\n\t"compilerOptions": {}\n}'
+		);
+
+		expect(project.isUsingSvelteKitV3(cwd)).toBe(true);
+	});
+
+	it("does not infer Kit 3 from a Kit 2 config with a non-semver spec", async () => {
+		const cwd = await createProject("catalog:", "none");
+		await fs.writeFile(
+			path.join(cwd, "tsconfig.json"),
+			'{\n\t"extends": "./.svelte-kit/tsconfig.json",\n\t"compilerOptions": {}\n}'
+		);
+
+		expect(project.isUsingSvelteKitV3(cwd)).toBe(false);
 	});
 });

--- a/packages/cli/test/utils/project-sync.test.ts
+++ b/packages/cli/test/utils/project-sync.test.ts
@@ -1,0 +1,96 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { detect, resolveCommand } from "package-manager-detector";
+import { exec } from "tinyexec";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as project from "../../src/utils/project.js";
+
+vi.mock("package-manager-detector", () => ({
+	detect: vi.fn(),
+	resolveCommand: vi.fn(),
+}));
+vi.mock("tinyexec", () => ({ exec: vi.fn() }));
+
+const tempDirs: string[] = [];
+
+async function createProject(version: string, generated: "none" | "kit2" | "kit3") {
+	const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "shadcn-svelte-kit-"));
+	tempDirs.push(cwd);
+	await fs.writeFile(
+		path.join(cwd, "package.json"),
+		JSON.stringify({ devDependencies: { "@sveltejs/kit": version } })
+	);
+
+	if (generated === "kit2" || generated === "kit3") {
+		await fs.mkdir(path.join(cwd, ".svelte-kit"), { recursive: true });
+	}
+	if (generated === "kit3") {
+		await fs.mkdir(path.join(cwd, "node_modules", "$app"), { recursive: true });
+		await fs.writeFile(path.join(cwd, "node_modules", "$app", "tsconfig.json"), "{}");
+	}
+
+	return cwd;
+}
+
+beforeEach(() => {
+	vi.resetAllMocks();
+	vi.mocked(detect).mockResolvedValue({ agent: "npm" } as never);
+	vi.mocked(resolveCommand).mockImplementation((_agent, command) => {
+		if (command === "install") return { command: "npm", args: ["install"] } as never;
+		return { command: "npx", args: ["svelte-kit", "sync"] } as never;
+	});
+	vi.mocked(exec).mockResolvedValue({ stdout: "", stderr: "" } as never);
+});
+
+afterEach(async () => {
+	await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("syncSvelteKit", () => {
+	it("keeps the SvelteKit 2 .svelte-kit readiness check", async () => {
+		const cwd = await createProject("^2.60.1", "kit2");
+
+		await project.syncSvelteKit(cwd);
+
+		expect(exec).not.toHaveBeenCalled();
+	});
+
+	it("skips sync when SvelteKit 3 has generated $app/tsconfig", async () => {
+		const cwd = await createProject("^3.0.0-next.0", "kit3");
+
+		await project.syncSvelteKit(cwd);
+
+		expect(exec).not.toHaveBeenCalled();
+	});
+
+	it("syncs SvelteKit 3 when $app/tsconfig is missing even if .svelte-kit exists", async () => {
+		const cwd = await createProject("^3.0.0-next.0", "kit2");
+
+		await project.syncSvelteKit(cwd);
+
+		expect(exec).toHaveBeenCalledWith("npx", ["svelte-kit", "sync"], {
+			throwOnError: true,
+			nodeOptions: { cwd },
+		});
+	});
+
+	it("keeps the actionable install error when sync cannot run", async () => {
+		const cwd = await createProject("^3.0.0-next.0", "none");
+		vi.mocked(exec).mockRejectedValueOnce(new Error("missing dependencies"));
+
+		await expect(project.syncSvelteKit(cwd)).rejects.toThrow(
+			"Ensure that your dependencies have been installed first with 'npm install'"
+		);
+	});
+});
+
+describe("isUsingSvelteKitV3", () => {
+	it("only enables v3 behavior for a declared SvelteKit 3 range", async () => {
+		const kit2 = await createProject("^2.60.1", "none");
+		const kit3 = await createProject("^3.0.0-next.0", "none");
+
+		expect(project.isUsingSvelteKitV3(kit2)).toBe(false);
+		expect(project.isUsingSvelteKitV3(kit3)).toBe(true);
+	});
+});

--- a/packages/cli/test/utils/sveltekit-3.test.ts
+++ b/packages/cli/test/utils/sveltekit-3.test.ts
@@ -1,0 +1,163 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import * as p from "@clack/prompts";
+import { afterEach, expect, it, vi } from "vitest";
+import {
+	getConfig,
+	getDefaultAliases,
+	promptForAliases,
+	type RawConfig,
+} from "../../src/utils/config/index.js";
+import type { TsConfigResult } from "get-tsconfig";
+
+vi.mock("@clack/prompts", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@clack/prompts")>()),
+	text: vi.fn(),
+}));
+
+const tempDirs: string[] = [];
+
+async function createProject(version: string) {
+	const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "shadcn-svelte-config-"));
+	tempDirs.push(cwd);
+	await fs.writeFile(
+		path.join(cwd, "package.json"),
+		JSON.stringify({
+			devDependencies: { "@sveltejs/kit": version },
+			imports: { "#lib": "./src/lib/index.js", "#lib/*": "./src/lib/*" },
+		})
+	);
+	return cwd;
+}
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+it("uses version-specific default aliases", async () => {
+	const kit2 = await createProject("^2.60.1");
+	const kit3 = await createProject("^3.0.0-next.0");
+
+	expect(getDefaultAliases(kit2)).toEqual({
+		lib: "$lib",
+		components: "$lib/components",
+		ui: "$lib/components/ui",
+		utils: "$lib/utils",
+		hooks: "$lib/hooks",
+	});
+	expect(getDefaultAliases(kit3)).toEqual({
+		lib: "#lib",
+		components: "#lib/components",
+		ui: "#lib/components/ui",
+		utils: "#lib/utils",
+		hooks: "#lib/hooks",
+	});
+});
+
+it("keeps explicit alias options unchanged in SvelteKit 3", async () => {
+	const cwd = await createProject("^3.0.0-next.0");
+	const aliases = await promptForAliases({
+		cwd,
+		tsconfig: {} as TsConfigResult,
+		existingConfig: undefined,
+		libAlias: "@lib",
+		componentsAlias: "@components",
+		uiAlias: "@ui",
+		utilsAlias: "@utils",
+		hooksAlias: "@hooks",
+	});
+
+	expect(aliases).toEqual({
+		libAlias: "@lib",
+		componentAlias: "@components",
+		uiAlias: "@ui",
+		utilsAlias: "@utils",
+		hooksAlias: "@hooks",
+	});
+	expect(p.text).not.toHaveBeenCalled();
+});
+
+it("keeps aliases from an existing components.json", async () => {
+	const cwd = await createProject("^3.0.0-next.0");
+	const existingConfig = {
+		tailwind: { css: "src/app.css", baseColor: "slate" },
+		aliases: {
+			lib: "@lib",
+			components: "@components",
+			ui: "@ui",
+			utils: "@utils",
+			hooks: "@hooks",
+		},
+		typescript: true,
+		registry: "https://shadcn-svelte.com/registry",
+	} satisfies RawConfig;
+	vi.mocked(p.text).mockImplementation(async (options) => options.initialValue as string);
+
+	const aliases = await promptForAliases({
+		cwd,
+		tsconfig: {} as TsConfigResult,
+		existingConfig,
+	});
+
+	expect(aliases).toEqual({
+		libAlias: "@lib",
+		componentAlias: "@components",
+		uiAlias: "@ui",
+		utilsAlias: "@utils",
+		hooksAlias: "@hooks",
+	});
+});
+
+it("resolves a SvelteKit 3 components.json through $app/tsconfig and package imports", async () => {
+	const cwd = await createProject("^3.0.0-next.0");
+	await fs.mkdir(path.join(cwd, "node_modules", "$app"), { recursive: true });
+	await fs.mkdir(path.join(cwd, "src", "lib", "components", "ui"), { recursive: true });
+	await fs.mkdir(path.join(cwd, "src", "lib", "hooks"), { recursive: true });
+	await fs.writeFile(
+		path.join(cwd, "node_modules", "$app", "tsconfig.json"),
+		JSON.stringify({ compilerOptions: { paths: {} } })
+	);
+	await fs.writeFile(
+		path.join(cwd, "tsconfig.json"),
+		JSON.stringify({ extends: "$app/tsconfig", include: ["src"] })
+	);
+	await fs.writeFile(path.join(cwd, "src", "app.css"), "");
+	await fs.writeFile(path.join(cwd, "src", "lib", "index.ts"), "");
+	await fs.writeFile(path.join(cwd, "src", "lib", "utils.ts"), "");
+	await fs.writeFile(
+		path.join(cwd, "components.json"),
+		JSON.stringify({
+			$schema: "https://shadcn-svelte.com/schema.json",
+			style: "nova",
+			tailwind: { css: "src/app.css", baseColor: "slate" },
+			aliases: {
+				lib: "#lib",
+				components: "#lib/components",
+				ui: "#lib/components/ui",
+				utils: "#lib/utils",
+				hooks: "#lib/hooks",
+			},
+			typescript: true,
+			registry: "https://shadcn-svelte.com/registry",
+		})
+	);
+
+	const config = await getConfig(cwd);
+
+	expect(config?.aliases).toEqual({
+		lib: "#lib",
+		components: "#lib/components",
+		ui: "#lib/components/ui",
+		utils: "#lib/utils",
+		hooks: "#lib/hooks",
+	});
+	expect(config?.resolvedPaths).toMatchObject({
+		lib: path.join(cwd, "src", "lib"),
+		components: path.join(cwd, "src", "lib", "components"),
+		ui: path.join(cwd, "src", "lib", "components", "ui"),
+		utils: path.join(cwd, "src", "lib", "utils"),
+		hooks: path.join(cwd, "src", "lib", "hooks"),
+	});
+});


### PR DESCRIPTION
## Summary

Resolves #2849 by adding version-aware SvelteKit behavior without migrating or changing the repository SvelteKit 2 docs application.

The [SvelteKit 3 migration guide](https://next.svelte.dev/docs/kit/migrating-to-sveltekit-3) introduces two relevant changes: `tsconfig.json` extends `$app/tsconfig`, and new projects use the `#lib` package import.

The reported npm failure occurs because installing component dependencies can remove generated `node_modules/$app/tsconfig.json` while leaving `.svelte-kit` intact. The CLI previously treated `.svelte-kit` as sufficient proof that sync had completed, so `get-tsconfig` subsequently failed.

## Implementation

- Detect SvelteKit 2 versus 3 from an unambiguous declared range, the Kit 2/3 config shape, or the installed package version for package-manager protocols, tags, and ranges spanning majors.
- Keep the existing `.svelte-kit` readiness check unchanged for SvelteKit 2.
- For SvelteKit 3, require `node_modules/$app/tsconfig.json` and run `svelte-kit sync` when it is missing.
- Rerun the guarded sync after dependency installation for SvelteKit 3 so npm cannot leave the generated `$app` package missing.
- Preserve the actionable package-manager-specific sync error if post-install recovery fails.
- Default new SvelteKit 3 configurations to `#lib`, `#lib/components`, `#lib/components/ui`, `#lib/utils`, and `#lib/hooks`.
- Preserve `$lib` defaults for SvelteKit 2 and non-Kit projects.
- Preserve explicit CLI aliases and aliases from an existing `components.json`.
- Keep the `components.json` schema and backward-compatible parsing defaults unchanged.
- Remove the registry responsive-combobox dependency on `$app/environment`; `onMount` already guarantees browser execution.
- Document separate SvelteKit 2 and SvelteKit 3 alias configuration examples and regenerate the schema artifact.
- Add a patch changeset.

## Validation

- [x] Full CLI test suite: 270 tests passed
- [x] Added Kit 2 and Kit 3 sync readiness coverage
- [x] Added semver, `catalog:`, npm tag, missing-dependency config, and cross-major range detection coverage
- [x] Added version-specific alias, explicit override, and existing-config coverage
- [x] Added post-install Kit 3 recovery, actionable-error, and Kit 2 no-regression coverage
- [x] Workspace TypeScript and Svelte checks passed with 0 errors and 0 warnings
- [x] Registry/schema generation passed
- [x] `pnpm lint` passed
- [x] Production build passed
- [x] `git diff --check` passed
- [x] Independent source audit found no legacy Kit imports in installable registry output
- [x] Independent Kit 2 and Kit 3 end-to-end reproductions passed

## SvelteKit 2 end-to-end validation

Verified independently with SvelteKit 2.70.3:

1. Initialized using the local CLI and confirmed every default remains `$lib`-based.
2. Confirmed dependency installation and `add button` do not invoke or rewrite Kit 3 generated state.
3. Confirmed generated component imports use `$lib/utils.js`.
4. Mounted the generated button through the real route import graph.
5. Confirmed project check passes with 0 errors and 0 warnings.
6. Confirmed the production client and SSR build passes.

## SvelteKit 3 npm reproduction

Verified independently with SvelteKit 3.0.0-next.25 in a disposable `sv@next` project:

1. Initialized the project and CLI with `#lib` aliases.
2. Installed an npm dependency and confirmed npm removed `$app/tsconfig.json` while `.svelte-kit` remained.
3. Ran `add button` with this branch of the CLI.
4. Confirmed the guarded sync restored `$app/tsconfig.json` and the component was added successfully.
5. Confirmed generated imports use `#lib`.
6. Confirmed project check passes with 0 errors and 0 warnings.
7. Confirmed the production build passes.

## Compatibility

SvelteKit 3-specific behavior is strictly version-gated. Existing SvelteKit 2 projects retain their current defaults and sync command flow, and the repository docs application remains on SvelteKit 2.
