### PR TITLE
fix(registry): pin zod instead of catalog specifier in dashboard-01

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -134,6 +134,6 @@
 		"vaul-svelte": "1.0.0-next.7",
 		"velite": "^0.3.1",
 		"vite": "^8.1.5",
-		"zod": "catalog:"
+		"zod": "^4.4.3"
 	}
 }

--- a/docs/static/registry/styles/luma/dashboard-01.json
+++ b/docs/static/registry/styles/luma/dashboard-01.json
@@ -14,7 +14,7 @@
 		"@dnd-kit-svelte/svelte@^0.1.5",
 		"@dnd-kit/abstract@^0.1.21",
 		"@dnd-kit/helpers@^0.1.21",
-		"zod@catalog:"
+		"zod@^4.4.3"
 	],
 	"registryDependencies": [
 		"sidebar",

--- a/docs/static/registry/styles/lyra/dashboard-01.json
+++ b/docs/static/registry/styles/lyra/dashboard-01.json
@@ -14,7 +14,7 @@
 		"@dnd-kit-svelte/svelte@^0.1.5",
 		"@dnd-kit/abstract@^0.1.21",
 		"@dnd-kit/helpers@^0.1.21",
-		"zod@catalog:"
+		"zod@^4.4.3"
 	],
 	"registryDependencies": [
 		"sidebar",

--- a/docs/static/registry/styles/maia/dashboard-01.json
+++ b/docs/static/registry/styles/maia/dashboard-01.json
@@ -14,7 +14,7 @@
 		"@dnd-kit-svelte/svelte@^0.1.5",
 		"@dnd-kit/abstract@^0.1.21",
 		"@dnd-kit/helpers@^0.1.21",
-		"zod@catalog:"
+		"zod@^4.4.3"
 	],
 	"registryDependencies": [
 		"sidebar",

--- a/docs/static/registry/styles/mira/dashboard-01.json
+++ b/docs/static/registry/styles/mira/dashboard-01.json
@@ -14,7 +14,7 @@
 		"@dnd-kit-svelte/svelte@^0.1.5",
 		"@dnd-kit/abstract@^0.1.21",
 		"@dnd-kit/helpers@^0.1.21",
-		"zod@catalog:"
+		"zod@^4.4.3"
 	],
 	"registryDependencies": [
 		"sidebar",

--- a/docs/static/registry/styles/nova/dashboard-01.json
+++ b/docs/static/registry/styles/nova/dashboard-01.json
@@ -14,7 +14,7 @@
 		"@dnd-kit-svelte/svelte@^0.1.5",
 		"@dnd-kit/abstract@^0.1.21",
 		"@dnd-kit/helpers@^0.1.21",
-		"zod@catalog:"
+		"zod@^4.4.3"
 	],
 	"registryDependencies": [
 		"sidebar",

--- a/docs/static/registry/styles/rhea/dashboard-01.json
+++ b/docs/static/registry/styles/rhea/dashboard-01.json
@@ -14,7 +14,7 @@
 		"@dnd-kit-svelte/svelte@^0.1.5",
 		"@dnd-kit/abstract@^0.1.21",
 		"@dnd-kit/helpers@^0.1.21",
-		"zod@catalog:"
+		"zod@^4.4.3"
 	],
 	"registryDependencies": [
 		"sidebar",

--- a/docs/static/registry/styles/sera/dashboard-01.json
+++ b/docs/static/registry/styles/sera/dashboard-01.json
@@ -14,7 +14,7 @@
 		"@dnd-kit-svelte/svelte@^0.1.5",
 		"@dnd-kit/abstract@^0.1.21",
 		"@dnd-kit/helpers@^0.1.21",
-		"zod@catalog:"
+		"zod@^4.4.3"
 	],
 	"registryDependencies": [
 		"sidebar",

--- a/docs/static/registry/styles/vega/dashboard-01.json
+++ b/docs/static/registry/styles/vega/dashboard-01.json
@@ -14,7 +14,7 @@
 		"@dnd-kit-svelte/svelte@^0.1.5",
 		"@dnd-kit/abstract@^0.1.21",
 		"@dnd-kit/helpers@^0.1.21",
-		"zod@catalog:"
+		"zod@^4.4.3"
 	],
 	"registryDependencies": [
 		"sidebar",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -116,6 +116,6 @@
 		"type-fest": "^4.41.0",
 		"typescript": "catalog:",
 		"vitest": "^4.1.10",
-		"zod": "catalog:"
+		"zod": "^4.4.3"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,9 +15,6 @@ catalogs:
     typescript:
       specifier: ^6.0.3
       version: 6.0.3
-    zod:
-      specifier: ^4.4.3
-      version: 4.4.3
 
 importers:
 
@@ -505,7 +502,7 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@25.5.0)(jsdom@27.3.0(postcss@8.5.25))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
       zod:
-        specifier: 'catalog:'
+        specifier: ^4.4.3
         version: 4.4.3
 
   sv-addons/registry:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -411,7 +411,7 @@ importers:
         specifier: ^8.1.5
         version: 8.1.5(@types/node@25.5.0)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       zod:
-        specifier: 'catalog:'
+        specifier: ^4.4.3
         version: 4.4.3
 
   packages/cli:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,6 @@ catalog:
     tsdown: ^0.22.14
     typescript: ^6.0.3
     vite: ^7.3.1
-    zod: ^4.4.3
 
 onlyBuiltDependencies:
     - "@tailwindcss/oxide"


### PR DESCRIPTION
#2840 re-introduced the pnpm `catalog:` specifier into the published dashboard-01 registry item, regressing #2665 (previously fixed by #2666).

**Repro** (shadcn-svelte 1.5.1, Bun, 2026-08-31):

```
bunx --bun shadcn-svelte@latest add dashboard-01 --yes
# all files scaffold, then:
# error: zod@catalog: failed to resolve
# CLI Error: Operation failed.
```

A consumer project has no matching pnpm workspace catalog, so the specifier cannot resolve. The failure output above is from Bun; exact behavior will vary by package manager.

**Evidence**

- Live: `https://shadcn-svelte.com/registry/styles/vega/dashboard-01.json` → `devDependencies` contains `"zod@catalog:"` (checked all 257 vega registry items on 2026-08-31; dashboard-01 is the only affected item).
- Source: `docs/static/registry/styles/*/dashboard-01.json` plus `docs/package.json` (`"zod": "catalog:"`) at tag `shadcn-svelte@1.5.1` and current main.

**Fix** — same approach as #2666: pin `zod` in `docs/package.json` and the eight per-style `dashboard-01.json` items to the workspace catalog's current value (`^4.4.3`). Lockfile regenerated with `pnpm install --lockfile-only` (pnpm 10.32.1).

Longer term, resolving `catalog:` specifiers during registry generation would prevent the next regression; happy to look into that if you'd prefer it over the pin.
