### PR TITLE
docs: add vite.config.ts option for SvelteKit 2.62.0+ path aliases

### DIFF
--- a/docs/content/installation/manual.md
+++ b/docs/content/installation/manual.md
@@ -33,25 +33,7 @@ Install `@lucide/svelte`:
 
 ### Configure path aliases
 
-If you are using SvelteKit and are not using the default alias `$lib`, you'll need to update your `vite.config.ts` file to include those aliases.
-
-```ts title="vite.config.ts" {8} showLineNumbers
-import { sveltekit } from "@sveltejs/kit/vite";
-import { defineConfig } from "vite";
-
-export default defineConfig({
-  plugins: [
-    sveltekit({
-      // ... other config
-      alias: {
-        "@/*": "./path/to/lib/*",
-      },
-    }),
-  ],
-});
-```
-
-When using SvelteKit versions older than 2.62.0, the aliases configuration will be in your `svelte.config.js` file instead.
+If you are using SvelteKit and are not using the default alias `$lib`, you'll need to update your `svelte.config.js` file to include those aliases.
 
 ```ts title="svelte.config.js" {6} showLineNumbers
 const config = {
@@ -63,6 +45,23 @@ const config = {
     },
   },
 };
+```
+
+Starting with `@sveltejs/kit` 2.62.0, you can alternatively pass this configuration directly to the `sveltekit()` Vite plugin in `vite.config.ts` instead of `svelte.config.js`:
+
+```ts title="vite.config.ts" {7} showLineNumbers
+import { sveltekit } from "@sveltejs/kit/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      alias: {
+        "@/*": "./path/to/lib/*",
+      },
+    }),
+  ],
+});
 ```
 
 If you are _not_ using SvelteKit, then you'll need to update your path aliases in your `tsconfig.json` and `vite.config.ts`.

--- a/docs/content/installation/manual.md
+++ b/docs/content/installation/manual.md
@@ -33,7 +33,25 @@ Install `@lucide/svelte`:
 
 ### Configure path aliases
 
-If you are using SvelteKit and are not using the default alias `$lib`, you'll need to update your `svelte.config.js` file to include those aliases.
+If you are using SvelteKit and are not using the default alias `$lib`, you'll need to update your `vite.config.ts` file to include those aliases.
+
+```ts title="vite.config.ts" {8} showLineNumbers
+import { sveltekit } from "@sveltejs/kit/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      // ... other config
+      alias: {
+        "@/*": "./path/to/lib/*",
+      },
+    }),
+  ],
+});
+```
+
+When using SvelteKit versions older than 2.62.0, the aliases configuration will be in your `svelte.config.js` file instead.
 
 ```ts title="svelte.config.js" {6} showLineNumbers
 const config = {
@@ -45,23 +63,6 @@ const config = {
     },
   },
 };
-```
-
-Starting with `@sveltejs/kit` 2.62.0, you can alternatively pass this configuration directly to the `sveltekit()` Vite plugin in `vite.config.ts` instead of `svelte.config.js`:
-
-```ts title="vite.config.ts" {7} showLineNumbers
-import { sveltekit } from "@sveltejs/kit/vite";
-import { defineConfig } from "vite";
-
-export default defineConfig({
-  plugins: [
-    sveltekit({
-      alias: {
-        "@/*": "./path/to/lib/*",
-      },
-    }),
-  ],
-});
 ```
 
 If you are _not_ using SvelteKit, then you'll need to update your path aliases in your `tsconfig.json` and `vite.config.ts`.

--- a/docs/content/installation/manual.md
+++ b/docs/content/installation/manual.md
@@ -33,7 +33,25 @@ Install `@lucide/svelte`:
 
 ### Configure path aliases
 
-If you are using SvelteKit and are not using the default alias `$lib`, you'll need to update your `svelte.config.js` file to include those aliases.
+If you are using SvelteKit and are not using the default alias `$lib`, you'll need to update your `vite.config.ts` file to include those aliases.
+
+```ts title="vite.config.ts" {8} showLineNumbers
+import { sveltekit } from "@sveltejs/kit/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      // ... other config
+      alias: {
+        "@/*": "./path/to/lib/*",
+      },
+    }),
+  ],
+});
+```
+
+When using SvelteKit versions older than 2.62.0, the aliases configuration will be in your `svelte.config.js` file instead.
 
 ```ts title="svelte.config.js" {6} showLineNumbers
 const config = {

--- a/docs/content/installation/sveltekit.md
+++ b/docs/content/installation/sveltekit.md
@@ -22,7 +22,25 @@ Use the SvelteKit CLI to create a new project with TailwindCSS
 
 ### Setup path aliases
 
-If you are not using the default alias `$lib`, you'll need to update your `svelte.config.js` file to include those aliases.
+If you are not using the default alias `$lib`, you'll need to update your `vite.config.ts` file to include those aliases.
+
+```ts title="vite.config.ts" {8} showLineNumbers
+import { sveltekit } from "@sveltejs/kit/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      // ... other config
+      alias: {
+        "@/*": "./path/to/lib/*",
+      },
+    }),
+  ],
+});
+```
+
+When using SvelteKit versions older than 2.62.0, the aliases configuration will be in your `svelte.config.js` file instead.
 
 ```ts title="svelte.config.js" {6} showLineNumbers
 const config = {
@@ -34,23 +52,6 @@ const config = {
     },
   },
 };
