### PR TITLE
fix: don't throw an import alias error when a subpath import is already defined

### DIFF
--- a/.changeset/tricky-shirts-hug.md
+++ b/.changeset/tricky-shirts-hug.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": patch
+---
+
+fix: don't throw an import alias error when a subpath import is already defined

--- a/packages/cli/src/utils/config/utils.ts
+++ b/packages/cli/src/utils/config/utils.ts
@@ -35,18 +35,21 @@ export async function resolveConfig(cwd: string, config: RawConfig): Promise<Res
 	const tsconfig = resolveTSConfig(cwd, config);
 
 	const tsconfigFilename = path.basename(tsconfig.path);
-	if (!tsconfig.config.compilerOptions?.paths) {
-		throw error(
-			`Missing ${highlight("paths")} field in your ${highlight(tsconfigFilename)} for path aliases. See: ${color.underline(`${SITE_BASE_URL}/docs/installation/manual#configure-path-aliases`)}`
-		);
-	}
 
-	const aliasError = (type: string, alias: string) =>
-		new ConfigError(
+	const aliasError = (type: string, alias: string) => {
+		// aliases may also resolve via `package.json` import maps, so only surface the
+		// missing `paths` error when the tsconfig has no `paths` field at all
+		if (!tsconfig.config.compilerOptions?.paths) {
+			return error(
+				`Missing ${highlight("paths")} field in your ${highlight(tsconfigFilename)} for path aliases. See: ${color.underline(`${SITE_BASE_URL}/docs/installation/manual#configure-path-aliases`)}`
+			);
+		}
+		return new ConfigError(
 			`Invalid import alias found: (${highlight(`"${type}": "${alias}"`)}) in ${highlight("components.json")}.
    - Import aliases ${color.underline("must use")} existing path aliases defined in your ${highlight(tsconfigFilename)} (e.g. "${type}": "$lib/${type}").
    - See: ${color.underline(`${SITE_BASE_URL}/docs/installation/manual#configure-path-aliases`)}.`
 		);
+	};
 
 	const resolvedPaths: Record<string, string> = {
 		cwd,

--- a/packages/cli/test/fixtures/config-pkg-imports/components.json
+++ b/packages/cli/test/fixtures/config-pkg-imports/components.json
@@ -1,0 +1,14 @@
+{
+	"tailwind": {
+		"css": "src/app.css",
+		"baseColor": "zinc"
+	},
+	"aliases": {
+		"components": "#lib/components",
+		"utils": "#lib/utils",
+		"ui": "#lib/components/ui",
+		"hooks": "#lib/hooks",
+		"lib": "#lib"
+	},
+	"typescript": true
+}

--- a/packages/cli/test/fixtures/config-pkg-imports/package.json
+++ b/packages/cli/test/fixtures/config-pkg-imports/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "test-cli-config-pkg-imports",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"imports": {
+		"#lib": "./src/lib/index.js",
+		"#lib/*": "./src/lib/*"
+	},
+	"devDependencies": {
+		"@sveltejs/vite-plugin-svelte": "^3.0.0",
+		"svelte": "^4.2.7",
+		"typescript": "^5.0.0",
+		"vite": "^5.0.3"
+	}
+}

--- a/packages/cli/test/fixtures/config-pkg-imports/tsconfig.json
+++ b/packages/cli/test/fixtures/config-pkg-imports/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"skipLibCheck": true,
+		"sourceMap": true,
+		"strict": true,
+		"moduleResolution": "bundler"
+	}
+}

--- a/packages/cli/test/utils/get-config.test.ts
+++ b/packages/cli/test/utils/get-config.test.ts
@@ -175,6 +175,38 @@ describe("getConfig", () => {
 		});
 	});
 
+	it("handles aliases defined via package.json subpath imports without tsconfig paths", async () => {
+		expect(await getConf("config-pkg-imports")).toEqual({
+			tailwind: {
+				css: "src/app.css",
+				baseColor: "zinc",
+			},
+			aliases: {
+				utils: "#lib/utils",
+				components: "#lib/components",
+				hooks: "#lib/hooks",
+				ui: "#lib/components/ui",
+				lib: "#lib",
+			},
+			resolvedPaths: {
+				components: resolvePath("../fixtures/config-pkg-imports/src/lib/components"),
+				tailwindCss: resolvePath("../fixtures/config-pkg-imports/src/app.css"),
+				utils: resolvePath("../fixtures/config-pkg-imports/src/lib/utils"),
+				hooks: resolvePath("../fixtures/config-pkg-imports/src/lib/hooks"),
+				ui: resolvePath("../fixtures/config-pkg-imports/src/lib/components/ui"),
+				lib: resolvePath("../fixtures/config-pkg-imports/src/lib"),
+				cwd: resolvePath("../fixtures/config-pkg-imports"),
+			},
+			iconLibrary: "lucide",
+			menuAccent: "subtle",
+			menuColor: "default",
+			style: "nova",
+			sveltekit: false,
+			typescript: true,
+			registry: `${SITE_BASE_URL}/registry`,
+		});
+	});
+
 	it("handles cases where the project uses jsconfig.json", async () => {
 		const config = await getConf("config-jsconfig");
 


### PR DESCRIPTION
Fixes an issue where an import alias error would be thrown (due to a missing `paths` field in the tsconfig) even when a subpath import in the `package.json` (e.g. `#lib/*`) is already defined.