### PR TITLE
feat: auto-detect `#lib` subpath import alias during `init`

### DIFF
--- a/.changeset/tricky-wings-run.md
+++ b/.changeset/tricky-wings-run.md
@@ -1,0 +1,5 @@
+---
+"shadcn-svelte": minor
+---
+
+feat: auto-detect `#lib` subpath imports from `package.json`

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -153,7 +153,7 @@ async function promptForConfig({
 	// if it's a SvelteKit project, run sync so that the aliases are always up to date
 	await project.syncSvelteKit(cwd);
 
-	const { cssPath, tsconfigPath } = detectConfigs(cwd, { relative: true });
+	const { cssPath, tsconfigPath, packageImportAlias } = detectConfigs(cwd, { relative: true });
 
 	let tsconfig;
 	if (existingConfig) {
@@ -213,6 +213,7 @@ async function promptForConfig({
 	const { utilsAlias, libAlias, componentAlias, hooksAlias, uiAlias } =
 		await cliConfig.promptForAliases({
 			...options,
+			libAliasDefault: packageImportAlias,
 			tsconfig,
 			cwd,
 			existingConfig,

--- a/packages/cli/src/utils/auto-detect.ts
+++ b/packages/cli/src/utils/auto-detect.ts
@@ -41,10 +41,9 @@ export function detectConfigs(cwd: string, config?: { relative: boolean }) {
 function findPackageImportAlias(cwd: string): string | undefined {
 	try {
 		const packageJson = getPackageInfo(cwd);
-		if (!packageJson.imports) return;
 
 		const imports = packageJson.imports;
-		if (imports["#lib/*"]) return "#lib";
+		if (imports && imports["#lib/*"]) return "#lib";
 	} catch {
 		return;
 	}

--- a/packages/cli/src/utils/auto-detect.ts
+++ b/packages/cli/src/utils/auto-detect.ts
@@ -4,6 +4,7 @@ import * as p from "@clack/prompts";
 import * as find from "empathic/find";
 import ignore, { type Ignore } from "ignore";
 import { AGENTS, detect, getUserAgent, type Agent, type AgentName } from "package-manager-detector";
+import { getPackageInfo } from "./project.js";
 import { cancel } from "./prompt-helpers.js";
 
 const STYLESHEETS = ["app.css", "main.css", "globals.css", "global.css", "layout.css"];
@@ -28,11 +29,25 @@ export function detectConfigs(cwd: string, config?: { relative: boolean }) {
 	const tsconfigPath = findTSConfig(cwd);
 	const resolvedTsconfigPath =
 		tsconfigPath && config?.relative ? path.relative(cwd, tsconfigPath) : tsconfigPath;
+	const packageImportAlias = findPackageImportAlias(cwd);
 
 	return {
 		cssPath,
 		tsconfigPath: resolvedTsconfigPath,
+		packageImportAlias,
 	};
+}
+
+function findPackageImportAlias(cwd: string): string | undefined {
+	try {
+		const packageJson = getPackageInfo(cwd);
+		if (!packageJson.imports) return;
+
+		const imports = packageJson.imports;
+		if (imports["#lib/*"]) return "#lib";
+	} catch {
+		return;
+	}
 }
 
 /**

--- a/packages/cli/src/utils/config/utils.ts
+++ b/packages/cli/src/utils/config/utils.ts
@@ -124,11 +124,12 @@ type PromptForAliasesOptions = {
 	existingConfig: RawConfig | undefined;
 	utilsAlias?: string | undefined;
 	libAlias?: string | undefined;
+	libAliasDefault?: string | undefined;
 	hooksAlias?: string | undefined;
 	uiAlias?: string | undefined;
 };
 export async function promptForAliases(options: PromptForAliasesOptions) {
-	const libAlias = await promptAlias("lib", "$lib", options);
+	const libAlias = await promptAlias("lib", options.libAliasDefault ?? "$lib", options);
 	const componentAlias = await promptAlias("components", `${libAlias}/components`, options);
 	const uiAlias = await promptAlias("ui", `${componentAlias}/ui`, options);
 	const utilsAlias = await promptAlias("utils", `${libAlias}/utils`, options);

--- a/packages/cli/test/utils/auto-detect.test.ts
+++ b/packages/cli/test/utils/auto-detect.test.ts
@@ -93,4 +93,14 @@ describe("detectConfigs", () => {
 		const result = detectConfigs(tmpDir);
 		expect(result.tsconfigPath).toBe(path.join(tmpDir, "tsconfig.json"));
 	});
+
+	it("should detect the #lib package subpath import alias", () => {
+		fs.writeFileSync(
+			path.join(tmpDir, "package.json"),
+			JSON.stringify({ imports: { "#lib/*": "./src/lib/*" } })
+		);
+
+		const result = detectConfigs(tmpDir);
+		expect(result.packageImportAlias).toBe("#lib");
+	});
 });

--- a/packages/cli/test/utils/prompt-for-aliases.test.ts
+++ b/packages/cli/test/utils/prompt-for-aliases.test.ts
@@ -1,0 +1,41 @@
+import path from "node:path";
+import * as p from "@clack/prompts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { promptForAliases } from "../../src/utils/config/utils.js";
+import type { TsConfigResult } from "get-tsconfig";
+
+vi.mock("@clack/prompts", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@clack/prompts")>();
+	return { ...actual, text: vi.fn() };
+});
+
+describe("promptForAliases", () => {
+	beforeEach(() => {
+		vi.mocked(p.text)
+			.mockResolvedValueOnce("#lib")
+			.mockResolvedValueOnce("#lib/components")
+			.mockResolvedValueOnce("#lib/components/ui")
+			.mockResolvedValueOnce("#lib/utils")
+			.mockResolvedValueOnce("#lib/hooks");
+	});
+
+	it("uses a detected package import as the suggested lib alias", async () => {
+		const tsconfig = {
+			path: path.join(process.cwd(), "tsconfig.json"),
+			config: {},
+		} satisfies TsConfigResult;
+
+		await promptForAliases({
+			cwd: process.cwd(),
+			tsconfig,
+			existingConfig: undefined,
+			libAliasDefault: "#lib",
+		});
+
+		expect(p.text).toHaveBeenNthCalledWith(1, expect.objectContaining({ initialValue: "#lib" }));
+		expect(p.text).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({ initialValue: "#lib/components" })
+		);
+	});
+});


### PR DESCRIPTION
closes #2849 

As SvelteKit 3 now recommends using [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) and no longer include the `$lib` path alias by default, we'll now auto-detect if the project contains the `#lib/*` subpath import during `init`.

I'll update the documentation in a different PR.