-```
-
-Starting with `@sveltejs/kit` 2.62.0, you can alternatively pass this configuration directly to the `sveltekit()` Vite plugin in `vite.config.ts` instead of `svelte.config.js`:
-
-```ts title="vite.config.ts" {7} showLineNumbers
-import { sveltekit } from "@sveltejs/kit/vite";
-import { defineConfig } from "vite";
-
-export default defineConfig({
-  plugins: [
-    sveltekit({
-      alias: {
-        "@/*": "./path/to/lib/*",
-      },
-    }),
-  ],
-});
 ```
 
 ### Run the CLI

--- a/docs/content/installation/sveltekit.md
+++ b/docs/content/installation/sveltekit.md
@@ -22,25 +22,7 @@ Use the SvelteKit CLI to create a new project with TailwindCSS
 
 ### Setup path aliases
 
-If you are not using the default alias `$lib`, you'll need to update your `vite.config.ts` file to include those aliases.
-
-```ts title="vite.config.ts" {8} showLineNumbers
-import { sveltekit } from "@sveltejs/kit/vite";
-import { defineConfig } from "vite";
-
-export default defineConfig({
-  plugins: [
-    sveltekit({
-      // ... other config
-      alias: {
-        "@/*": "./path/to/lib/*",
-      },
-    }),
-  ],
-});
-```
-
-When using SvelteKit versions older than 2.62.0, the aliases configuration will be in your `svelte.config.js` file instead.
+If you are not using the default alias `$lib`, you'll need to update your `svelte.config.js` file to include those aliases.
 
 ```ts title="svelte.config.js" {6} showLineNumbers
 const config = {
@@ -52,6 +34,23 @@ const config = {
     },
   },
 };
+```
+
+Starting with `@sveltejs/kit` 2.62.0, you can alternatively pass this configuration directly to the `sveltekit()` Vite plugin in `vite.config.ts` instead of `svelte.config.js`:
+
+```ts title="vite.config.ts" {7} showLineNumbers
+import { sveltekit } from "@sveltejs/kit/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      alias: {
+        "@/*": "./path/to/lib/*",
+      },
+    }),
+  ],
+});
 ```
 
 ### Run the CLI

--- a/docs/content/installation/sveltekit.md
+++ b/docs/content/installation/sveltekit.md
@@ -22,7 +22,25 @@ Use the SvelteKit CLI to create a new project with TailwindCSS
 
 ### Setup path aliases
 
-If you are not using the default alias `$lib`, you'll need to update your `svelte.config.js` file to include those aliases.
+If you are not using the default alias `$lib`, you'll need to update your `vite.config.ts` file to include those aliases.
+
+```ts title="vite.config.ts" {8} showLineNumbers
+import { sveltekit } from "@sveltejs/kit/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    sveltekit({
+      // ... other config
+      alias: {
+        "@/*": "./path/to/lib/*",
+      },
+    }),
+  ],
+});
+```
+
+When using SvelteKit versions older than 2.62.0, the aliases configuration will be in your `svelte.config.js` file instead.
 
 ```ts title="svelte.config.js" {6} showLineNumbers
 const config = {


### PR DESCRIPTION
## What was wrong

The SvelteKit and manual installation pages only showed configuring path aliases in `svelte.config.js`. Since `@sveltejs/kit` 2.62.0 ([sveltejs/kit#15944](https://github.com/sveltejs/kit/pull/15944)) the SvelteKit config, including `alias`, can be passed directly to the `sveltekit()` Vite plugin in `vite.config.ts`, and when you do that `svelte.config.js` is ignored. The docs never mentioned this.

## What changed

Following @ieedan's suggestion on the issue, both pages now lead with the `vite.config.ts` example and add the note: "When using SvelteKit versions older than 2.62.0, the aliases configuration will be in your `svelte.config.js` file instead", keeping the original `svelte.config.js` snippet below it.

- `docs/content/installation/sveltekit.md`
- `docs/content/installation/manual.md`

The `vite.config.ts` example uses the flat option shape (`sveltekit({ alias })`, no `kit` wrapper), matching the SvelteKit configuration docs.

## Verification

```
pnpm -F docs build:content   # velite build finished, 0 warnings
pnpm -F docs check           # svelte-check: 0 errors, 0 warnings
pnpm -F docs build:svelte    # built successfully
```

Fixes #2750
